### PR TITLE
Split the ObjectOrImagePlane into mutually exclusive variants

### DIFF
--- a/raytracer/src/ray_tracing/paraxial_model/mod.rs
+++ b/raytracer/src/ray_tracing/paraxial_model/mod.rs
@@ -507,13 +507,14 @@ impl From<&SurfacePair> for ParaxElem {
         let n_1 = surface_pair.1.n();
 
         match surf {
+            Surface::ImagePlane(surf) => ParaxElem::new_img_plane(surf.diam / 2.0),
             Surface::RefractingCircularConic(surf) => {
                 ParaxElem::new_refr_curved_surf(surf.diam / 2.0, n_0, n_1, surf.roc)
             }
             Surface::RefractingCircularFlat(surf) => {
                 ParaxElem::new_refr_flat_surf(surf.diam / 2.0, n_0, n_1)
             }
-            Surface::ObjectOrImagePlane(surf) => ParaxElem::new_no_op_surf(surf.diam / 2.0),
+            Surface::ObjectPlane(surf) => ParaxElem::new_obj_plane(surf.diam / 2.0),
             Surface::Stop(surf) => ParaxElem::new_no_op_surf(surf.diam / 2.0),
         }
     }

--- a/raytracer/src/ray_tracing/rays.rs
+++ b/raytracer/src/ray_tracing/rays.rs
@@ -81,7 +81,8 @@ impl Ray {
                 self.dir = term_1 + term_2;
             }
             // No-op surfaces
-            Surface::ObjectOrImagePlane(_) => {}
+            Surface::ImagePlane(_) => {}
+            Surface::ObjectPlane(_) => {}
             Surface::Stop(_) => {}
         }
     }

--- a/raytracer/src/ray_tracing/sequential_model/mod.rs
+++ b/raytracer/src/ray_tracing/sequential_model/mod.rs
@@ -115,7 +115,8 @@ impl SequentialModel {
 /// A surface in a sequential model of an optical system.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum SurfaceSpec {
-    ObjectOrImagePlane { diam: f32 },
+    ImagePlane { diam: f32 },
+    ObjectPlane { diam: f32 },
     RefractingCircularConic { diam: f32, roc: f32, k: f32 },
     RefractingCircularFlat { diam: f32 },
     Stop { diam: f32 },
@@ -124,8 +125,12 @@ pub enum SurfaceSpec {
 impl From<&Surface> for SurfaceSpec {
     fn from(value: &Surface) -> Self {
         match value {
-            Surface::ObjectOrImagePlane(surf) => {
-                let surf = SurfaceSpec::ObjectOrImagePlane { diam: surf.diam };
+            Surface::ImagePlane(surf) => {
+                let surf = SurfaceSpec::ImagePlane { diam: surf.diam };
+                surf
+            }
+            Surface::ObjectPlane(surf) => {
+                let surf = SurfaceSpec::ObjectPlane { diam: surf.diam };
                 surf
             }
             Surface::RefractingCircularConic(surf) => {

--- a/raytracer/src/ray_tracing/surface_types/image.rs
+++ b/raytracer/src/ray_tracing/surface_types/image.rs
@@ -1,0 +1,44 @@
+use crate::math::mat3::Mat3;
+use crate::math::vec3::Vec3;
+
+/// Represents the image plane in an optical system.
+#[derive(Debug, Clone, Copy)]
+pub struct ImagePlane {
+    // Position of the center of the object plane
+    pub pos: Vec3,
+
+    // Euler angles of the normal to the object plane
+    pub dir: Vec3,
+
+    // Rotation matrix from the global reference frame to the surface reference frame
+    pub rot_mat: Mat3,
+
+    // Diameter of the object plane
+    pub diam: f32,
+
+    // Refractive index
+    pub(crate) n: f32,
+}
+
+impl ImagePlane {
+    pub fn new(pos: Vec3, dir: Vec3, diam: f32, n: f32) -> Self {
+        let rot_mat = Mat3::from_euler_angles(dir.x(), dir.y(), dir.z());
+        Self {
+            pos,
+            dir,
+            rot_mat,
+            diam: diam,
+            n,
+        }
+    }
+
+    pub fn sag_norm(&self, _: Vec3) -> (f32, Vec3) {
+        // Compute surface sag
+        let sag = 0.0;
+
+        // Compute surface normal
+        let norm = Vec3::new(0.0, 0.0, 1.0);
+
+        (sag, norm)
+    }
+}

--- a/raytracer/src/ray_tracing/surface_types/mod.rs
+++ b/raytracer/src/ray_tracing/surface_types/mod.rs
@@ -1,9 +1,11 @@
 mod conics;
 mod flats;
-mod object_or_image;
+mod image;
+mod object;
 mod stop;
 
 pub(crate) use conics::RefractingCircularConic;
 pub(crate) use flats::RefractingCircularFlat;
-pub(crate) use object_or_image::ObjectOrImagePlane;
+pub(crate) use image::ImagePlane;
+pub(crate) use object::ObjectPlane;
 pub(crate) use stop::Stop;

--- a/raytracer/src/ray_tracing/surface_types/object.rs
+++ b/raytracer/src/ray_tracing/surface_types/object.rs
@@ -1,9 +1,9 @@
 use crate::math::mat3::Mat3;
 use crate::math::vec3::Vec3;
 
-/// Represents the object or image plane in an optical system.
+/// Represents the object plane in an optical system.
 #[derive(Debug, Clone, Copy)]
-pub struct ObjectOrImagePlane {
+pub struct ObjectPlane {
     // Position of the center of the object plane
     pub pos: Vec3,
 
@@ -20,7 +20,7 @@ pub struct ObjectOrImagePlane {
     pub(crate) n: f32,
 }
 
-impl ObjectOrImagePlane {
+impl ObjectPlane {
     pub fn new(pos: Vec3, dir: Vec3, diam: f32, n: f32) -> Self {
         let rot_mat = Mat3::from_euler_angles(dir.x(), dir.y(), dir.z());
         Self {


### PR DESCRIPTION
This fixes a logical mistake I made earlier in not making the object and image planes distinct variants. It will also be useful for when I implement the `Builder` because I can explicitly validate the model requirements that the first surface is an ObjectPlane and the last is an ImagePlane.

## UI Changes

I don't think this changes anything currently since the object and image planes aren't specified in the UI. This will change once we have the Builder in place, though. The JS test still works.