### PR TITLE
Expose primary axial color to frontend

### DIFF
--- a/raytracer/cherry-rs/examples/convexplano_lens.rs
+++ b/raytracer/cherry-rs/examples/convexplano_lens.rs
@@ -342,7 +342,7 @@ mod test_ri_info {
             ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
         let expected = axial_primary_color();
-        let results = view.axial_primary_color(&WAVELENGTHS).unwrap();
+        let results = view.axial_primary_color();
 
         assert_eq!(expected.len(), results.len());
         for (axis, expected_value) in expected.iter() {

--- a/raytracer/cherry-rs/src/core/sequential_model.rs
+++ b/raytracer/cherry-rs/src/core/sequential_model.rs
@@ -497,17 +497,21 @@ impl<'a> SequentialSubModel for SequentialSubModelSlice<'a> {
 }
 
 impl Serialize for SubModelID {
-    // Serialize as a string like "0:Y" because tuples as map keys are difficult to work with in
-    // languages like Javascript.
+    // Serialize as a string like "0:Y" because tuples as map keys are difficult to
+    // work with in languages like Javascript.
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         // Serialize as a string like "0:Y"
-        let key = format!("{}:{}", self.0, match self.1 {
-            Axis::X => "X",
-            Axis::Y => "Y",
-        });
+        let key = format!(
+            "{}:{}",
+            self.0,
+            match self.1 {
+                Axis::X => "X",
+                Axis::Y => "Y",
+            }
+        );
         serializer.serialize_str(&key)
     }
 }

--- a/raytracer/cherry-rs/src/core/sequential_model.rs
+++ b/raytracer/cherry-rs/src/core/sequential_model.rs
@@ -43,6 +43,7 @@ pub struct Gap {
 pub struct SequentialModel {
     surfaces: Vec<Surface>,
     submodels: HashMap<SubModelID, SequentialSubModelBase>,
+    wavelengths: Vec<Float>,
 }
 
 /// A submodel of a sequential optical system.
@@ -327,6 +328,7 @@ impl SequentialModel {
         Ok(Self {
             surfaces,
             submodels: models,
+            wavelengths: wavelengths.to_vec(),
         })
     }
 
@@ -354,6 +356,11 @@ impl SequentialModel {
                 _ => None,
             })
             .fold(0.0, |acc, x| acc.max(x))
+    }
+
+    /// Returns the wavelengths at which the system is modeled.
+    pub fn wavelengths(&self) -> &[Float] {
+        &self.wavelengths
     }
 
     /// Computes the unique IDs for each paraxial model.

--- a/raytracer/cherry-rs/src/lib.rs
+++ b/raytracer/cherry-rs/src/lib.rs
@@ -150,4 +150,5 @@ pub use views::{
 };
 
 // Re-exports from dependencies
+#[cfg(feature = "ri-info")]
 pub use lib_ria::Material;

--- a/raytracer/cherry-rs/src/views/paraxial.rs
+++ b/raytracer/cherry-rs/src/views/paraxial.rs
@@ -68,7 +68,7 @@ pub struct ParaxialView {
 #[derive(Debug, Serialize)]
 pub struct ParaxialViewDescription {
     subviews: HashMap<SubModelID, ParaxialSubViewDescription>,
-    axial_primary_color: HashMap<Axis, Float>,
+    primary_axial_color: HashMap<Axis, Float>,
 }
 
 /// A paraxial subview of an optical system.
@@ -257,7 +257,7 @@ impl ParaxialView {
                 .iter()
                 .map(|(id, subview)| (*id, subview.describe()))
                 .collect(),
-            axial_primary_color: self.axial_primary_color()
+            primary_axial_color: self.axial_primary_color(),
         }
     }
 
