### PR TITLE
Fix button alignment on narrow screens.

### DIFF
--- a/www/cljs/src/main/net/thewagner/cherry.cljs
+++ b/www/cljs/src/main/net/thewagner/cherry.cljs
@@ -235,14 +235,11 @@
            [:p.subtitle "Surfaces"]]]
       [:div.level-right
         [:p.level-item
-          [:button.button {:on-click #(reset! surfaces (surfaces-and-gaps->rows cherry-spec/planoconvex))} "Planoconvex"]]
-        [:p.level-item
-          [:button.button {:on-click #(reset! surfaces (surfaces-and-gaps->rows cherry-spec/petzval))} "Petzval"]]
-        [:p.level-item
-          [:button.button {:on-click #(reset! surfaces (into [] (gen/sample (s/gen ::row) 5)))}
-           "I'm Feeling Lucky"]]
-        [:p.level-item
-          [:button.button.is-success {:on-click #(swap! surfaces conj nil)} "New"]]]]
+          [:div.field.is-grouped
+            [:p.control>button.button {:on-click #(reset! surfaces (surfaces-and-gaps->rows cherry-spec/planoconvex))} "Planoconvex"]
+            [:p.control>button.button {:on-click #(reset! surfaces (surfaces-and-gaps->rows cherry-spec/petzval))} "Petzval"]
+            [:p.control>button.button {:on-click #(reset! surfaces (into [] (gen/sample (s/gen ::row) 5)))} "I'm Feeling Lucky"]
+            [:p.control>button.button.is-success [:button.button.is-success {:on-click #(swap! surfaces conj nil)} "New"]]]]]]
     [:div.table-container
       [:table.table
          [:thead


### PR DESCRIPTION
Viewed on a narrow screen the buttons above the table shited on top of
each other despite the avilable horizontal space.

Add the buttons to a button group to keep them in a single line.

Reference: https://bulma.io/documentation/elements/button/#button-group

# Before

![image](https://github.com/kmdouglass/cherry/assets/514775/e249005d-3ffd-41e8-b1ce-5a2275651f96)

# After

![image](https://github.com/kmdouglass/cherry/assets/514775/27771776-401f-4de9-b3a8-0b87967dbdd3)

