### PR TITLE
Remove buttons from the top of the table

### DIFF
--- a/www/cljs/src/main/kmdouglass/cherry.cljc
+++ b/www/cljs/src/main/kmdouglass/cherry.cljc
@@ -54,6 +54,11 @@
 (s/def ::surface-samples (s/coll-of (s/keys :req-un [::samples])))
 (s/def ::samples (s/coll-of (s/tuple number? number? number?) :min-count 1))
 
+(def object-and-image-plane
+  [{::ObjectPlane {::diam 50}}
+   {::n 1 ::thickness 50}
+   {::ImagePlane {::diam 50}}])
+
 (def planoconvex
   [{::ObjectPlane {::diam 50}}
    {::n 1 ::thickness 50}

--- a/www/cljs/src/main/net/thewagner/html.cljc
+++ b/www/cljs/src/main/net/thewagner/html.cljc
@@ -1,22 +1,5 @@
 (ns net.thewagner.html)
 
-(def table-nav
-  [:nav.level {:id :surfaces-table-nav}
-    [:div.level-left
-      [:div.level-item
-        [:p.subtitle "Surfaces"]]]
-    [:div.level-right
-      [:div.level-item
-        [:div.field.is-grouped
-          [:p.control
-            [:button.button {:id :preset-planoconvex-button} "Planoconvex"]]
-          [:p.control
-            [:button.button {:id :preset-petzval-button} "Petzval"]]
-          [:p.control
-            [:button.button {:id :preset-random-button} "I'm Feeling Lucky"]]
-          [:p.control
-            [:button.button.is-success {:id :new-row-button} "New"]]]]]])
-
 (def table
   [:div.table-container
     [:table.table {:id "surfaces-table"}
@@ -36,7 +19,19 @@
 (def navbar
   [:nav.navbar {:role "navigation" :aria-label "main navigation"}
     [:div.navbar-brand
-      [:a.navbar-item {:href "https://browser.science"} cherry-raytracer]]])
+      [:a.navbar-item {:href "https://browser.science"} cherry-raytracer]
+      [:a.navbar-burger {:role "button" :aria-label "menu" :aria-expanded "false"
+                         :data-target :navMenu}
+        [:span {:aria-hidden true}]
+        [:span {:aria-hidden true}]
+        [:span {:aria-hidden true}]]]
+    [:div#navMenu.navbar-menu
+      [:div.navbar-start
+        [:div.navbar-item.has-dropdown.is-hoverable
+          [:a.navbar-link "Examples"]
+          [:div.navbar-dropdown
+            [:a#preset-planoconvex.navbar-item "Planoconvex lens"]
+            [:a#preset-petzval.navbar-item "Petzval objective"]]]]]])
 
 (defn tabs-nav [active]
   (letfn [(current [t] (if (= t active) {:class :is-active} {}))]
@@ -47,7 +42,7 @@
 
 (defn tabs-body [active]
   (case active
-    :surfaces [:div.container table-nav table]
+    :surfaces [:div.container table]
     :aperture [:div.container
                 [:div.field.is-horizontal
                   [:div.field-label.is-normal


### PR DESCRIPTION
Some UI changes to make the app more usable:

* Move the Examples to the top navbar
* Move surface insertion in the Actions column
* The default system contains an Object Plane and an Image Plane

<img width="851" alt="image" src="https://github.com/kmdouglass/cherry/assets/514775/1682bad6-95e6-4d3c-9065-90ecc1b94b8c">

<img width="850" alt="image" src="https://github.com/kmdouglass/cherry/assets/514775/7d07ce39-79b3-4dee-9542-ccd3167d0374">