@@ -284,13 +284,15 @@ impl ParaxialView {
     pub fn axial_primary_color(&self) -> HashMap<Axis, Float> {
         // Find the indexes of the minimum and maximum wavelengths. Return with the
         // empty axial primary color if there are no wavelengths.
-        let min_wav_index = self.wavelengths
+        let min_wav_index = self
+            .wavelengths
             .iter()
             .enumerate()
             .min_by(|(_, a), (_, b)| a.total_cmp(b))
             .map(|(index, _)| index)
             .unwrap_or_default();
-        let max_wav_index = self.wavelengths
+        let max_wav_index = self
+            .wavelengths
             .iter()
             .enumerate()
             .max_by(|(_, a), (_, b)| a.total_cmp(b))

--- a/raytracer/cherry-rs/src/views/paraxial.rs
+++ b/raytracer/cherry-rs/src/views/paraxial.rs
@@ -59,6 +59,7 @@ type RayTransferMatrix = Array2<Float>;
 #[derive(Debug)]
 pub struct ParaxialView {
     subviews: HashMap<SubModelID, ParaxialSubView>,
+    wavelengths: Vec<Float>,
 }
 
 /// A description of a paraxial optical system.
@@ -67,6 +68,7 @@ pub struct ParaxialView {
 #[derive(Debug, Serialize)]
 pub struct ParaxialViewDescription {
     subviews: HashMap<SubModelID, ParaxialSubViewDescription>,
+    axial_primary_color: HashMap<Axis, Float>,
 }
 
 /// A paraxial subview of an optical system.
@@ -238,6 +240,7 @@ impl ParaxialView {
 
         Ok(Self {
             subviews: subviews?,
+            wavelengths: sequential_model.wavelengths().to_vec(),
         })
     }
 
@@ -254,6 +257,7 @@ impl ParaxialView {
                 .iter()
                 .map(|(id, subview)| (*id, subview.describe()))
                 .collect(),
+            axial_primary_color: self.axial_primary_color()
         }
     }
 
@@ -275,34 +279,18 @@ impl ParaxialView {
     /// enter the wavelengths for the Fraunhofer F and C lines as minimum and
     /// maximum wavelengths to the underlying sequential model.
     ///
-    /// # Arguments
-    /// * `wavelengths` - The wavelengths to compute the axial primary color.
-    ///   These must match the wavelengths used in the underlying sequential
-    ///   model.
-    ///
     /// # Returns
     /// A HashMap containing the axial primary color for each axis.
-    ///
-    /// # Errors
-    /// An error is returned if the number of wavelengths does not match the
-    /// number of unique wavelengths in the paraxial view.
-    pub fn axial_primary_color(&self, wavelengths: &[Float]) -> Result<HashMap<Axis, Float>> {
-        let unique_wavelengths = self.subviews.keys().map(|id| id.0).collect::<Vec<usize>>();
-        if unique_wavelengths.len() != wavelengths.len() {
-            return Err(anyhow!(
-                "The number of wavelengths must match the number of unique wavelengths in the system."
-            ));
-        }
-
+    pub fn axial_primary_color(&self) -> HashMap<Axis, Float> {
         // Find the indexes of the minimum and maximum wavelengths. Return with the
         // empty axial primary color if there are no wavelengths.
-        let min_wav_index = wavelengths
+        let min_wav_index = self.wavelengths
             .iter()
             .enumerate()
             .min_by(|(_, a), (_, b)| a.total_cmp(b))
             .map(|(index, _)| index)
             .unwrap_or_default();
-        let max_wav_index = wavelengths
+        let max_wav_index = self.wavelengths
             .iter()
             .enumerate()
             .max_by(|(_, a), (_, b)| a.total_cmp(b))
@@ -333,7 +321,7 @@ impl ParaxialView {
             }
         }
 
-        Ok(axial_primary_color)
+        axial_primary_color
     }
 }
 

--- a/www/js/CHANGELOG.md
+++ b/www/js/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Materials dispersion data is now downloaded and added to the browser's IndexedDB database when the application starts.
 - Users may now specify materials data to use in a lens design, and this data will be used to automatically compute refractive indexes at each wavelength.
-- The results summary window now contains paraxial data computed at multiple wavelengths.
+- The results summary window now contains paraxial data computed at multiple wavelengths and pximary axial color information.
 
 ## [0.2.0] 2024-12-09
 


### PR DESCRIPTION
This addresses #178 . Primary axial color data is now shown on the frontend.

![image](https://github.com/user-attachments/assets/eee8c98a-cfab-445b-9c79-f0fb7da4b796)
