### PR TITLE
Represent DOM elements as data (nested vectors)

### DIFF
--- a/www/cljs/src/main/net/thewagner/build.clj
+++ b/www/cljs/src/main/net/thewagner/build.clj
@@ -1,8 +1,9 @@
 (ns net.thewagner.build
-  (:require [net.thewagner.html :as pages]))
+  (:require [hiccup.page :refer [html5]]
+            [net.thewagner.html :as pages]))
 
 (defn hook
   {:shadow.build/stage :flush}
   [{:keys [shadow.build/config] :as build-state} & _args]
-  (spit (str (:output-dir config) "/../index.html") pages/index)
+  (spit (str (:output-dir config) "/../index.html") (html5 pages/index-head pages/index-body))
   build-state)

--- a/www/cljs/src/main/net/thewagner/html.cljc
+++ b/www/cljs/src/main/net/thewagner/html.cljc
@@ -1,36 +1,35 @@
-(ns net.thewagner.html
-  (:require [hiccup.core :refer [html]]
-            [hiccup.page :refer [html5]]))
+(ns net.thewagner.html)
+
+(def table-nav
+  [:nav.level {:id :surfaces-table-nav}
+    [:div.level-left
+      [:div.level-item
+        [:p.subtitle "Surfaces"]]]
+    [:div.level-right
+      [:div.level-item
+        [:div.field.is-grouped
+          [:p.control
+            [:button.button {:id :preset-planoconvex-button} "Planoconvex"]]
+          [:p.control
+            [:button.button {:id :preset-petzval-button} "Petzval"]]
+          [:p.control
+            [:button.button {:id :preset-random-button} "I'm Feeling Lucky"]]
+          [:p.control
+            [:button.button.is-success {:id :new-row-button} "New"]]]]]])
 
 (def table
-  (html
-    [:nav.level {:id :surfaces-table-nav}
-      [:div.level-left
-        [:div.level-item
-          [:p.subtitle "Surfaces"]]]
-      [:div.level-right
-        [:div.level-item
-          [:div.field.is-grouped
-            [:p.control
-              [:button.button {:id :preset-planoconvex-button} "Planoconvex"]]
-            [:p.control
-              [:button.button {:id :preset-petzval-button} "Petzval"]]
-            [:p.control
-              [:button.button {:id :preset-random-button} "I'm Feeling Lucky"]]
-            [:p.control
-              [:button.button.is-success {:id :new-row-button} "New"]]]]]]
-    [:div.table-container
-      [:table.table {:id "surfaces-table"}
-         [:thead
-           [:tr
-             [:th {:style "width: 14%"} "Surface type"]
-             [:th {:style "width: 14%"} "n"]
-             [:th {:style "width: 14%"} "thickness"]
-             [:th {:style "width: 14%"} "diam"]
-             [:th {:style "width: 14%"} "roc"]
-             [:th {:style "width: 14%"} "k"]
-             [:th {:style "width: 14%"} "Actions"]]]
-         [:tbody]]]))
+  [:div.table-container
+    [:table.table {:id "surfaces-table"}
+       [:thead
+         [:tr
+           [:th {:style "width: 14%"} "Surface type"]
+           [:th {:style "width: 14%"} "n"]
+           [:th {:style "width: 14%"} "thickness"]
+           [:th {:style "width: 14%"} "diam"]
+           [:th {:style "width: 14%"} "roc"]
+           [:th {:style "width: 14%"} "k"]
+           [:th {:style "width: 14%"} "Actions"]]]
+       [:tbody]]])
 
 (def cherry-raytracer "🍒 Cherry Raytracer")
 
@@ -39,23 +38,22 @@
     [:div.navbar-brand
       [:a.navbar-item {:href "https://browser.science"} cherry-raytracer]]])
 
