### PR TITLE
Add alerts from the WASM layer

### DIFF
--- a/www/js/src/App.js
+++ b/www/js/src/App.js
@@ -4,6 +4,7 @@ import { useMaterialsService } from "./services/materialsDataService";
 import { useMemo, useState } from "react";
 
 import "./css/cherry.css";
+import showAlert from "./modules/alerts";
 import CutawayView from "./components/CutawayView";
 import Navbar from "./components/Navbar";
 import SpecsExplorer from "./components/explorers/SpecsExplorer";
@@ -69,8 +70,8 @@ function App({ wasmModule }) {
                     "description": newDescription,
                     "newRayPaths": newRayPaths
                 }
-            } catch (e) {
-                console.error(e);
+            } catch (error) {
+                showAlert(error instanceof Error ? error.message : "Error creating optical system");
                 return {
                     "description": null,
                     "newRayPaths": null

--- a/www/js/src/components/Navbar.js
+++ b/www/js/src/components/Navbar.js
@@ -107,7 +107,6 @@ const Navbar = ( {
             }
         };
 
-
         // Convert to JSON string
         const jsonString = deepStringify(dataToSave);
 

--- a/www/js/src/components/Navbar.js
+++ b/www/js/src/components/Navbar.js
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 import SummaryWindow from "./SummaryWindow";
+import showAlert from "../modules/alerts";
 
 import cpLensData from "../examples/convexplanoLens";
 import cpmLensData from "../examples/convexplanoLensWithMaterials";
@@ -86,76 +87,6 @@ const Navbar = ( {
         setFields(newFields);
         setAperture(newAperture);
         setWavelengths(newWavelengths);
-    };
-
-    const showAlert = (message) => {
-        // Create alert container if it doesn't exist
-        let alertContainer = document.getElementById('alert-container');
-        if (!alertContainer) {
-            alertContainer = document.createElement('div');
-            alertContainer.id = 'alert-container';
-            alertContainer.style.cssText = `
-                position: fixed;
-                top: 20px;
-                right: 20px;
-                z-index: 1000;
-                transition: opacity 0.3s ease-in-out;
-            `;
-            document.body.appendChild(alertContainer);
-        }
-
-        // Create new alert element
-        const alertElement = document.createElement('div');
-        alertElement.style.cssText = `
-            background-color: #f44336;
-            color: white;
-            padding: 15px 20px;
-            margin-bottom: 10px;
-            border-radius: 4px;
-            box-shadow: 0 2px 5px rgba(0,0,0,0.2);
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            min-width: 300px;
-        `;
-
-        // Add message
-        const textElement = document.createElement('span');
-        textElement.textContent = message;
-        alertElement.appendChild(textElement);
-
-        // Add close button
-        const closeButton = document.createElement('button');
-        closeButton.innerHTML = '&times;';
-        closeButton.style.cssText = `
-            background: none;
-            border: none;
-            color: white;
-            font-size: 20px;
-            cursor: pointer;
-            padding: 0 5px;
-            margin-left: 10px;
-        `;
-        closeButton.onclick = () => {
-            alertElement.style.opacity = '0';
-            setTimeout(() => alertElement.remove(), 300);
-        };
-        alertElement.appendChild(closeButton);
-
-        // Add to container
-        alertContainer.appendChild(alertElement);
-
-        // Auto remove after 5 seconds
-        setTimeout(() => {
-            if (alertElement.parentElement) {
-                alertElement.style.opacity = '0';
-                setTimeout(() => {
-                    if (alertElement.parentElement) {
-                        alertElement.remove();
-                    }
-                }, 300);
-            }
-        }, 5000);
     };
 
     const handleSave = () => {

--- a/www/js/src/components/SummaryWindow.js
+++ b/www/js/src/components/SummaryWindow.js
@@ -135,8 +135,6 @@ const SummaryWindow = ({ description, isOpen, wavelengths, appModes, onClose }) 
   useEffect(() => {
     if (!description) return;
 
-    console.log(description.paraxial_view);
-
     // For now we only deal with the Y axis as we don't support toric surfaces
     const newSummary = {
       "Primary Axial Color": description.paraxial_view.primary_axial_color.get("Y") || 0,

--- a/www/js/src/modules/alerts.js
+++ b/www/js/src/modules/alerts.js
@@ -1,0 +1,74 @@
+/* 
+ * Display an alert message on the screen.
+ */
+const showAlert = (message) => {
+    // Create alert container if it doesn't exist
+    let alertContainer = document.getElementById('alert-container');
+    if (!alertContainer) {
+        alertContainer = document.createElement('div');
+        alertContainer.id = 'alert-container';
+        alertContainer.style.cssText = `
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            z-index: 1000;
+            transition: opacity 0.3s ease-in-out;
+        `;
+        document.body.appendChild(alertContainer);
+    }
+
+    // Create new alert element
+    const alertElement = document.createElement('div');
+    alertElement.style.cssText = `
+        background-color: #f44336;
+        color: white;
+        padding: 15px 20px;
+        margin-bottom: 10px;
+        border-radius: 4px;
+        box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        min-width: 300px;
+    `;
+
+    // Add message
+    const textElement = document.createElement('span');
+    textElement.textContent = message;
+    alertElement.appendChild(textElement);
+
+    // Add close button
+    const closeButton = document.createElement('button');
+    closeButton.innerHTML = '&times;';
+    closeButton.style.cssText = `
+        background: none;
+        border: none;
+        color: white;
+        font-size: 20px;
+        cursor: pointer;
+        padding: 0 5px;
+        margin-left: 10px;
+    `;
+    closeButton.onclick = () => {
+        alertElement.style.opacity = '0';
+        setTimeout(() => alertElement.remove(), 300);
+    };
+    alertElement.appendChild(closeButton);
+
+    // Add to container
+    alertContainer.appendChild(alertElement);
+
+    // Auto remove after 5 seconds
+    setTimeout(() => {
+        if (alertElement.parentElement) {
+            alertElement.style.opacity = '0';
+            setTimeout(() => {
+                if (alertElement.parentElement) {
+                    alertElement.remove();
+                }
+            }, 300);
+        }
+    }, 5000);
+};
+
+export default showAlert;


### PR DESCRIPTION
Error messages from a mis-specified optical system are now shown to the user as a red pop-up alert that disappears automatically after a few seconds. This essentially exposes errors from the WASM layer directly to the user. Since these are intended to be user-friendly errors already, they can help diagnose problems like wavelengths being outside the bounds of a material spec.

Addresses #181 .