### PR TITLE
Set object planes of examples to infinity

### DIFF
--- a/www/cljs/src/main/kmdouglass/cherry.cljc
+++ b/www/cljs/src/main/kmdouglass/cherry.cljc
@@ -60,7 +60,7 @@
 
 (def planoconvex
   [{::ObjectPlane {::diam 50}}
-   {::n 1 ::thickness 50}
+   {::n 1 ::thickness ##Inf}
    {::RefractingCircularConic {::diam 25.0 ::roc 25.8 ::k 0.0}}
    {::n 1.515 ::thickness 5.3}
    {::RefractingCircularFlat {::diam 25.0}}
@@ -69,7 +69,7 @@
 
 (def petzval
   [{::ObjectPlane {::diam 50}}
-   {::n 1 ::thickness 200}
+   {::n 1 ::thickness ##Inf}
    {::RefractingCircularConic {::diam 56.956, ::roc 99.56266, ::k 0.0}}
    {::n 1.5168 ::thickness 13.0}
    {::RefractingCircularConic {::diam 52.552, ::roc -86.84002, ::k 0.0}}


### PR DESCRIPTION
I verified that entering `Infinity` into the UI also works.

![image](https://github.com/kmdouglass/cherry/assets/3697676/b5c6b6b9-30b9-444e-bc17-455e3706f89b)

I'm going to look into why the rays suddenly terminate in many cases. I'm guessing it's a bug in the Newton-Raphson routine for finding the ray/surface intersections.
