### PR TITLE
Fix aperture stop bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- A macro `n` for easily creating real `RefractiveIndexSpec`s.
+- A Petzval lens example.
+
+[0.1.0]: https://github.com/kmdouglass/cherry/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A macro `n` for easily creating real `RefractiveIndexSpec`s.
 - A Petzval lens example.
 
+### Fixed
+
+- The aperture stop calculation of the paraxial view now correctly finds the minimum semi-diameter to pseudo-marginal ray height ratio by first taking the absolute value of the ratios. 
+
 [0.1.0]: https://github.com/kmdouglass/cherry/releases/tag/v0.1.0

--- a/raytracer/cherry-rs/src/examples/mod.rs
+++ b/raytracer/cherry-rs/src/examples/mod.rs
@@ -1,1 +1,2 @@
 pub mod convexplano_lens;
+pub mod petzval_lens;

--- a/raytracer/cherry-rs/src/examples/petzval_lens.rs
+++ b/raytracer/cherry-rs/src/examples/petzval_lens.rs
@@ -1,8 +1,4 @@
-use ndarray::{arr3, Array3};
-
-use crate::{
-    n, GapSpec, Pupil, RealSpec, RefractiveIndexSpec, SequentialModel, SurfaceSpec, SurfaceType,
-};
+use crate::{n, GapSpec, RealSpec, RefractiveIndexSpec, SequentialModel, SurfaceSpec, SurfaceType};
 
 pub fn sequential_model() -> SequentialModel {
     let air = n!(1.0);
@@ -86,7 +82,7 @@ pub fn sequential_model() -> SequentialModel {
         surf_type: SurfaceType::Refracting,
     };
     let surf_7 = SurfaceSpec::Conic {
-        semi_diameter: 16.492,
+        semi_diameter: 20.074,
         radius_of_curvature: -614.68633,
         conic_constant: 0.0,
         surf_type: SurfaceType::Refracting,
@@ -115,17 +111,3 @@ pub fn sequential_model() -> SequentialModel {
 
 // Paraxial View values
 pub const APERTURE_STOP: usize = 4;
-
-pub const ENTRANCE_PUPIL: Pupil = Pupil {
-    location: 0.0,
-    semi_diameter: 12.5,
-};
-
-pub fn marginal_ray() -> Array3<f64> {
-    arr3(&[
-        [[12.5000], [0.0]],
-        [[12.5000], [-0.1647]],
-        [[11.6271], [-0.2495]],
-        [[-0.0003], [-0.2495]],
-    ])
-}

--- a/raytracer/cherry-rs/src/examples/petzval_lens.rs
+++ b/raytracer/cherry-rs/src/examples/petzval_lens.rs
@@ -1,0 +1,131 @@
+use ndarray::{arr3, Array3};
+
+use crate::{
+    n, GapSpec, Pupil, RealSpec, RefractiveIndexSpec, SequentialModel, SurfaceSpec, SurfaceType,
+};
+
+pub fn sequential_model() -> SequentialModel {
+    let air = n!(1.0);
+
+    let gap_0 = GapSpec {
+        thickness: f64::INFINITY,
+        refractive_index: air.clone(),
+    };
+    let gap_1 = GapSpec {
+        thickness: 13.0,
+        refractive_index: n!(1.5168),
+    };
+    let gap_2 = GapSpec {
+        thickness: 4.0,
+        refractive_index: n!(1.6645),
+    };
+    let gap_3 = GapSpec {
+        thickness: 40.0,
+        refractive_index: air.clone(),
+    };
+    let gap_4 = GapSpec {
+        thickness: 40.0,
+        refractive_index: air.clone(),
+    };
+    let gap_5 = GapSpec {
+        thickness: 12.0,
+        refractive_index: n!(1.6074),
+    };
+    let gap_6 = GapSpec {
+        thickness: 3.0,
+        refractive_index: n!(1.6727),
+    };
+    let gap_7 = GapSpec {
+        thickness: 46.82210,
+        refractive_index: air.clone(),
+    };
+    let gap_8 = GapSpec {
+        thickness: 2.0,
+        refractive_index: n!(1.6727),
+    };
+    let gap_9 = GapSpec {
+        thickness: 1.87179,
+        refractive_index: air.clone(),
+    };
+    let gaps = vec![
+        gap_0, gap_1, gap_2, gap_3, gap_4, gap_5, gap_6, gap_7, gap_8, gap_9,
+    ];
+
+    let surf_0 = SurfaceSpec::Object;
+    let surf_1 = SurfaceSpec::Conic {
+        semi_diameter: 28.478,
+        radius_of_curvature: 99.56266,
+        conic_constant: 0.0,
+        surf_type: SurfaceType::Refracting,
+    };
+    let surf_2 = SurfaceSpec::Conic {
+        semi_diameter: 26.276,
+        radius_of_curvature: -86.84002,
+        conic_constant: 0.0,
+        surf_type: SurfaceType::Refracting,
+    };
+    let surf_3 = SurfaceSpec::Conic {
+        semi_diameter: 21.02,
+        radius_of_curvature: -1187.63858,
+        conic_constant: 0.0,
+        surf_type: SurfaceType::Refracting,
+    };
+    let surf_4 = SurfaceSpec::Stop {
+        semi_diameter: 16.631,
+    };
+    let surf_5 = SurfaceSpec::Conic {
+        semi_diameter: 20.543,
+        radius_of_curvature: 57.47491,
+        conic_constant: 0.0,
+        surf_type: SurfaceType::Refracting,
+    };
+    let surf_6 = SurfaceSpec::Conic {
+        semi_diameter: 20.074,
+        radius_of_curvature: -54.61685,
+        conic_constant: 0.0,
+        surf_type: SurfaceType::Refracting,
+    };
+    let surf_7 = SurfaceSpec::Conic {
+        semi_diameter: 16.492,
+        radius_of_curvature: -614.68633,
+        conic_constant: 0.0,
+        surf_type: SurfaceType::Refracting,
+    };
+    let surf_8 = SurfaceSpec::Conic {
+        semi_diameter: 17.297,
+        radius_of_curvature: -38.17110,
+        conic_constant: 0.0,
+        surf_type: SurfaceType::Refracting,
+    };
+    let surf_9 = SurfaceSpec::Conic {
+        semi_diameter: 18.94,
+        radius_of_curvature: f64::INFINITY,
+        conic_constant: 0.0,
+        surf_type: SurfaceType::Refracting,
+    };
+    let surf_10 = SurfaceSpec::Image;
+    let surfaces = vec![
+        surf_0, surf_1, surf_2, surf_3, surf_4, surf_5, surf_6, surf_7, surf_8, surf_9, surf_10,
+    ];
+
+    let wavelengths: Vec<f64> = vec![0.567];
+
+    SequentialModel::new(&gaps, &surfaces, &wavelengths).unwrap()
+}
+
+// Paraxial View values
+pub const APERTURE_STOP: usize = 4;
+
+pub const ENTRANCE_PUPIL: Pupil = Pupil {
+    location: 0.0,
+    semi_diameter: 12.5,
+};
+
+pub fn marginal_ray() -> Array3<f64> {
+    arr3(&[
+        [[12.5000], [0.0]],
+        [[12.5000], [-0.1647]],
+        [[11.6271], [-0.2495]],
+        [[-0.0003], [-0.2495]],
+    ])
+}

--- a/raytracer/cherry-rs/src/specs/fields.rs
+++ b/raytracer/cherry-rs/src/specs/fields.rs
@@ -127,7 +127,7 @@ mod test {
             angle: -5.0,
             pupil_sampling: PupilSampling::SquareGrid { spacing: 0.1 },
         };
-        assert!(angle.validate().is_err());
+        assert!(angle.validate().is_ok());
 
         let angle = FieldSpec::Angle {
             angle: 45.0,

--- a/raytracer/cherry-rs/src/specs/gaps.rs
+++ b/raytracer/cherry-rs/src/specs/gaps.rs
@@ -16,6 +16,18 @@ pub struct RefractiveIndexSpec {
     pub imag: Option<ImagSpec>,
 }
 
+/// Creates a real refractive index spec.
+#[macro_export]
+macro_rules! n {
+    ($n:expr) => {
+        RefractiveIndexSpec {
+            real: RealSpec::Constant($n),
+            imag: None,
+        }
+    };
+    () => {};
+}
+
 /// Specifies the real part of a refractive index.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum RealSpec {

--- a/raytracer/cherry-rs/src/views/paraxial.rs
+++ b/raytracer/cherry-rs/src/views/paraxial.rs
@@ -206,8 +206,11 @@ impl ParaxialSubView {
                 .collect::<Vec<Float>>(),
         );
 
-        let ratios =
-            semi_diameters / pseudo_marginal_ray[[pseudo_marginal_ray.shape()[0] - 1, 0, 0]];
+        // Absolute value is necessary because the pseudo-marginal ray trace
+        // can result in surface intersections that are negative.
+        let ratios = (semi_diameters
+            / pseudo_marginal_ray[[pseudo_marginal_ray.shape()[0] - 1, 0, 0]])
+        .mapv(|x| x.abs());
 
         // Do not include the object or image surfaces when computing the aperture stop.
         argmin(&ratios.slice(s![1..(ratios.len() - 1)])) + 1

--- a/raytracer/cherry-rs/tests/petzval_lens.rs
+++ b/raytracer/cherry-rs/tests/petzval_lens.rs
@@ -1,0 +1,41 @@
+use cherry_rs::examples::petzval_lens::*;
+use cherry_rs::ParaxialView;
+
+fn paraxial_view() -> ParaxialView {
+    let model = sequential_model();
+    ParaxialView::new(&model, false).expect("Could not create paraxial view")
+}
+
+#[test]
+fn test_describe_paraxial_view() {
+    let view = paraxial_view();
+    let _ = view.describe();
+}
+
+#[test]
+fn test_paraxial_view_aperture_stop() {
+    let model = sequential_model();
+    let sub_models = model.submodels();
+    let view = paraxial_view();
+
+    for sub_model_id in sub_models.keys() {
+        let sub_view = view.subviews.get(sub_model_id).unwrap();
+        let result = sub_view.aperture_stop();
+
+        assert_eq!(APERTURE_STOP, *result)
+    }
+}
+
+#[test]
+fn test_paraxial_view_entrance_pupil() {
+    let model = sequential_model();
+    let sub_models = model.submodels();
+    let view = paraxial_view();
+
+    for (sub_model_id, _) in sub_models {
+        let sub_view = view.subviews.get(sub_model_id).unwrap();
+        let result = sub_view.entrance_pupil();
+
+        assert_eq!(ENTRANCE_PUPIL, *result)
+    }
+}

--- a/raytracer/cherry-rs/tests/petzval_lens.rs
+++ b/raytracer/cherry-rs/tests/petzval_lens.rs
@@ -25,17 +25,3 @@ fn test_paraxial_view_aperture_stop() {
         assert_eq!(APERTURE_STOP, *result)
     }
 }
-
-#[test]
-fn test_paraxial_view_entrance_pupil() {
-    let model = sequential_model();
-    let sub_models = model.submodels();
-    let view = paraxial_view();
-
-    for (sub_model_id, _) in sub_models {
-        let sub_view = view.subviews.get(sub_model_id).unwrap();
-        let result = sub_view.entrance_pupil();
-
-        assert_eq!(ENTRANCE_PUPIL, *result)
-    }
-}

--- a/www/js/src/examples/petzvalLens.js
+++ b/www/js/src/examples/petzvalLens.js
@@ -6,7 +6,7 @@ const surfaces = [
     { type: "Stop", n: 1.0, thickness: 40.0, semiDiam: 16.631},
     { type: "Conic", n: 1.6074, thickness: 12.0, semiDiam: 20.543, roc: 57.47491 },
     { type: "Conic", n: 1.6727, thickness: 3.0, semiDiam: 20.074, roc: -54.61685 },
-    { type: "Conic", n: 1.0, thickness: 46.82210, semiDiam: 16.492, roc: -614.68633 },
+    { type: "Conic", n: 1.0, thickness: 46.82210, semiDiam: 20.074, roc: -614.68633 },
     { type: "Conic", n: 1.6727, thickness: 2.0, semiDiam: 17.297, roc: -38.17110 },
     { type: "Conic", n: 1.0, thickness: 1.87179, semiDiam: 18.94, roc: "Infinity" },
     { type: "Image", n: "", thickness: "", semiDiam: 25.0, roc: "" },


### PR DESCRIPTION
Fixes #146 

The aperture stop calculation should have been performed on absolute values of semi-diameter to marginal ray height ratios.