### PR TITLE
Pass the tab processor constructors as arguments

### DIFF
--- a/www/cljs/src/main/net/thewagner/cherry.cljs
+++ b/www/cljs/src/main/net/thewagner/cherry.cljs
@@ -487,7 +487,7 @@
          (if (= active selected)
            (recur active tab-done tab-state tab-proc)
            (let [state (when tab-proc
-                         (async/close! tab-done) ; ask the tab proces to close
+                         (async/close! tab-done) ; ask the tab process to close
                          (<! tab-proc))]         ; wait for the process to exit
              (-set-active! el selected)
              (-render-tab! (dom/get-element :tab-body) selected (tab-state selected))


### PR DESCRIPTION
This is a follow-up of PR #51 which makes the tab component now fully generic.