-(def index
-  (html5 {:lang "en"}
-    [:head
+(def index-head
+  [:head
       [:meta {:charset "UTF-8"}]
       [:meta {:name "viewport" :content "width=device-width, initial-scale=1"}]
       [:meta {:http-equiv "x-ua-compatible" :content "ie=edge"}]
-      [:title cherry-raytracer]
-      [:link {:rel "stylesheet" :href "./cherry.css"}]]
-    [:body
-      navbar
-      [:section.section
-        [:div.container
-          [:canvas#systemModel]]
-        [:div.container
-          table]]
-      [:script {:deferred true :src "./index.js"}]
-      [:script {:deferred true :src "./main.js"}]]))
+      [:title "🍒 Cherry Raytracer"]
+      [:link {:rel "stylesheet" :href "./cherry.css"}]])
 
-(comment
-  (spit "public/index.html" index))
+(def index-body
+ [:body
+   navbar
+   [:section.section
+     [:div.container
+       [:canvas#systemModel]]
+     [:div.container
+       table-nav
+       table]]
+   [:script {:deferred true :src "./index.js"}]
+   [:script {:deferred true :src "./main.js"}]])

--- a/www/cljs/src/main/science/browser/cherry/dom.cljs
+++ b/www/cljs/src/main/science/browser/cherry/dom.cljs
@@ -1,0 +1,75 @@
+; Based on https://github.com/clojure/clojurescript/blob/master/samples/twitterbuzz/src/twitterbuzz/dom-helpers.cljs
+(ns science.browser.cherry.dom
+  (:require [clojure.string :as string]
+            [goog.dom :as dom]))
+
+(defn get-element
+  "Return the element with the passed id."
+  [id]
+  (dom/getElement (name id)))
+
+(defn append
+  "Append all children to parent."
+  [parent & children]
+  (doseq [child children]
+    (dom/appendChild parent child))
+  parent)
+
+(defn set-text
+  "Set the text content for the passed element returning the
+  element. If a keyword is passed in the place of e, the element with
+  that id will be used and returned."
+  [e s]
+  (let [e (if (keyword? e) (get-element e) e)]
+    (doto e (dom/setTextContent s))))
+
+(defn normalize-args [tag args]
+  (let [parts (string/split (name tag) #"(\.|#)")
+        [tag attrs] [(first parts)
+                     (apply hash-map (map #(cond (= % ".") :class
+                                                 (= % "#") :id
+                                                 :else %)
+                                          (rest parts)))]]
+    (if (map? (first args))
+      [tag (merge attrs (first args)) (rest args)]
+      [tag attrs args])))
+
+(defn element
+  "Create a dom element using a keyword for the element name and a map
+  for the attributes. Append all children to parent. If the first
+  child is a string then the string will be set as the text content of
+  the parent and all remaining children will be appended."
+  [tag & args]
+  (let [[tag attrs children] (normalize-args tag args)
+        parent (dom/createDom (name tag) (clj->js attrs))
+        [parent children] (if (string? (first children))
+                            [(set-text (element tag attrs) (first children))
+                             (rest children)]
+                            [parent children])]
+    (apply append parent children)))
+
+(defn text [t]
+  (dom/createTextNode t))
+
+(defn remove-children
+  "Remove all children from the element."
+  [parent]
+  (dom/removeChildren parent)
+  parent)
+
+(defn- element-arg? [x]
+  (or (keyword? x)
+      (map? x)
+      (string? x)))
+
+(defn build
+  "Build up a dom element from nested vectors."
+  [x]
+  (if (vector? x)
+    (let [[parent children] (if (keyword? (first x))
+                              [(apply element (take-while element-arg? x))
+                               (drop-while element-arg? x)]
+                              [(first x) (rest x)])
+          children (map build children)]
+      (apply append parent children))
+    x))


### PR DESCRIPTION
Add a lightweight implementation of the "Hiccup"-template language to the project.  This represents HTML elements as nested vectors.

For example, to build a table cell with a combo box, we need the following HTML structure:

    <td>
      <div class="select">
        <select>
          <option>Select</option>
        </select
      </div>
    </td>

Currently, we build using nested JavaScript DOM API calls:

    (dom/createDom "td"
      (dom/createDom "div" {:class  "select"}
        (dom/createDom "select"
          (dom/createDom "option" "Select"))))

Instead of code, construct the same nested structure using data:

    [:td
       [:div.select
         [:select
           [:option "Select"]]]]

This is more concise in most of the cases where multiple levels of nesting is required.

But more importantly, this representation is _just data_, so it can be shared between the frontend and the backend.

In our case we don't have a backend yet, but we pre-render the bulk of the page using the same "template language".
