### PR TITLE
Add a stop surface type

### DIFF
--- a/src/ray_tracing/component_model/mod.rs
+++ b/src/ray_tracing/component_model/mod.rs
@@ -165,6 +165,7 @@ impl From<&SequentialModel> for ComponentModel {
             components.insert(component);
 
             // Skip air gaps
+            // TODO Check if gap is an air gap to account for doublets, etc.
             gap_idx += 2;
         }
 

--- a/src/ray_tracing/mod.rs
+++ b/src/ray_tracing/mod.rs
@@ -11,7 +11,7 @@ use crate::math::vec3::Vec3;
 
 use component_model::ComponentModel;
 use sequential_model::{Gap, SequentialModel, SurfaceSpec};
-use surface_types::{ObjectOrImagePlane, RefractingCircularConic, RefractingCircularFlat};
+use surface_types::{ObjectOrImagePlane, RefractingCircularConic, RefractingCircularFlat, Stop};
 
 /// A model of an optical system.
 #[derive(Debug)]
@@ -71,6 +71,7 @@ pub enum Surface {
     ObjectOrImagePlane(ObjectOrImagePlane),
     RefractingCircularConic(RefractingCircularConic),
     RefractingCircularFlat(RefractingCircularFlat),
+    Stop(Stop),
 }
 
 impl Surface {
@@ -87,12 +88,17 @@ impl Surface {
         Self::RefractingCircularFlat(RefractingCircularFlat::new(pos, dir, diam, n))
     }
 
+    pub fn new_stop(pos: Vec3, dir: Vec3, diam: f32, n: f32) -> Self {
+        Self::Stop(Stop::new(pos, dir, diam, n))
+    }
+
     /// Compute the surface sag and surface normals at a given position.
     pub fn sag_norm(&self, pos: Vec3) -> (f32, Vec3) {
         match self {
             Self::ObjectOrImagePlane(surf) => surf.sag_norm(pos),
             Self::RefractingCircularConic(surf) => surf.sag_norm(pos),
             Self::RefractingCircularFlat(surf) => surf.sag_norm(pos),
+            Self::Stop(surf) => surf.sag_norm(pos),
         }
     }
 
@@ -103,6 +109,7 @@ impl Surface {
             Self::ObjectOrImagePlane(surf) => surf.pos,
             Self::RefractingCircularConic(surf) => surf.pos,
             Self::RefractingCircularFlat(surf) => surf.pos,
+            Self::Stop(surf) => surf.pos,
         }
     }
 
@@ -111,6 +118,7 @@ impl Surface {
             Self::ObjectOrImagePlane(surf) => surf.pos = pos,
             Self::RefractingCircularConic(surf) => surf.pos = pos,
             Self::RefractingCircularFlat(surf) => surf.pos = pos,
+            Self::Stop(surf) => surf.pos = pos,
         }
     }
 
@@ -121,6 +129,7 @@ impl Surface {
             Self::ObjectOrImagePlane(surf) => surf.rot_mat,
             Self::RefractingCircularConic(surf) => surf.rot_mat,
             Self::RefractingCircularFlat(surf) => surf.rot_mat,
+            Self::Stop(surf) => surf.rot_mat,
         }
     }
 
@@ -131,6 +140,7 @@ impl Surface {
             Self::ObjectOrImagePlane(surf) => surf.diam,
             Self::RefractingCircularConic(surf) => surf.diam,
             Self::RefractingCircularFlat(surf) => surf.diam,
+            Self::Stop(surf) => surf.diam,
         }
     }
 
@@ -141,6 +151,7 @@ impl Surface {
             Self::ObjectOrImagePlane(surf) => surf.n,
             Self::RefractingCircularConic(surf) => surf.n,
             Self::RefractingCircularFlat(surf) => surf.n,
+            Self::Stop(surf) => surf.n,
         }
     }
 
@@ -166,6 +177,7 @@ impl Surface {
                 Self::ObjectOrImagePlane(surf) => surf.sag_norm(point),
                 Self::RefractingCircularConic(surf) => surf.sag_norm(point),
                 Self::RefractingCircularFlat(surf) => surf.sag_norm(point),
+                Self::Stop(surf) => surf.sag_norm(point),
             };
 
             // Transform the sample into the global coordinate system.
@@ -195,6 +207,10 @@ impl From<(SurfaceSpec, &Gap)> for Surface {
             }
             SurfaceSpec::RefractingCircularFlat { diam } => {
                 let surf = Surface::new_refr_circ_flat(pos, dir, diam, gap.n());
+                surf
+            }
+            SurfaceSpec::Stop { diam } => {
+                let surf = Surface::new_stop(pos, dir, diam, gap.n());
                 surf
             }
         }

