### PR TITLE
Fix rendering of system with infinite object planes

### DIFF
--- a/www/js/modules/rendering.js
+++ b/www/js/modules/rendering.js
@@ -82,23 +82,27 @@ function commands(descr, rayPaths, centerSystem, centerSVG, sf) {
         "color": "red",
         "stroke-width": 0.5,
     });
-
     return commands;
 }
 
 function drawCommands(commands, svg) {
     for (let command of commands) {
         command.paths.forEach(function(path, i) {
-            let pathElement = document.createElementNS("http://www.w3.org/2000/svg", "path");
-            let d = `M ${path[0][0]} ${path[0][1]}`;
-            for (let point of path) {
-                d += ` L ${point[0]} ${point[1]}`;
+            if (path.length == 0) {
+                // Nothing to draw
+            } else {
+
+                let pathElement = document.createElementNS("http://www.w3.org/2000/svg", "path");
+                let d = `M ${path[0][0]} ${path[0][1]}`;
+                for (let point of path) {
+                    d += ` L ${point[0]} ${point[1]}`;
+                }
+                pathElement.setAttribute("d", d);
+                pathElement.setAttribute("stroke", command.color);
+                pathElement.setAttribute("stroke-width", command["stroke-width"] || 1.0);
+                pathElement.setAttribute("fill", "none");
+                svg.appendChild(pathElement);
             }
-            pathElement.setAttribute("d", d);
-            pathElement.setAttribute("stroke", command.color);
-            pathElement.setAttribute("stroke-width", command["stroke-width"] || 1.0);
-            pathElement.setAttribute("fill", "none");
-            svg.appendChild(pathElement);
         });
     }
 }


### PR DESCRIPTION
This fixes #12 in which systems with infinite object planes threw an error when rendering. There's no need to render infinite image planes since these can't exist in practice, at least as far as I can foresee.

 
![image](https://github.com/kmdouglass/cherry/assets/3697676/9ec45ea3-a7b2-482b-a35c-2986eff5b972)
