### PR TITLE
Show valid wavelength range in the materials explorer

### DIFF
--- a/www/js/src/services/materialsDataService.js
+++ b/www/js/src/services/materialsDataService.js
@@ -18,7 +18,7 @@ const FULL_DATA_URL = `${__webpack_public_path__}data/full-materials-data.json`;
 
 export class MaterialsDataService {
   #worker;
-  #selectedMaterials;
+  #selectedMaterials; // To be used in the lens design
 
   constructor() {
     this.worker = new Worker(new URL("./materialsDataWorker.js", import.meta.url));


### PR DESCRIPTION
The valid range of wavelengths for a material is now displayed in the Materials Explorer so the user has a better idea about what wavelengths are allowed.

Fixes #185 

![image](https://github.com/user-attachments/assets/5f0720f8-6d3d-4e35-96a5-cae2ddeaff11)
