### PR TITLE
Add test case for finite object, infinite image

### DIFF
--- a/raytracer/src/math/mat2.rs
+++ b/raytracer/src/math/mat2.rs
@@ -18,6 +18,40 @@ impl Mat2 {
             e: [[1.0, 0.0], [0.0, 1.0]],
         }
     }
+
+    /// Computes the determinant of the matrix.
+    pub fn det(&self) -> f32 {
+        let e00 = self.e[0][0];
+        let e01 = self.e[0][1];
+        let e10 = self.e[1][0];
+        let e11 = self.e[1][1];
+
+        e00 * e11 - e01 * e10
+    }
+
+    /// Computes the inverse of the matrix.
+    /// If the matrix is not invertible, None is returned.
+    pub fn inv(&self) -> Option<Self> {
+        let det = self.det();
+
+        if det == 0.0 {
+            return None;
+        }
+
+        let e00 = self.e[0][0];
+        let e01 = self.e[0][1];
+        let e10 = self.e[1][0];
+        let e11 = self.e[1][1];
+
+        let inv_det = 1.0 / det;
+
+        Some(Self {
+            e: [
+                [e11 * inv_det, -e01 * inv_det],
+                [-e10 * inv_det, e00 * inv_det],
+            ],
+        })
+    }
 }
 
 macro_rules! mat2 {
@@ -28,7 +62,7 @@ macro_rules! mat2 {
 
 pub(crate) use mat2;
 
-impl std::ops::Mul<&Vec2> for &Mat2 {
+impl std::ops::Mul<&Vec2> for Mat2 {
     type Output = Vec2;
 
     fn mul(self, rhs: &Vec2) -> Vec2 {

--- a/raytracer/src/ray_tracing/sequential_model/mod.rs
+++ b/raytracer/src/ray_tracing/sequential_model/mod.rs
@@ -151,10 +151,11 @@ impl From<&Surface> for SurfaceSpec {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
 
-    #[test]
-    fn test_insert_surface_and_gap() {
+    fn planoconvex_lens_obj_at_inf() -> SystemModel {
+        // The image is located at the lens back focal plane.
         let mut system_model = SystemModel::new();
         let mut model = system_model.seq_model_mut();
 
@@ -164,12 +165,45 @@ mod tests {
                 Surface::new_refr_circ_conic(
                     Vec3::new(0.0, 0.0, 0.0),
                     Vec3::new(0.0, 0.0, 0.0),
-                    25.0,
+                    25.8,
                     1.5,
-                    25.0,
+                    25.8,
                     0.0,
                 ),
-                Gap::new(1.0, 1.0),
+                Gap::new(1.5, 5.3),
+            )
+            .unwrap();
+        model
+            .insert_surface_and_gap(
+                2,
+                Surface::new_refr_circ_flat(
+                    Vec3::new(0.0, 0.0, 5.3),
+                    Vec3::new(0.0, 0.0, 0.0),
+                    25.0,
+                    1.0,
+                ),
+                Gap::new(1.0, 46.6),
+            )
+            .unwrap();
+
+        system_model
+    }
+
+    fn planoconvex_lens_img_at_inf() -> SystemModel {
+        // The object is located at the lens front focal plane.
+        let mut system_model = SystemModel::new();
+        let mut model = system_model.seq_model_mut();
+
+        model
+            .insert_surface_and_gap(
+                1,
+                Surface::new_refr_circ_flat(
+                    Vec3::new(0.0, 0.0, 0.0),
+                    Vec3::new(0.0, 0.0, 0.0),
+                    25.0,
+                    1.5,
+                ),
+                Gap::new(1.5, 5.3),
             )
             .unwrap();
         model
@@ -178,22 +212,30 @@ mod tests {
                 Surface::new_refr_circ_conic(
                     Vec3::new(0.0, 0.0, 0.0),
                     Vec3::new(0.0, 0.0, 0.0),
-                    25.0,
+                    -25.8,
                     1.0,
-                    -25.0,
+                    -25.8,
                     0.0,
                 ),
-                Gap::new(1.0, 10.0),
+                Gap::new(1.0, f32::INFINITY),
             )
             .unwrap();
+
+        system_model
+    }
+
+    #[test]
+    fn test_insert_surface_and_gap() {
+        let system_model = planoconvex_lens_obj_at_inf();
+        let model = system_model.seq_model();
 
         // 2 surfaces + object plane + image plane
         assert_eq!(model.surfaces.len(), 4);
         assert_eq!(model.gaps.len(), 3);
         assert_eq!(model.surfaces[0].pos(), Vec3::new(0.0, 0.0, -1.0));
         assert_eq!(model.surfaces[1].pos(), Vec3::new(0.0, 0.0, 0.0));
-        assert_eq!(model.surfaces[2].pos(), Vec3::new(0.0, 0.0, 1.0));
-        assert_eq!(model.surfaces[3].pos(), Vec3::new(0.0, 0.0, 11.0));
+        assert_eq!(model.surfaces[2].pos(), Vec3::new(0.0, 0.0, 5.3));
+        assert_eq!(model.surfaces[3].pos(), Vec3::new(0.0, 0.0, 51.9));
     }
 
     #[test]
@@ -248,37 +290,8 @@ mod tests {
 
     #[test]
     fn test_remove_surface_and_gap() {
-        let mut system_model = SystemModel::new();
-        let mut model = system_model.seq_model_mut();
-
-        model
-            .insert_surface_and_gap(
-                1,
-                Surface::new_refr_circ_conic(
-                    Vec3::new(0.0, 0.0, 0.0),
-                    Vec3::new(0.0, 0.0, 0.0),
-                    25.0,
-                    1.5,
-                    1.0,
-                    0.0,
-                ),
-                Gap::new(1.5, 1.0),
-            )
-            .unwrap();
-        model
-            .insert_surface_and_gap(
-                2,
-                Surface::new_refr_circ_conic(
-                    Vec3::new(0.0, 0.0, 0.0),
-                    Vec3::new(0.0, 0.0, 0.0),
-                    25.0,
-                    1.0,
-                    -1.0,
-                    0.0,
-                ),
-                Gap::new(1.0, 10.0),
-            )
-            .unwrap();
+        let mut system_model = planoconvex_lens_obj_at_inf();
+        let model = system_model.seq_model_mut();
 
         assert_eq!(model.surfaces.len(), 4);
         assert_eq!(model.gaps.len(), 3);
@@ -289,46 +302,17 @@ mod tests {
         assert_eq!(model.gaps.len(), 2);
         assert_eq!(model.surfaces[0].pos(), Vec3::new(0.0, 0.0, -1.0));
         assert_eq!(model.surfaces[1].pos(), Vec3::new(0.0, 0.0, 0.0));
-        assert_eq!(model.surfaces[2].pos(), Vec3::new(0.0, 0.0, 1.0));
+        assert_eq!(model.surfaces[2].pos(), Vec3::new(0.0, 0.0, 5.3));
     }
 
     #[test]
     fn test_surf_distance_from_origin() {
-        let mut system_model = SystemModel::new();
-        let mut model = system_model.seq_model_mut();
-
-        model
-            .insert_surface_and_gap(
-                1,
-                Surface::new_refr_circ_conic(
-                    Vec3::new(0.0, 0.0, 0.0),
-                    Vec3::new(0.0, 0.0, 0.0),
-                    25.0,
-                    1.5,
-                    1.0,
-                    0.0,
-                ),
-                Gap::new(1.5, 1.0),
-            )
-            .unwrap();
-        model
-            .insert_surface_and_gap(
-                2,
-                Surface::new_refr_circ_conic(
-                    Vec3::new(0.0, 0.0, 0.0),
-                    Vec3::new(0.0, 0.0, 0.0),
-                    25.0,
-                    1.0,
-                    -1.0,
-                    0.0,
-                ),
-                Gap::new(1.0, 10.0),
-            )
-            .unwrap();
+        let mut system_model = planoconvex_lens_obj_at_inf();
+        let model = system_model.seq_model_mut();
 
         assert_eq!(model.surf_distance_from_origin(0), 1.0);
         assert_eq!(model.surf_distance_from_origin(1), 0.0);
-        assert_eq!(model.surf_distance_from_origin(2), 1.0);
-        assert_eq!(model.surf_distance_from_origin(3), 11.0);
+        assert_eq!(model.surf_distance_from_origin(2), 5.3);
+        assert_eq!(model.surf_distance_from_origin(3), 5.3 + 46.6);
     }
 }


### PR DESCRIPTION
Here I add a test case for finding the entrance pupil location for an object located at a finite distance from the system, with an image located an infinite distance away.

To make this work I had to do paraxial ray traces in reverse, which I successfully implemented by inverting the ray transfer matrix for each surface, then tracing through the inverted system.

With this we now have infinite object/finite image and finite object/infinite image cases working correctly. I think I can move on to new features, like field angles, now.