### PR TITLE
Build immutable optical systems with the builder pattern

### DIFF
--- a/raytracer/src/ray_tracing/component_model/mod.rs
+++ b/raytracer/src/ray_tracing/component_model/mod.rs
@@ -187,7 +187,7 @@ mod tests {
     use crate::ray_tracing::{Gap, SystemModel};
 
     fn system_model() -> SystemModel {
-        let mut system_model = SystemModel::new();
+        let mut system_model = SystemModel::old();
 
         let surf_spec_1 = SurfaceSpec::RefractingCircularConic {
             diam: 25.0,

--- a/raytracer/src/ray_tracing/sequential_model/mod.rs
+++ b/raytracer/src/ray_tracing/sequential_model/mod.rs
@@ -160,7 +160,7 @@ mod tests {
 
     fn planoconvex_lens_obj_at_inf() -> SystemModel {
         // The image is located at the lens back focal plane.
-        let mut system_model = SystemModel::new();
+        let mut system_model = SystemModel::old();
         let mut model = system_model.seq_model_mut();
 
         model
@@ -195,7 +195,7 @@ mod tests {
 
     fn planoconvex_lens_img_at_inf() -> SystemModel {
         // The object is located at the lens front focal plane.
-        let mut system_model = SystemModel::new();
+        let mut system_model = SystemModel::old();
         let mut model = system_model.seq_model_mut();
 
         model
@@ -244,7 +244,7 @@ mod tests {
 
     #[test]
     fn test_insert_surface_and_gap_before_another_surface() {
-        let mut system_model = SystemModel::new();
+        let mut system_model = SystemModel::old();
         let mut model = system_model.seq_model_mut();
 
         model

--- a/www/js/index.js
+++ b/www/js/index.js
@@ -1,22 +1,16 @@
 import { WasmSystemModel } from "cherry";
 import { centerOfMass, draw, resultsToRayPaths, scaleFactor, toCanvasCoordinates } from "./modules/rendering.js"
-import { surfaces, gaps } from "./modules/petzval_lens.js";
+import { surfaces, gaps, aperture, fields } from "./modules/petzval_lens.js";
+// import { surfaces, gaps, aperture, fields } from "./modules/planoconvex_lens.js";
 
 let wasmSystemModel = new WasmSystemModel();
 
-// Set the system aperture to an entrance pupil diameter to 40 mm
-let aperture = {"EntrancePupilDiameter": { diam: 40 }};
-wasmSystemModel.setAperture(aperture);
-
-// Loop over surfaces and gaps and insert them into the system model
-for (let i = 0; i < surfaces.length; i++) {
-    let surface = surfaces[i];
-    let gap = gaps[i];
-    wasmSystemModel.insertSurfaceAndGap(i + 1, surface, gap);
-}
-
-// Set the object space thickness to 200 mm
-wasmSystemModel.setObjectSpace(1.0, 200);
+//Build the optical system
+wasmSystemModel.setSurfaces(surfaces);
+wasmSystemModel.setGaps(gaps);
+wasmSystemModel.setApertureV2(aperture);  // TODO Change name once the old setAperture is removed
+wasmSystemModel.setFields(fields);
+wasmSystemModel.build();
 
 console.log("Surfaces:", wasmSystemModel.surfaces());
 console.log("Gaps:", wasmSystemModel.gaps());

--- a/www/js/modules/petzval_lens.js
+++ b/www/js/modules/petzval_lens.js
@@ -1,5 +1,6 @@
 // From https://www.comsol.com/blogs/how-to-create-complex-lens-geometries-for-ray-optics-simulations/
 export const surfaces = [
+    {"ObjectPlane": {"diam": 50.0}},
     {"RefractingCircularConic": {"diam": 56.956, "roc": 99.56266, "k": 0.0}},
     {"RefractingCircularConic": {"diam": 52.552, "roc": -86.84002, "k": 0.0}},
     {"RefractingCircularConic": {"diam": 42.04, "roc": -1187.63858, "k": 0.0}},
@@ -9,9 +10,11 @@ export const surfaces = [
     {"RefractingCircularConic": {"diam": 32.984, "roc": -614.68633, "k": 0.0}},
     {"RefractingCircularConic": {"diam": 34.594, "roc": -38.17110, "k": 0.0}},
     {"RefractingCircularFlat": {"diam": 37.88}},
+    {"ImagePlane": {"diam": 50.0}},
 ];
 
 export const gaps = [
+    {"n": 1.0, "thickness": 200.0},
     {"n": 1.5168, "thickness": 13.0},
     {"n": 1.6645, "thickness": 4.0},
     {"n": 1.0, "thickness": 40.0},
@@ -22,3 +25,7 @@ export const gaps = [
     {"n": 1.6727, "thickness": 2.0},
     {"n": 1.0, "thickness": 1.87179},
 ];
+
+export const aperture = {"EntrancePupilDiameter": { diam: 40 }};
+
+export const fields = [{"angle": 0}, {"angle": 5}]

--- a/www/js/modules/planoconvex_lens.js
+++ b/www/js/modules/planoconvex_lens.js
@@ -1,9 +1,16 @@
 export const surfaces = [
+    {"ObjectPlane": {"diam": 50}},
     {"RefractingCircularConic": {"diam": 25.0, "roc": 25.8, "k": 0.0}},
     {"RefractingCircularFlat": {"diam": 25.0}},
+    {"ImagePlane": {"diam": 50}},
 ]
 
 export const gaps = [
+    {"n": 1.0, "thickness": 50},
     {"n": 1.515, "thickness": 5.3},
     {"n": 1.0, "thickness": 46.6},
 ]
+
+export const aperture = {"EntrancePupilDiameter": { diam: 20 }};
+
+export const fields = [{"angle": 0}, {"angle": 5}]

--- a/www/js/package-lock.json
+++ b/www/js/package-lock.json
@@ -23,6 +23,7 @@
       }
     },
     "../../raytracer/pkg": {
+      "name": "cherry",
       "version": "0.1.0"
     },
     "../cherry": {


### PR DESCRIPTION
Here I introduce the builder pattern for creating new optical systems. The new features are:

1. A new JS API based on the builder pattern to create SystemModels
2. Fields are now settable via the API
3. The object and image spaces are now directly settable via surfaces and gaps
4. SystemModels are now immutable (technically they will be once the old API is removed)

I left the old API in place for now so that you have time to change to the new one.