### PR TITLE
Add compute service

### DIFF
--- a/www/js/src/App.js
+++ b/www/js/src/App.js
@@ -16,7 +16,7 @@ function App({ wasmModule }) {
     const { materialsService, isLoadingInitialData, isLoadingFullData, error } = useMaterialsService();
 
     // Start the compute service
-    const computeService = useComputeService();
+    const { computeService, isComputeServiceInitializing } = useComputeService();
 
     // GUI state
     const [activeExplorersTab, setExplorersActiveTab] = useState('specs');
@@ -43,7 +43,6 @@ function App({ wasmModule }) {
     const systemData = useMemo(() => {
         if (wasmModule) {
             try {
-                computeService.test();
                 const opticalSystem = getOpticalSystem(wasmModule);
 
                 const { surfaceSpecs, gapSpecs, fieldSpecs, apertureSpec, wavelengthSpecs } = convertUIStateToLibFormat(
@@ -119,8 +118,8 @@ function App({ wasmModule }) {
 
     // --------------------------------------------------------------------------------
     // Rendering
-    if (isLoadingInitialData) {
-        return <div>Loading initial materials data...</div>;
+    if (isLoadingInitialData || isComputeServiceInitializing) {
+        return <div>Loading...</div>;
     }
 
     // TODO Handle error

--- a/www/js/src/App.js
+++ b/www/js/src/App.js
@@ -2,7 +2,7 @@ import { convertUIStateToLibFormat, getOpticalSystem } from "./modules/opticalSy
 import { useComputeService } from "./services/computeService";
 import { useMaterialsService } from "./services/materialsDataService";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 
 import "./css/cherry.css";
 import showAlert from "./modules/alerts";
@@ -15,8 +15,12 @@ function App({ wasmModule }) {
     // Load the material data
     const { materialsService, isLoadingInitialData, isLoadingFullData, error } = useMaterialsService();
 
-    // Start the compute service
+    // Start the compute service and results listener
     const { computeService, isComputeServiceInitializing } = useComputeService();
+    const results = useSyncExternalStore(
+        (onStoreChange) => computeService.subscribe(onStoreChange),
+        () => computeService.results
+    )
 
     // GUI state
     const [activeExplorersTab, setExplorersActiveTab] = useState('specs');
@@ -136,6 +140,8 @@ function App({ wasmModule }) {
                 return null;
         }
     }
+
+    console.debug("Results:", results);
 
     // --------------------------------------------------------------------------------
     // Rendering

--- a/www/js/src/App.js
+++ b/www/js/src/App.js
@@ -141,8 +141,6 @@ function App({ wasmModule }) {
         }
     }
 
-    console.debug("Results:", results);
-
     // --------------------------------------------------------------------------------
     // Rendering
     if (isLoadingInitialData || isComputeServiceInitializing) {

--- a/www/js/src/App.js
+++ b/www/js/src/App.js
@@ -1,4 +1,5 @@
 import { convertUIStateToLibFormat, getOpticalSystem } from "./modules/opticalSystem";
+import { useComputeService } from "./services/computeService";
 import { useMaterialsService } from "./services/materialsDataService";
 
 import { useMemo, useState } from "react";
@@ -13,6 +14,9 @@ import MaterialsExplorer from "./components/explorers/MaterialsExplorer";
 function App({ wasmModule }) {
     // Load the material data
     const { materialsService, isLoadingInitialData, isLoadingFullData, error } = useMaterialsService();
+
+    // Start the compute service
+    const computeService = useComputeService();
 
     // GUI state
     const [activeExplorersTab, setExplorersActiveTab] = useState('specs');
@@ -39,6 +43,7 @@ function App({ wasmModule }) {
     const systemData = useMemo(() => {
         if (wasmModule) {
             try {
+                computeService.test();
                 const opticalSystem = getOpticalSystem(wasmModule);
 
                 const { surfaceSpecs, gapSpecs, fieldSpecs, apertureSpec, wavelengthSpecs } = convertUIStateToLibFormat(

--- a/www/js/src/services/computeContants.js
+++ b/www/js/src/services/computeContants.js
@@ -1,0 +1,2 @@
+export const MSG_IN_INIT = "Initialize";
+export const MSG_OUT_INIT = "Initialized";

--- a/www/js/src/services/computeContants.js
+++ b/www/js/src/services/computeContants.js
@@ -1,2 +1,7 @@
+// Worker/main thread messages
+// In -> Into worker
+// Out -> Out of worker
 export const MSG_IN_INIT = "Initialize";
 export const MSG_OUT_INIT = "Initialized";
+export const MSG_IN_COMPUTE = "Compute";
+export const MSG_OUT_COMPUTE = "Computed";

--- a/www/js/src/services/computeService.js
+++ b/www/js/src/services/computeService.js
@@ -10,9 +10,7 @@ export class ComputeService {
 
     constructor() {
         this.#worker = new Worker(new URL("./computeWorker.js", import.meta.url));
-        this.#worker.onmessage = (event) => {
-            console.debug('Received message from the worker:', event.data);
-        }
+        this.#worker.onmessage = (_) => { }
 
         this.#results = {};
         this.#subscribers = new Set();
@@ -87,14 +85,11 @@ export function useComputeService() {
 
                 // Set up the message handler for the worker to replace the one for initialization
                 computeService.setWorkerMessageHandler(event => {
-                    console.debug('Received message from the worker:', event.data);
-
                     const msg = event.data[0];
                     const arg = event.data[1];
 
                     switch (msg) {
                         case MSG_OUT_COMPUTE:
-                            console.debug("Received computed results from the worker:", arg);
                             computeService.results = arg;
                             break;
                         default:
@@ -109,7 +104,6 @@ export function useComputeService() {
         init();
 
         return () => {
-            console.debug("Terminating compute service worker");
             computeService.terminateWorker();
         };
     }, []);

--- a/www/js/src/services/computeService.js
+++ b/www/js/src/services/computeService.js
@@ -1,0 +1,34 @@
+import { useState, useEffect, use } from 'react';
+
+export class ComputeService {
+    #worker;
+
+    constructor() {
+        this.#worker = new Worker(new URL("./computeWorker.js", import.meta.url));
+        this.#worker.onmessage = (event) => {
+            console.debug('Received message from the worker:', event.data);
+        }
+    }
+
+    test() {
+        this.#worker.postMessage("Hello from the main thread!");
+    }
+
+    terminateWorker() {
+        this.#worker.terminate();
+    }
+}
+
+// React hook
+export function useComputeService() {
+    const [computeService] = useState(() => new ComputeService());
+
+    useEffect(() => {
+        return () => {
+            console.debug("Terminating worker");
+            computeService.terminateWorker();
+        };
+    }, []);
+
+    return computeService;
+}

--- a/www/js/src/services/computeService.js
+++ b/www/js/src/services/computeService.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 
-import { MSG_IN_INIT } from './computeContants';
+import { MSG_IN_COMPUTE, MSG_IN_INIT, MSG_OUT_INIT } from './computeContants';
 
 export class ComputeService {
     #worker;
@@ -12,28 +12,52 @@ export class ComputeService {
         }
     }
 
-    async initWorker() {
-        this.#worker.postMessage([MSG_IN_INIT, null]);
-    }
-
     test() {
         this.#worker.postMessage(["Hello from the main thread!", null]);
     }
 
+    async initWorker() {
+        this.#worker.postMessage([MSG_IN_INIT, null]);
+
+        // Wait for the worker to finish initializing
+        return new Promise((resolve, reject) => {
+            this.#worker.onmessage = (event) => {
+                if (event.data === MSG_OUT_INIT) {
+                    resolve();
+                } else {
+                    reject(new Error(`Failed to initialize compute service: ${event.data}`));
+                }
+            }
+        });
+    }
+
+    setWorkerMessageHandler(handler) {
+        this.#worker.onmessage = handler;
+    }
+
     terminateWorker() {
         this.#worker.terminate();
+    }
+
+    compute(specs) {
+        this.#worker.postMessage([MSG_IN_COMPUTE, specs]);
     }
 }
 
 // React hook
 export function useComputeService() {
     const [computeService] = useState(() => new ComputeService());
-    const [isInitializing, setIsInitializing] = useState(true);
+    const [isComputeServiceInitializing, setIsInitializing] = useState(true);
 
     useEffect(() => {
         async function init() {
             try{
                 await computeService.initWorker();
+
+                // Set up the message handler for the worker to replace the one for initialization
+                computeService.setWorkerMessageHandler(event => {
+                    console.debug('Received message from the worker:', event.data);
+                });
                 setIsInitializing(false);
             } catch (error) {
                 console.error("Failed to initialize the worker:", error);
@@ -47,5 +71,5 @@ export function useComputeService() {
         };
     }, []);
 
-    return { computeService, isInitializing };
+    return { computeService, isComputeServiceInitializing };
 }

--- a/www/js/src/services/computeService.js
+++ b/www/js/src/services/computeService.js
@@ -6,6 +6,7 @@ export class ComputeService {
     #worker;
     #results;
     #subscribers;
+    #requestID;
 
     constructor() {
         this.#worker = new Worker(new URL("./computeWorker.js", import.meta.url));
@@ -15,6 +16,7 @@ export class ComputeService {
 
         this.#results = {};
         this.#subscribers = new Set();
+        this.#requestID = 0;
     }
 
     test() {
@@ -57,7 +59,10 @@ export class ComputeService {
     }
 
     compute(specs) {
+        // Append the request ID to the specs
+        specs.requestID = this.#requestID;
         this.#worker.postMessage([MSG_IN_COMPUTE, specs]);
+        this.#requestID++;
     }
 
     get results() {

--- a/www/js/src/services/computeWorker.js
+++ b/www/js/src/services/computeWorker.js
@@ -1,4 +1,4 @@
-import { MSG_IN_COMPUTE, MSG_IN_INIT, MSG_OUT_INIT } from "./computeContants";
+import { MSG_IN_COMPUTE, MSG_OUT_COMPUTE, MSG_IN_INIT, MSG_OUT_INIT } from "./computeContants";
 
 import { initializeWasm } from "../wasmLoader";
 
@@ -18,7 +18,7 @@ onmessage = function (event) {
                     wasmModule = module;
                     opticalSystem = new wasmModule.OpticalSystem();
 
-                    postMessage(MSG_OUT_INIT);
+                    this.postMessage(MSG_OUT_INIT);
                 })
                 .catch((error) => {
                     console.error("Failed to initialize the worker:", error);
@@ -37,6 +37,7 @@ onmessage = function (event) {
             opticalSystem.build();
 
             const rays = opticalSystem.trace();
+            this.postMessage([MSG_OUT_COMPUTE, rays]);
                 
             console.debug("3D ray trace complete: ", rays);
 

--- a/www/js/src/services/computeWorker.js
+++ b/www/js/src/services/computeWorker.js
@@ -1,5 +1,29 @@
+import { MSG_IN_INIT, MSG_OUT_INIT } from "./computeContants";
+
+import { initializeWasm } from "../wasmLoader";
+
+let wasmModule;
+
 onmessage = function (event) {
     console.debug("Received message from the main thread:", event.data);
+    
+    const message = event.data[0];
+    const arg = event.data[1];
 
-    this.postMessage("Hello from the worker!");
+    switch (message) {
+        case MSG_IN_INIT:
+            console.debug("Initializing the worker");
+            initializeWasm(true)
+                .then((module) => {
+                    wasmModule = module;
+                    postMessage([MSG_OUT_INIT, null]);
+                })
+                .catch((error) => {
+                    console.error("Failed to initialize the worker:", error);
+                });
+
+            break;
+        default:
+            console.error("Unknown message from the main thread:", event.data);
+    }
 }

--- a/www/js/src/services/computeWorker.js
+++ b/www/js/src/services/computeWorker.js
@@ -1,4 +1,4 @@
-import { MSG_IN_INIT, MSG_OUT_INIT } from "./computeContants";
+import { MSG_IN_COMPUTE, MSG_IN_INIT, MSG_OUT_INIT } from "./computeContants";
 
 import { initializeWasm } from "../wasmLoader";
 
@@ -12,16 +12,18 @@ onmessage = function (event) {
 
     switch (message) {
         case MSG_IN_INIT:
-            console.debug("Initializing the worker");
             initializeWasm(true)
                 .then((module) => {
                     wasmModule = module;
-                    postMessage([MSG_OUT_INIT, null]);
+                    postMessage(MSG_OUT_INIT);
                 })
                 .catch((error) => {
                     console.error("Failed to initialize the worker:", error);
                 });
 
+            break;
+        case MSG_IN_COMPUTE:
+            console.debug("Computing the optical system: ", arg);
             break;
         default:
             console.error("Unknown message from the main thread:", event.data);

--- a/www/js/src/services/computeWorker.js
+++ b/www/js/src/services/computeWorker.js
@@ -25,6 +25,7 @@ onmessage = function (event) {
                 });
 
             break;
+
         case MSG_IN_COMPUTE:
             console.debug("Computing full 3D ray trace: ", arg);
 

--- a/www/js/src/services/computeWorker.js
+++ b/www/js/src/services/computeWorker.js
@@ -8,10 +8,10 @@ let opticalSystem;
 onmessage = function (event) {
     console.debug("Received message from the main thread:", event.data);
     
-    const message = event.data[0];
+    const msg = event.data[0];
     const arg = event.data[1];
 
-    switch (message) {
+    switch (msg) {
         case MSG_IN_INIT:
             initializeWasm(true)
                 .then((module) => {
@@ -27,9 +27,9 @@ onmessage = function (event) {
             break;
 
         case MSG_IN_COMPUTE:
-            console.debug("Computing full 3D ray trace: ", arg);
+            const { surfaces, gaps, fields, aperture, wavelengths, gapMode, requestID } = arg;
+            console.debug("Computing full 3D ray trace: ", requestID);
 
-            const { surfaces, gaps, fields, aperture, wavelengths, gapMode } = arg;
             opticalSystem.setSurfaces(surfaces);
             opticalSystem.setGaps(gaps, gapMode);
             opticalSystem.setFields(fields);
@@ -38,6 +38,7 @@ onmessage = function (event) {
             opticalSystem.build();
 
             const rays = opticalSystem.trace();
+
             this.postMessage([MSG_OUT_COMPUTE, rays]);
                 
             console.debug("3D ray trace complete: ", rays);

--- a/www/js/src/services/computeWorker.js
+++ b/www/js/src/services/computeWorker.js
@@ -1,0 +1,5 @@
+onmessage = function (event) {
+    console.debug("Received message from the main thread:", event.data);
+
+    this.postMessage("Hello from the worker!");
+}

--- a/www/js/src/services/computeWorker.js
+++ b/www/js/src/services/computeWorker.js
@@ -6,8 +6,6 @@ let wasmModule;
 let opticalSystem;
 
 onmessage = function (event) {
-    console.debug("Received message from the main thread:", event.data);
-    
     const msg = event.data[0];
     const arg = event.data[1];
 
@@ -28,7 +26,6 @@ onmessage = function (event) {
 
         case MSG_IN_COMPUTE:
             const { surfaces, gaps, fields, aperture, wavelengths, gapMode, requestID } = arg;
-            console.debug("Computing full 3D ray trace: ", requestID);
 
             opticalSystem.setSurfaces(surfaces);
             opticalSystem.setGaps(gaps, gapMode);
@@ -40,8 +37,6 @@ onmessage = function (event) {
             const rays = opticalSystem.trace();
 
             this.postMessage([MSG_OUT_COMPUTE, rays]);
-                
-            console.debug("3D ray trace complete: ", rays);
 
             break;
         default:

--- a/www/js/src/services/materialsDataConstants.js
+++ b/www/js/src/services/materialsDataConstants.js
@@ -1,4 +1,3 @@
-export const DATABASE_NAME = "materials";
 export const OBJECT_STORE_NAME = "materials";
 export const INDEX_SHELF_NAME = "shelf";
 export const INDEX_SHELF_BOOK_NAME = "shelfAndBook";

--- a/www/js/src/services/materialsDataService.js
+++ b/www/js/src/services/materialsDataService.js
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 
 import {
-  DATABASE_NAME,
   INDEX_SHELF_NAME,
   INDEX_SHELF_BOOK_NAME,
   KEY_SEPARATOR,
@@ -12,6 +11,7 @@ import {
   MSG_FULL_DATA_FETCHED,
   MSG_INITIALIZED,
   OBJECT_STORE_NAME } from './materialsDataConstants';
+import { DATABASE_NAME } from "./sharedConstants";
 
 const INITIAL_DATA_URL = `${__webpack_public_path__}data/initial-materials-data.json`;
 const FULL_DATA_URL = `${__webpack_public_path__}data/full-materials-data.json`;

--- a/www/js/src/services/materialsDataService.js
+++ b/www/js/src/services/materialsDataService.js
@@ -31,7 +31,7 @@ export class MaterialsDataService {
     this.#subscribers = new Set();
   }
 
-  // So React can subscribe to state changes
+  // Allows React to subscribe to state changes
   subscribe(callback) {
     this.#subscribers.add(callback);
     return () => {

--- a/www/js/src/services/materialsDataService.js
+++ b/www/js/src/services/materialsDataService.js
@@ -23,9 +23,7 @@ export class MaterialsDataService {
 
   constructor() {
     this.#worker = new Worker(new URL("./materialsDataWorker.js", import.meta.url));
-    this.#worker.onmessage = (event) => {
-      console.debug('Received message from the worker:', event.data);
-    }
+    this.#worker.onmessage = (_) => { }
 
     this.#selectedMaterials = new Map();
     this.#subscribers = new Set();

--- a/www/js/src/services/materialsDataWorker.js
+++ b/www/js/src/services/materialsDataWorker.js
@@ -1,5 +1,4 @@
 import {
-    DATABASE_NAME,
     INDEX_SHELF_NAME,
     INDEX_SHELF_BOOK_NAME,
     MSG_ERR,
@@ -11,6 +10,7 @@ import {
     MSG_INITIALIZED,
     OBJECT_STORE_NAME
 } from './materialsDataConstants';
+import { DATABASE_NAME } from "./sharedConstants";
 
 let db;
 
@@ -64,7 +64,7 @@ onmessage = function (event) {
                 })
                 .then(([db, data]) => {
                     let store = db
-                        .transaction(DATABASE_NAME, "readwrite")
+                        .transaction(OBJECT_STORE_NAME, "readwrite")
                         .objectStore(OBJECT_STORE_NAME);
 
                     for (const [key, value] of Object.entries(data.inner)) {
@@ -102,7 +102,7 @@ onmessage = function (event) {
                 .then(data => {
                     // Put full data into indexedDB
                     let store = db
-                        .transaction(DATABASE_NAME, "readwrite")
+                        .transaction(OBJECT_STORE_NAME, "readwrite")
                         .objectStore(OBJECT_STORE_NAME);
 
                     for (const [key, value] of Object.entries(data.inner)) {

--- a/www/js/src/services/materialsDataWorker.js
+++ b/www/js/src/services/materialsDataWorker.js
@@ -94,7 +94,6 @@ onmessage = function (event) {
             fetch(arg)
                 .then(response => {
                     if (!response.ok) {
-                        console.debug(response);
                         throw new Error(`HTTP error! status: ${response.status}`);
                     }
                     return response.json()

--- a/www/js/src/services/sharedConstants.js
+++ b/www/js/src/services/sharedConstants.js
@@ -1,0 +1,1 @@
+export const DATABASE_NAME = "cherry";

--- a/www/js/src/wasmLoader.js
+++ b/www/js/src/wasmLoader.js
@@ -2,8 +2,17 @@ import init, { OpticalSystem, GapMode } from "../pkg/cherry_js.js";
 
 let wasmModule = null;
 
-export async function initializeWasm() {
-    if (wasmModule) {
+/*
+    * Initialize the WASM module and return it.
+    *
+    * This function will only initialize the WASM module once. If it has already been initialized,
+    * it will return the existing module. If you want to force a new module to be created, pass
+    * `true` as the `forceNew` parameter.
+    * 
+    * @param {boolean} forceNew - If true, a new WASM module will be returned no matter what.
+*/
+export async function initializeWasm(forceNew = false) {
+    if (wasmModule && !forceNew) {
         return wasmModule;
     }
 


### PR DESCRIPTION
This adds a simple webworker-based service to compute full 3D ray traces off of the main thread whenever the lens data changes.

Currently, every change is processed serially in the webworker.