### PR TITLE
Bevel linejoins on lens outlines

### DIFF
--- a/www/cljs/src/rendering/index.js
+++ b/www/cljs/src/rendering/index.js
@@ -72,6 +72,7 @@ function commands(descr, rayPaths, centerSystem, centerSVG, sf) {
         "paths": paths,
         "color": "black",
         "stroke-width": 1.0,
+        "stroke-linejoin": "bevel",
         "close-path": true,
     });
 
@@ -104,6 +105,7 @@ function drawCommands(commands, svg) {
                 pathElement.setAttribute("d", d);
                 pathElement.setAttribute("stroke", command.color);
                 pathElement.setAttribute("stroke-width", command["stroke-width"] || 1.0);
+                pathElement.setAttribute("stroke-linejoin", command["stroke-linejoin"] || "miter");
                 pathElement.setAttribute("fill", "none");
                 svg.appendChild(pathElement);
             }

--- a/www/js/modules/rendering.js
+++ b/www/js/modules/rendering.js
@@ -72,6 +72,7 @@ function commands(descr, rayPaths, centerSystem, centerSVG, sf) {
         "paths": paths,
         "color": "black",
         "stroke-width": 1.0,
+        "stroke-linejoin": "bevel",
         "close-path": true,
     });
 
@@ -104,6 +105,7 @@ function drawCommands(commands, svg) {
                 pathElement.setAttribute("d", d);
                 pathElement.setAttribute("stroke", command.color);
                 pathElement.setAttribute("stroke-width", command["stroke-width"] || 1.0);
+                pathElement.setAttribute("stroke-linejoin", command["stroke-linejoin"] || "miter");
                 pathElement.setAttribute("fill", "none");
                 svg.appendChild(pathElement);
             }


### PR DESCRIPTION
Use a beveled linejoin on lens paths to avoid lenses cutting into one another at their corners. This is especially noticeable on mobile.

### Before

![image](https://github.com/kmdouglass/cherry/assets/3697676/aeca7ba7-9aae-4a4a-91be-a6cc95db78cb)

### After

![image](https://github.com/kmdouglass/cherry/assets/3697676/b4fca8ce-42d8-454b-b1bb-9ff8bd854af1)
