### PR TITLE
Rename sequential model to surface model

### DIFF
--- a/raytracer/src/lib.rs
+++ b/raytracer/src/lib.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use wasm_bindgen::prelude::*;
 
 use ray_tracing::description::SystemDescription;
-use ray_tracing::sequential_model::SequentialModel;
+use ray_tracing::surface_model::SurfaceModel;
 use ray_tracing::{ApertureSpec, Gap, SurfaceSpec, SystemBuilder, SystemModel};
 
 static COUNTER: AtomicUsize = AtomicUsize::new(1);
@@ -181,11 +181,11 @@ impl WasmSystemModel {
         Ok(serde_wasm_bindgen::to_value(&sanitized).unwrap())
     }
 
-    fn seq_model(&self) -> &SequentialModel {
-        self.system_model.seq_model()
+    fn seq_model(&self) -> &SurfaceModel {
+        self.system_model.surf_model()
     }
 
-    fn seq_model_mut(&mut self) -> &mut SequentialModel {
-        self.system_model.seq_model_mut()
+    fn seq_model_mut(&mut self) -> &mut SurfaceModel {
+        self.system_model.surf_model_mut()
     }
 }

--- a/raytracer/src/ray_tracing/component_model/mod.rs
+++ b/raytracer/src/ray_tracing/component_model/mod.rs
@@ -22,7 +22,7 @@ impl ComponentModel {
         let mut surf_pairs = SurfacePairIterator::new(surfaces).enumerate();
         let max_idx = surfaces.len() - 1;
         let mut paired_surfaces = HashSet::new();
-    
+
         if max_idx < 2 {
             // There are no components because only the object and image plane exist.
             return Self {
@@ -87,16 +87,18 @@ mod tests {
     use super::*;
 
     use crate::test_cases::{
-        empty_system, planoconvex_lens_obj_at_inf, silly_single_surface_and_stop, silly_unpaired_surface,
-        wollaston_landscape_lens,
+        empty_system, planoconvex_lens_obj_at_inf, silly_single_surface_and_stop,
+        silly_unpaired_surface, wollaston_landscape_lens,
     };
 
     #[test]
     fn test_new_no_components() {
         let system_model = empty_system();
 
-        let component_model =
-            ComponentModel::new(system_model.seq_model.surfaces(), system_model.background());
+        let component_model = ComponentModel::new(
+            system_model.surf_model.surfaces(),
+            system_model.background(),
+        );
 
         assert_eq!(component_model.components.len(), 0);
     }
@@ -105,8 +107,10 @@ mod tests {
     fn test_planoconvex_lens() {
         let system_model = planoconvex_lens_obj_at_inf();
 
-        let component_model =
-            ComponentModel::new(system_model.seq_model.surfaces(), system_model.background());
+        let component_model = ComponentModel::new(
+            system_model.surf_model.surfaces(),
+            system_model.background(),
+        );
 
         assert_eq!(component_model.components.len(), 1);
         assert!(component_model
@@ -119,8 +123,10 @@ mod tests {
         // This is not a useful system but a good test.
         let system_model = silly_single_surface_and_stop();
 
-        let component_model =
-            ComponentModel::new(system_model.seq_model.surfaces(), system_model.background());
+        let component_model = ComponentModel::new(
+            system_model.surf_model.surfaces(),
+            system_model.background(),
+        );
 
         assert_eq!(component_model.components.len(), 1);
         assert!(component_model
@@ -133,20 +139,28 @@ mod tests {
         // This is not a useful system but a good test.
         let system_model = silly_unpaired_surface();
 
-        let component_model =
-            ComponentModel::new(system_model.seq_model.surfaces(), system_model.background());
+        let component_model = ComponentModel::new(
+            system_model.surf_model.surfaces(),
+            system_model.background(),
+        );
 
         assert_eq!(component_model.components.len(), 2);
-        assert!(component_model.components.contains(&Component::Element { surf_idxs: (1, 2) }));
-        assert!(component_model.components.contains(&Component::UnpairedSurface { surf_idx: 3 }));
+        assert!(component_model
+            .components
+            .contains(&Component::Element { surf_idxs: (1, 2) }));
+        assert!(component_model
+            .components
+            .contains(&Component::UnpairedSurface { surf_idx: 3 }));
     }
 
     #[test]
     fn test_wollaston_landscape_lens() {
         let system_model = wollaston_landscape_lens();
 
-        let component_model =
-            ComponentModel::new(system_model.seq_model.surfaces(), system_model.background());
+        let component_model = ComponentModel::new(
+            system_model.surf_model.surfaces(),
+            system_model.background(),
+        );
 
         assert_eq!(component_model.components.len(), 2);
         assert!(component_model

--- a/raytracer/src/ray_tracing/description.rs
+++ b/raytracer/src/ray_tracing/description.rs
@@ -23,7 +23,7 @@ pub struct SystemDescription {
 
 impl SystemDescription {
     pub fn new(system: &SystemModel) -> Self {
-        let surfaces = system.seq_model.surfaces();
+        let surfaces = system.surf_model.surfaces();
         let component_model = ComponentModelDescr::new(system.comp_model.components());
         let surface_model = SurfaceModelDescr::new(surfaces, NUM_SAMPLES_PER_SURFACE);
 

--- a/raytracer/src/ray_tracing/surface_model/mod.rs
+++ b/raytracer/src/ray_tracing/surface_model/mod.rs
@@ -4,13 +4,13 @@ use crate::math::vec3::Vec3;
 use crate::ray_tracing::{Gap, Surface, SurfacePairIterator};
 
 #[derive(Debug)]
-pub struct SequentialModel {
+pub struct SurfaceModel {
     gaps: Vec<Gap>,
     surfaces: Vec<Surface>,
 }
 
-impl SequentialModel {
-    pub fn new(surfaces: &[Surface]) -> SequentialModel {
+impl SurfaceModel {
+    pub fn new(surfaces: &[Surface]) -> SurfaceModel {
         // Iterate over SurfacePairs and convert to Surfaces and Gaps
         let mut gaps = Vec::new();
         let mut surfs = Vec::new();
@@ -120,7 +120,7 @@ mod tests {
     fn planoconvex_lens_obj_at_inf() -> SystemModel {
         // The image is located at the lens back focal plane.
         let mut system_model = SystemModel::old();
-        let mut model = system_model.seq_model_mut();
+        let mut model = system_model.surf_model_mut();
 
         model
             .insert_surface_and_gap(
@@ -155,7 +155,7 @@ mod tests {
     fn planoconvex_lens_img_at_inf() -> SystemModel {
         // The object is located at the lens front focal plane.
         let mut system_model = SystemModel::old();
-        let mut model = system_model.seq_model_mut();
+        let mut model = system_model.surf_model_mut();
 
         model
             .insert_surface_and_gap(
@@ -190,7 +190,7 @@ mod tests {
     #[test]
     fn test_insert_surface_and_gap() {
         let system_model = planoconvex_lens_obj_at_inf();
-        let model = system_model.seq_model();
+        let model = system_model.surf_model();
 
         // 2 surfaces + object plane + image plane
         assert_eq!(model.surfaces.len(), 4);
@@ -204,7 +204,7 @@ mod tests {
     #[test]
     fn test_insert_surface_and_gap_before_another_surface() {
         let mut system_model = SystemModel::old();
-        let mut model = system_model.seq_model_mut();
+        let mut model = system_model.surf_model_mut();
 
         model
             .insert_surface_and_gap(
@@ -254,7 +254,7 @@ mod tests {
     #[test]
     fn test_remove_surface_and_gap() {
         let mut system_model = planoconvex_lens_obj_at_inf();
-        let model = system_model.seq_model_mut();
+        let model = system_model.surf_model_mut();
 
         assert_eq!(model.surfaces.len(), 4);
         assert_eq!(model.gaps.len(), 3);
@@ -271,7 +271,7 @@ mod tests {
     #[test]
     fn test_surf_distance_from_origin() {
         let mut system_model = planoconvex_lens_obj_at_inf();
-        let model = system_model.seq_model_mut();
+        let model = system_model.surf_model_mut();
 
         assert_eq!(model.surf_distance_from_origin(0), 1.0);
         assert_eq!(model.surf_distance_from_origin(1), 0.0);


### PR DESCRIPTION
There are no API changes; this is just part of a code cleanup.

Fixes #56 