### PR TITLE
Update ria to 0.3

### DIFF
--- a/raytracer/Cargo.lock
+++ b/raytracer/Cargo.lock
@@ -201,9 +201,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "ria"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea7245444985c07319823cdc18bb17ea5558eb7de4c9670d7f1a13c150c56401"
+checksum = "ccee4864634bd735cfe61d7c3965a3f8f4295fb888e63451352809132a446b86"
 dependencies = [
  "anyhow",
  "serde",

--- a/raytracer/cherry-rs/Cargo.toml
+++ b/raytracer/cherry-rs/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0"
 ndarray = { version = "0.15", features = [ "serde" ] }
 serde = { version = "1", features = [ "derive" ] }
 
-ria = { version = "0.2", optional = true }
+ria = { version = "0.3", optional = true }
 
 [dev-dependencies]
 approx = { version = "0.5" }


### PR DESCRIPTION
This pulls in better error messages when a wavelength is out of range.