### PR TITLE
Fix channel name

### DIFF
--- a/www/cljs/src/main/net/thewagner/cherry.cljs
+++ b/www/cljs/src/main/net/thewagner/cherry.cljs
@@ -333,7 +333,7 @@
 
 (defn ^:dev/before-load stop []
   (unlisten-events!)
-  (async/close! stop))
+  (async/close! done))
 
 (defn init []
   (start))


### PR DESCRIPTION
The channel is called `done` and not `stop`.

This has no effect on the production system, only the interactive
development environment complains.
