### PR TITLE
Add binaryen to the devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
             ghp-import
             yarn
 
+            binaryen
             rust
             wasm-pack
             curl


### PR DESCRIPTION
On an x86 machine setting up the development environment didn't work. Calling wasm-pack failed with the following error message:

    Error: failed to download from https://github.com/WebAssembly/binaryen/releases/download/version_90/binaryen-version_90-x86-linux.tar.gz
    To disable `wasm-opt`, add `wasm-opt = false` to your package metadata in your `Cargo.toml`.

I already added binaryen to the build, but it was missing from the devShell.  I'll research better ways to maintain the list of required packages for build and for the development environments.
