### PR TITLE
Update brand link

### DIFF
--- a/www/js/src/components/Navbar.js
+++ b/www/js/src/components/Navbar.js
@@ -241,7 +241,7 @@ const Navbar = ( {
                 onChange={handleFileChange}
             />
             <div className="navbar-brand">
-                <a className="navbar-item" href="/">
+                <a className="navbar-item" href="/cherry">
                     🍒 Cherry Ray Tracer
                 </a>
                 <button 


### PR DESCRIPTION
Currently clicking on the brand link brings the user to https://https://kmdouglass.github.io, which is a cool site 😎 but not the raytracer.

Instead, link to https://kmdouglass.github.io/cherry