### PR TITLE
Avoid overindexing when rays terminate

### DIFF
--- a/www/cljs/src/main/kmdouglass/cherry.cljc
+++ b/www/cljs/src/main/kmdouglass/cherry.cljc
@@ -45,8 +45,7 @@
                                 (fn [{:keys [surfaces]}] (= :ImagePlane (first (last surfaces))))))
 
 ; Ray-race results
-(s/def ::raytrace-results (s/and (s/coll-of ::ray)
-                                 (fn all-same-length [rays] (= 1 (count (set (map count rays)))))))
+(s/def ::raytrace-results (s/coll-of ::ray))
 (s/def ::ray (s/coll-of (s/keys :req-un [::pos ::dir])))
 (s/def ::pos (s/tuple number? number? number?))
 (s/def ::dir (s/tuple number? number? number?))

--- a/www/cljs/src/rendering/index.js
+++ b/www/cljs/src/rendering/index.js
@@ -94,8 +94,10 @@ export function resultsToRayPaths(rayTraceResults) {
     let rayPaths = Array.from(Array(numRays), () => {return {"samples": []};});
     for (let surface of rayTraceResults) {
         for (let ray_id = 0; ray_id < numRays; ray_id++) {
-            let ray = surface[ray_id];
-            rayPaths[ray_id].samples.push(ray.pos);
+            if (ray_id < surface.length) {
+                let ray = surface[ray_id];
+                rayPaths[ray_id].samples.push(ray.pos);
+            }
         }
     }
 


### PR DESCRIPTION
Currently the rays drawing works only if the number of rays is identical on all surfaces.  This was
captured in the `::raytrace-results` spec so it didn't cause any problems, but it also prevented
some results to be drawn.

Check the length of each surface when iterating and remove the `all-same-length` condition from the spec.
