### PR TITLE
Add support for off-axis field angles

### DIFF
--- a/raytracer/src/math/vec3.rs
+++ b/raytracer/src/math/vec3.rs
@@ -81,19 +81,20 @@ impl Vec3 {
     /// Create a fan of uniformly spaced vectors with endpoints in a given z-plane.
     ///
     /// The vectors have endpoints at an angle theta with respect to the x-axis and extend from
-    /// distances -r to r from the point (0, 0, z).
+    /// distances (-r + radial_offset) to (r + radial_offset) from the point (0, 0, z).
     ///
     /// # Arguments
     /// - n: Number of vectors to create
     /// - r: Radial span of vector endpoints from [-r, r]
     /// - theta: Angle of vectors with respect to x
     /// - z: z-coordinate of endpoints
-    pub fn fan(n: usize, r: f32, theta: f32, z: f32) -> Vec<Self> {
+    /// - radial_offset: Offset the radial position of the vectors by this amount
+    pub fn fan(n: usize, r: f32, theta: f32, z: f32, radial_offset: f32) -> Vec<Self> {
         let mut vecs = Vec::with_capacity(n);
         let step = 2.0 * r / (n - 1) as f32;
         for i in 0..n {
-            let x = (-r + i as f32 * step) * theta.cos();
-            let y = (-r + i as f32 * step) * theta.sin();
+            let x = (-r + i as f32 * step) * theta.cos() + radial_offset;
+            let y = (-r + i as f32 * step) * theta.sin() + radial_offset;
             vecs.push(Vec3::new(x, y, z));
         }
         vecs

--- a/raytracer/src/ray_tracing/rays.rs
+++ b/raytracer/src/ray_tracing/rays.rs
@@ -123,8 +123,9 @@ impl Ray {
     /// - theta: Angle of vectors with respect to x, radians
     /// - z: z-coordinate of endpoints
     /// - phi: Angle of vectors with respect to z, the optics axis, radians
-    pub fn fan(n: usize, r: f32, theta: f32, z: f32, phi: f32) -> Vec<Ray> {
-        let pos = Vec3::fan(n, r, theta, z);
+    /// - radial_offset: Offset the radial position of the vectors by this amount
+    pub fn fan(n: usize, r: f32, theta: f32, z: f32, phi: f32, radial_offset: f32) -> Vec<Ray> {
+        let pos = Vec3::fan(n, r, theta, z, radial_offset);
         let dir: Vec<Vec3> = pos
             .iter()
             .map(|p| {

--- a/raytracer/src/ray_tracing/sequential_model/mod.rs
+++ b/raytracer/src/ray_tracing/sequential_model/mod.rs
@@ -75,9 +75,8 @@ impl SequentialModel {
     }
 
     pub fn set_obj_space(&mut self, gap: Gap) {
-        // Surfaces should not need to be readjusted because the first non-object surface is
-        // anchored at z=0.
         self.gaps[0] = gap;
+        self.surfaces[0].set_pos(Vec3::new(0.0, 0.0, -gap.thickness()));
     }
 
     fn readjust_surfaces(&mut self, idx: usize) {

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -15,8 +15,8 @@ for (let i = 0; i < surfaces.length; i++) {
     wasmSystemModel.insertSurfaceAndGap(i + 1, surface, gap);
 }
 
-// Set the object space thickness to 50 mm
-wasmSystemModel.setObjectSpace(1.0, 50);
+// Set the object space thickness to 200 mm
+wasmSystemModel.setObjectSpace(1.0, 200);
 
 console.log("Surfaces:", wasmSystemModel.surfaces());
 console.log("Gaps:", wasmSystemModel.gaps());

--- a/www/js/package-lock.json
+++ b/www/js/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
-        "cherry": "file:../pkg"
+        "cherry": "file:../../raytracer/pkg"
       },
       "bin": {
         "create-wasm-app": ".bin/create-wasm-app.js"
@@ -22,12 +22,19 @@
         "webpack-dev-server": "*"
       }
     },
+    "../../raytracer/pkg": {
+      "version": "0.1.0"
+    },
     "../cherry": {
       "extraneous": true
     },
     "../pkg": {
       "name": "cherry",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "extraneous": true
+    },
+    "../raytracer/pkg": {
+      "extraneous": true
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -835,7 +842,7 @@
       ]
     },
     "node_modules/cherry": {
-      "resolved": "../pkg",
+      "resolved": "../../raytracer/pkg",
       "link": true
     },
     "node_modules/chokidar": {

--- a/www/js/package.json
+++ b/www/js/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/rustwasm/create-wasm-app#readme",
   "dependencies": {
-    "cherry": "file:../raytracer/pkg"
+    "cherry": "file:../../raytracer/pkg"
   },
   "devDependencies": {
     "@webpack-cli/serve": "^2.0.5",


### PR DESCRIPTION
The ray tracer now can trace off-axis field angles that properly fill the paraxial entrance pupil.

I have not yet added UI support to set the field angles; instead, I hard code them for now at 0 and 5 degrees.

Note that this more-often-than-not will create errors when drawing the rays in the JS code if the optical system isn't setup properly. The object space for the Petzval lens should be set to a thickness of >= 200 mm to see the rays. The planoconvex lens should work as is, but it might fail when the entrance pupil diameter is set to greater than 25 mm. This is related to #5 .I'll fix this in a later PR.

### Petzval lens
![image](https://github.com/kmdouglass/cherry/assets/3697676/a837daf8-fb72-4988-a8b1-d22f1409eb67)

### Planoconvex lens
![image](https://github.com/kmdouglass/cherry/assets/3697676/24507efc-75e9-42e1-a753-1a3870f41f37)
