### PR TITLE
Generate HTML5 compatible index page

### DIFF
--- a/www/cljs/src/main/net/thewagner/build.clj
+++ b/www/cljs/src/main/net/thewagner/build.clj
@@ -1,9 +1,8 @@
 (ns net.thewagner.build
-  (:require [hiccup.core :refer [html]]
-            [net.thewagner.html :as pages]))
+  (:require [net.thewagner.html :as pages]))
 
 (defn hook
   {:shadow.build/stage :flush}
   [{:keys [shadow.build/config] :as build-state} & _args]
-  (spit (str (:output-dir config) "/index.html") (html pages/index))
+  (spit (str (:output-dir config) "/index.html") pages/index)
   build-state)

--- a/www/cljs/src/main/net/thewagner/html.cljc
+++ b/www/cljs/src/main/net/thewagner/html.cljc
@@ -1,7 +1,8 @@
-(ns net.thewagner.html)
+(ns net.thewagner.html
+  (:require [hiccup.page :refer [html5]]))
 
 (def index
-  [:html
+  (html5 {:lang "en"}
     [:head
       [:meta {:charset "UTF-8"}]
       [:meta {:name "viewport" :content "width=device-width, initial-scale=1"}]
@@ -11,8 +12,7 @@
     [:body
       [:div#app]
       [:script {:src "./index.js"}]
-      [:script {:src "./main.js"}]]])
+      [:script {:src "./main.js"}]]))
 
 (comment
-  (require '[hiccup.core :refer [html]])
-  (spit "build/index.html" (html index)))
+  (spit "build/index.html" index))


### PR DESCRIPTION
Before:
```html
<html><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1" name="viewport"><meta content="ie=edge" http-equiv="x-ua-compatible"><title>🍒 Cherry Raytracer</title><link href="[css/cherry.css](view-source:http://localhost:8080/css/cherry.css)" rel="stylesheet"></head><body><div id="app"></div><script src="[./index.js](view-source:http://localhost:8080/index.js)"></script><script src="[./main.js](view-source:http://localhost:8080/main.js)"></script></body></html>
```

After:
```html
<!DOCTYPE html>
<html lang="en"><head><meta charset="UTF-8"><meta content="width=device-width, initial-scale=1" name="viewport"><meta content="ie=edge" http-equiv="x-ua-compatible"><title>🍒 Cherry Raytracer</title><link href="[css/cherry.css](view-source:http://localhost:8080/css/cherry.css)" rel="stylesheet"></head><body><div id="app"></div><script src="[./index.js](view-source:http://localhost:8080/index.js)"></script><script src="[./main.js](view-source:http://localhost:8080/main.js)"></script></body></html>
```