--- a/src/ray_tracing/rays.rs
+++ b/src/ray_tracing/rays.rs
@@ -81,7 +81,8 @@ impl Ray {
                 self.dir = term_1 + term_2;
             }
             // No-op surfaces
-            Surface::ObjectOrImagePlane(_) => {}
+            Surface::ObjectOrImagePlane(_) => {},
+            Surface::Stop(_) => {},
         }
     }
 

--- a/src/ray_tracing/sequential_model/mod.rs
+++ b/src/ray_tracing/sequential_model/mod.rs
@@ -141,6 +141,7 @@ pub enum SurfaceSpec {
     ObjectOrImagePlane { diam: f32 },
     RefractingCircularConic { diam: f32, roc: f32, k: f32 },
     RefractingCircularFlat { diam: f32 },
+    Stop { diam: f32 },
 }
 
 impl From<&Surface> for SurfaceSpec {
@@ -162,6 +163,10 @@ impl From<&Surface> for SurfaceSpec {
                 let surf = SurfaceSpec::RefractingCircularFlat { diam: surf.diam };
                 surf
             }
+            Surface::Stop(surf) => {
+                let surf = SurfaceSpec::Stop { diam: surf.diam };
+                surf
+            }
         }
     }
 }
@@ -181,6 +186,10 @@ impl From<SurfacePair> for (Surface, Gap) {
                 (value.0, gap)
             }
             Surface::RefractingCircularFlat(surf) => {
+                let gap = Gap::new(surf.n, thickness);
+                (value.0, gap)
+            }
+            Surface::Stop(surf) => {
                 let gap = Gap::new(surf.n, thickness);
                 (value.0, gap)
             }

--- a/src/ray_tracing/surface_types/mod.rs
+++ b/src/ray_tracing/surface_types/mod.rs
@@ -1,7 +1,9 @@
 mod conics;
 mod flats;
 mod object_or_image;
+mod stop;
 
 pub(crate) use conics::RefractingCircularConic;
 pub(crate) use flats::RefractingCircularFlat;
 pub(crate) use object_or_image::ObjectOrImagePlane;
+pub(crate) use stop::Stop;

--- a/src/ray_tracing/surface_types/stop.rs
+++ b/src/ray_tracing/surface_types/stop.rs
@@ -1,0 +1,44 @@
+use crate::math::mat3::Mat3;
+use crate::math::vec3::Vec3;
+
+/// A physical stop.
+#[derive(Debug, Clone, Copy)]
+pub struct Stop {
+    // Position of the center of the stop relative to the global reference frame
+    pub pos: Vec3,
+
+    // Euler angles of the optics axis through the stop relative to the global reference frame
+    pub dir: Vec3,
+
+    // Rotation matrix from the global reference frame to the surface reference frame
+    pub rot_mat: Mat3,
+
+    // Diameter of the stop
+    pub diam: f32,
+
+    // Refractive index to the right of the stop
+    pub(crate) n: f32,
+}
+
+impl Stop {
+    pub fn new(pos: Vec3, dir: Vec3, diam: f32, n: f32) -> Self {
+        let rot_mat = Mat3::from_euler_angles(dir.x(), dir.y(), dir.z());
+        Self {
+            pos,
+            dir,
+            rot_mat,
+            diam,
+            n,
+        }
+    }
+
+    pub fn sag_norm(&self, _: Vec3) -> (f32, Vec3) {
+        // Compute surface sag
+        let sag = 0.0;
+
+        // Compute surface normal
+        let norm = Vec3::new(0.0, 0.0, 1.0);
+
+        (sag, norm)
+    }
+}

--- a/www/modules/petzval_lens.js
+++ b/www/modules/petzval_lens.js
@@ -3,7 +3,7 @@ export const surfaces = [
     {"RefractingCircularConic": {"diam": 56.956, "roc": 99.56266, "k": 0.0}},
     {"RefractingCircularConic": {"diam": 52.552, "roc": -86.84002, "k": 0.0}},
     {"RefractingCircularConic": {"diam": 42.04, "roc": -1187.63858, "k": 0.0}},
-    {"RefractingCircularFlat": {"diam": 33.262}},
+    {"Stop": {"diam": 33.262}},
     {"RefractingCircularConic": {"diam": 41.086, "roc": 57.47491, "k": 0.0}},
     {"RefractingCircularConic": {"diam": 40.148, "roc": -54.61685, "k": 0.0}},
     {"RefractingCircularConic": {"diam": 32.984, "roc": -614.68633, "k": 0.0}},


### PR DESCRIPTION
This will be necessary to set hard apertures (and eventually the system aperture).

@wagdav This creates a new surface type that models a hard stop (basically a hole with no optical power). See the Petzval lens spec for how to define one in JS.