### PR TITLE
Remove materials data storage in LFS

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -17,8 +17,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        lfs: true
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Optical system design in the browser
 
 - Rust compiler (see [raytracer/rust-toolchain.toml](raytracer/rust-toolchain.toml) for the version)
 - Node 22.13.1 (for the frontend)
-- [Git LFS](https://git-lfs.com/) (to fetch materials data)
 
 ## Build
 


### PR DESCRIPTION
The GitHub bandwidth limit makes it more trouble than it's worth. I might later move it to GitHub releases.