### PR TITLE
Refactor 3d ray tracing

### DIFF
--- a/raytracer/CHANGELOG.md
+++ b/raytracer/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A `ri-info` feature for loading materials data from the RefractiveIndex.info database.
 - A `primary_axial_color` method to `ParaxialView` for computing the axial primary color aberration of a lens.
+- An `axes` method on `SequentialModel` to return the set of axes that the system is modeled over.
 
 ### Changed
 

--- a/raytracer/CHANGELOG.md
+++ b/raytracer/CHANGELOG.md
@@ -12,11 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A `ri-info` feature for loading materials data from the RefractiveIndex.info database.
 - A `primary_axial_color` method to `ParaxialView` for computing the axial primary color aberration of a lens.
 - An `axes` method on `SequentialModel` to return the set of axes that the system is modeled over.
+- `RayBundle`, `TraceResultsCollection` were added as part of refactoring the `ray_trace_3d_view`.
 
 ### Changed
 
 - `RefractiveIndexSpec` is now a trait which supports getting refractive index data from any generic materials database.
 - The examples, including the associated tests, were moved into a Cargo-specific `examples` folder.
+- `ray_trace_3d_view` now returns a `TraceResultsCollection` of modified `TraceResults` structs. This allows for better access to a given set of values for (field_id, wavelength_id, Axis). `Ray` was also modified and now contains only position and direction information.
 
 ### Fixed
 

--- a/raytracer/cherry-rs/benches/convexplano_lens.rs
+++ b/raytracer/cherry-rs/benches/convexplano_lens.rs
@@ -3,8 +3,8 @@ use std::hint::black_box;
 use std::rc::Rc;
 
 use cherry_rs::{
-    examples::convexplano_lens::sequential_model, n, ray_trace_3d_view, ray_trace_3d_view_v2, ApertureSpec, FieldSpec,
-    ParaxialView, PupilSampling, RefractiveIndexSpec,
+    examples::convexplano_lens::sequential_model, n, ray_trace_3d_view, ray_trace_3d_view_v2,
+    ApertureSpec, FieldSpec, ParaxialView, PupilSampling, RefractiveIndexSpec,
 };
 
 // Inputs
@@ -21,15 +21,15 @@ const FIELD_SPECS: [FieldSpec; 2] = [
 ];
 const APERTURE_SPEC: ApertureSpec = ApertureSpec::EntrancePupil { semi_diameter: 5.0 };
 
-// Create a benchmark group to compare ray_trace_3d_view with ray_trace_3d_view_v2
-// Use c.benchmark_group
+// Create a benchmark group to compare ray_trace_3d_view with
+// ray_trace_3d_view_v2 Use c.benchmark_group
 fn benchmark(c: &mut Criterion) {
     let n_air: Rc<dyn RefractiveIndexSpec> = n!(1.0);
     let n_nbk7: Rc<dyn RefractiveIndexSpec> = n!(1.515);
     let model = sequential_model(n_air, n_nbk7, &WAVELENGTHS);
     let paraxial_view = ParaxialView::new(&model, &FIELD_SPECS, false).unwrap();
     let mut group = c.benchmark_group("3D ray trace, convexplano lens");
-    
+
     group.bench_function("ray_trace_3d_view", |b| {
         b.iter(|| {
             ray_trace_3d_view(

--- a/raytracer/cherry-rs/benches/convexplano_lens.rs
+++ b/raytracer/cherry-rs/benches/convexplano_lens.rs
@@ -3,7 +3,7 @@ use std::hint::black_box;
 use std::rc::Rc;
 
 use cherry_rs::{
-    examples::convexplano_lens::sequential_model, n, ray_trace_3d_view, ApertureSpec, FieldSpec,
+    examples::convexplano_lens::sequential_model, n, ray_trace_3d_view, ray_trace_3d_view_v2, ApertureSpec, FieldSpec,
     ParaxialView, PupilSampling, RefractiveIndexSpec,
 };
 
@@ -21,13 +21,16 @@ const FIELD_SPECS: [FieldSpec; 2] = [
 ];
 const APERTURE_SPEC: ApertureSpec = ApertureSpec::EntrancePupil { semi_diameter: 5.0 };
 
+// Create a benchmark group to compare ray_trace_3d_view with ray_trace_3d_view_v2
+// Use c.benchmark_group
 fn benchmark(c: &mut Criterion) {
-    c.bench_function("3D ray trace, convexplano lens", |b| {
-        let n_air: Rc<dyn RefractiveIndexSpec> = n!(1.0);
-        let n_nbk7: Rc<dyn RefractiveIndexSpec> = n!(1.515);
-        let model = sequential_model(n_air, n_nbk7, &WAVELENGTHS);
-        let paraxial_view = ParaxialView::new(&model, &FIELD_SPECS, false).unwrap();
-
+    let n_air: Rc<dyn RefractiveIndexSpec> = n!(1.0);
+    let n_nbk7: Rc<dyn RefractiveIndexSpec> = n!(1.515);
+    let model = sequential_model(n_air, n_nbk7, &WAVELENGTHS);
+    let paraxial_view = ParaxialView::new(&model, &FIELD_SPECS, false).unwrap();
+    let mut group = c.benchmark_group("3D ray trace, convexplano lens");
+    
+    group.bench_function("ray_trace_3d_view", |b| {
         b.iter(|| {
             ray_trace_3d_view(
                 black_box(&APERTURE_SPEC),
@@ -37,8 +40,21 @@ fn benchmark(c: &mut Criterion) {
                 black_box(None),
             )
             .unwrap();
-        })
+        });
     });
+    group.bench_function("ray_trace_3d_view_v2", |b| {
+        b.iter(|| {
+            ray_trace_3d_view_v2(
+                black_box(&APERTURE_SPEC),
+                black_box(&FIELD_SPECS),
+                black_box(&model),
+                black_box(&paraxial_view),
+                black_box(None),
+            )
+            .unwrap();
+        });
+    });
+    group.finish();
 }
 
 criterion_group!(benches, benchmark);

--- a/raytracer/cherry-rs/benches/convexplano_lens.rs
+++ b/raytracer/cherry-rs/benches/convexplano_lens.rs
@@ -12,11 +12,11 @@ const WAVELENGTHS: [f64; 1] = [0.5876]; // He d line
 const FIELD_SPECS: [FieldSpec; 2] = [
     FieldSpec::Angle {
         angle: 0.0,
-        pupil_sampling: PupilSampling::ChiefAndMarginalRays,
+        pupil_sampling: PupilSampling::SquareGrid { spacing: 0.1 },
     },
     FieldSpec::Angle {
         angle: 5.0,
-        pupil_sampling: PupilSampling::ChiefAndMarginalRays,
+        pupil_sampling: PupilSampling::SquareGrid { spacing: 0.1 },
     },
 ];
 const APERTURE_SPEC: ApertureSpec = ApertureSpec::EntrancePupil { semi_diameter: 5.0 };

--- a/raytracer/cherry-rs/src/core/sequential_model.rs
+++ b/raytracer/cherry-rs/src/core/sequential_model.rs
@@ -332,14 +332,20 @@ impl SequentialModel {
         })
     }
 
-    /// Returns the surfaces in the system.
-    pub fn surfaces(&self) -> &[Surface] {
-        &self.surfaces
-    }
+    /// Returns the axes along which the system is modeled.
+    pub fn axes(&self) -> Vec<Axis> {
+        // Loop over submodel IDs and extract all axes
+        let mut axes = Vec::new();
+        for id in self.submodels.keys() {
+            // Avoid duplicates just in case
+            if axes.contains(&id.1) {
+                continue;
+            }
 
-    /// Returns the submodels in the system.
-    pub fn submodels(&self) -> &HashMap<SubModelID, impl SequentialSubModel> {
-        &self.submodels
+            axes.push(id.1);
+        }
+
+        axes
     }
 
     /// Returns the largest semi-diameter of any surface in the system.
@@ -356,6 +362,16 @@ impl SequentialModel {
                 _ => None,
             })
             .fold(0.0, |acc, x| acc.max(x))
+    }
+
+    /// Returns the surfaces in the system.
+    pub fn surfaces(&self) -> &[Surface] {
+        &self.surfaces
+    }
+
+    /// Returns the submodels in the system.
+    pub fn submodels(&self) -> &HashMap<SubModelID, impl SequentialSubModel> {
+        &self.submodels
     }
 
     /// Returns the wavelengths at which the system is modeled.
@@ -829,15 +845,26 @@ mod tests {
     fn test_calc_model_ids() {
         let air = n!(1.0);
         let nbk7 = n!(1.515);
-        let wavelengths: [Float; 1] = [0.5876];
+        let wavelengths: [Float; 2] = [0.4, 0.6];
         let sequential_model = sequential_model(air, nbk7, &wavelengths);
         let surfaces = sequential_model.surfaces();
-        let wavelengths = vec![0.4, 0.6];
 
         let model_ids = SequentialModel::calc_model_ids(surfaces, &wavelengths);
 
         assert_eq!(model_ids.len(), 2); // Two wavelengths, rotationally
                                         // symmetric
+    }
+
+    #[test]
+    fn test_axes() {
+        let air = n!(1.0);
+        let nbk7 = n!(1.515);
+        let wavelengths: [Float; 1] = [0.5876];
+        let sequential_model = sequential_model(air, nbk7, &wavelengths);
+        let axes = sequential_model.axes();
+
+        assert_eq!(axes.len(), 1); // Rotationally symmetric
+        assert_eq!(axes[0], Axis::Y);
     }
 
     #[test]

--- a/raytracer/cherry-rs/src/lib.rs
+++ b/raytracer/cherry-rs/src/lib.rs
@@ -147,6 +147,7 @@ pub use views::{
         ParaxialViewDescription, Pupil,
     },
     ray_trace_3d::{ray_trace_3d_view, Ray, TraceResults},
+    ray_trace_3d_v2::{ray_trace_3d_view_v2, RayV2, TraceResultsV2},
 };
 
 // Re-exports from dependencies

--- a/raytracer/cherry-rs/src/lib.rs
+++ b/raytracer/cherry-rs/src/lib.rs
@@ -148,7 +148,7 @@ pub use views::{
     },
     ray_trace_3d::{ray_trace_3d_view, Ray, TraceResults},
     ray_trace_3d_v2::{
-        ray_trace_3d_view_v2, RayV2, TraceResultsCollection, TraceResultsV2, TraceSubResults,
+        ray_trace_3d_view_v2, RayBundle, RayV2, TraceResultsCollection, TraceResultsV2,
     },
 };
 

--- a/raytracer/cherry-rs/src/lib.rs
+++ b/raytracer/cherry-rs/src/lib.rs
@@ -147,7 +147,9 @@ pub use views::{
         ParaxialViewDescription, Pupil,
     },
     ray_trace_3d::{ray_trace_3d_view, Ray, TraceResults},
-    ray_trace_3d_v2::{ray_trace_3d_view_v2, RayV2, TraceResultsV2},
+    ray_trace_3d_v2::{
+        ray_trace_3d_view_v2, RayV2, TraceResultsCollection, TraceResultsV2, TraceSubResults,
+    },
 };
 
 // Re-exports from dependencies

--- a/raytracer/cherry-rs/src/lib.rs
+++ b/raytracer/cherry-rs/src/lib.rs
@@ -119,7 +119,7 @@
 //!     &paraxial_view,
 //!     None,
 //! ).unwrap();
-//! 
+//!
 //! // Get all results for the second (5 degree) field point.
 //! let results = results_collection.get_by_field_id(1);
 //! println!("Results for 5 degree field point: {:?}", results);

--- a/raytracer/cherry-rs/src/lib.rs
+++ b/raytracer/cherry-rs/src/lib.rs
@@ -37,7 +37,7 @@
 //! # Quick Start
 //! ```rust
 //! use cherry_rs::{
-//!     n, ray_trace_3d_view, ApertureSpec, FieldSpec, GapSpec, ImagePlane, ParaxialView, Pupil, PupilSampling, RefractiveIndexSpec,
+//!     n, ray_trace_3d_view_v2, ApertureSpec, FieldSpec, GapSpec, ImagePlane, ParaxialView, Pupil, PupilSampling, RefractiveIndexSpec,
 //!     SequentialModel, SurfaceSpec, SurfaceType,
 //! };
 //!
@@ -113,12 +113,16 @@
 //! }
 //!
 //! // Compute a 3D ray trace of the system.
-//! let rays = ray_trace_3d_view(
+//! let results_collection = ray_trace_3d_view_v2(
 //!     &aperture_spec, &field_specs,
 //!     &sequential_model,
 //!     &paraxial_view,
 //!     None,
 //! ).unwrap();
+//! 
+//! // Get all results for the second (5 degree) field point.
+//! let results = results_collection.get_by_field_id(1);
+//! println!("Results for 5 degree field point: {:?}", results);
 //! ```
 
 mod core;

--- a/raytracer/cherry-rs/src/views/mod.rs
+++ b/raytracer/cherry-rs/src/views/mod.rs
@@ -10,3 +10,4 @@ pub mod components;
 pub mod cutaway;
 pub mod paraxial;
 pub mod ray_trace_3d;
+pub mod ray_trace_3d_v2;

--- a/raytracer/cherry-rs/src/views/ray_trace_3d_v2/mod.rs
+++ b/raytracer/cherry-rs/src/views/ray_trace_3d_v2/mod.rs
@@ -1,0 +1,315 @@
+/// Performs a 3D ray trace on the system.
+mod rays;
+mod trace;
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+
+use crate::{
+    core::{
+        sequential_model::{SequentialModel, SequentialSubModel, SubModelID, Surface},
+        Float, PI,
+    },
+    specs::{
+        aperture::ApertureSpec,
+        fields::{FieldSpec, PupilSampling},
+    },
+    Pupil,
+};
+
+use trace::trace;
+
+pub use rays::Ray as RayV2;
+pub use trace::TraceResults as TraceResultsV2;
+
+use super::paraxial::{ParaxialSubView, ParaxialView};
+
+/// Perform a 3D ray trace on a sequential model.
+///
+/// # Arguments
+/// * `aperture_spec` - The aperture specification.
+/// * `field_specs` - The field specifications.
+/// * `sequential_model` - The sequential model.
+/// * `paraxial_view` - A paraxial view. This is required for finding a system's
+///   entrance pupil.
+/// * `pupil_sampling` - The pupil sampling method. This will override the
+///   sampling method specified in the field specs for every field if provided.
+pub fn ray_trace_3d_view_v2(
+    aperture_spec: &ApertureSpec,
+    field_specs: &[FieldSpec],
+    sequential_model: &SequentialModel,
+    paraxial_view: &ParaxialView,
+    pupil_sampling: Option<PupilSampling>,
+) -> Result<HashMap<SubModelID, TraceResultsV2>> {
+    let results = sequential_model
+        .submodels()
+        .iter()
+        .map(|(id, submodel)| {
+            let surfaces = sequential_model.surfaces();
+            let paraxial_sub_view = paraxial_view.subviews().get(id).unwrap();
+            Ok((
+                *id,
+                ray_trace_sub_model(
+                    field_specs,
+                    submodel,
+                    surfaces,
+                    aperture_spec,
+                    paraxial_sub_view,
+                    pupil_sampling,
+                )?,
+            ))
+        })
+        .collect();
+
+    results
+}
+
+fn ray_trace_sub_model(
+    field_specs: &[FieldSpec],
+    sequential_sub_model: &impl SequentialSubModel,
+    surfaces: &[Surface],
+    aperture_spec: &ApertureSpec,
+    paraxial_sub_view: &ParaxialSubView,
+    pupil_sampling: Option<PupilSampling>,
+) -> Result<TraceResultsV2> {
+    let rays = rays(
+        surfaces,
+        aperture_spec,
+        paraxial_sub_view,
+        field_specs,
+        pupil_sampling,
+    )?;
+
+    let mut sequential_sub_model_iter = sequential_sub_model.try_iter(surfaces)?;
+    Ok(trace(&mut sequential_sub_model_iter, rays))
+}
+
+/// Returns the rays to trace through the system as defined by the fields.
+///
+/// # Arguments
+///
+/// * `sampling` - The pupil sampling method. This will override the sampling
+///   method specified in the field specs for every field if provided.
+fn rays(
+    surfaces: &[Surface],
+    aperture_spec: &ApertureSpec,
+    paraxial_sub_view: &ParaxialSubView,
+    field_specs: &[FieldSpec],
+    sampling: Option<PupilSampling>,
+) -> Result<Vec<RayV2>> {
+    let mut rays = Vec::new();
+
+    for (field_id, field) in field_specs.iter().enumerate() {
+        match field {
+            FieldSpec::Angle {
+                angle,
+                pupil_sampling,
+            } => {
+                let angle = angle.to_radians();
+
+                let pupil_sampling = match sampling {
+                    Some(sampling) => sampling,
+                    None => *pupil_sampling,
+                };
+
+                let rays_field = match pupil_sampling {
+                    PupilSampling::SquareGrid { spacing } => pupil_ray_sq_grid(
+                        surfaces,
+                        aperture_spec,
+                        paraxial_sub_view,
+                        spacing,
+                        angle,
+                        field_id,
+                    )?,
+                    PupilSampling::ChiefAndMarginalRays => {
+                        // 3 rays -> two diametrically-opposed marginal rays at the pupil edge
+                        // and a chief ray in the center
+                        pupil_ray_fan(
+                            surfaces,
+                            aperture_spec,
+                            paraxial_sub_view,
+                            3,
+                            PI / 2.0,
+                            angle,
+                            field_id,
+                        )?
+                    }
+                };
+
+                rays.extend(rays_field);
+            }
+            _ => unimplemented!(),
+        }
+    }
+
+    Ok(rays)
+}
+
+/// Create a linear ray fan that passes through the entrance pupil.
+///
+/// # Arguments
+///
+/// * `num_rays` - The number of rays in the fan.
+/// * `theta` - The polar angle of the ray fan in the x-y plane.
+/// * `phi` - The angle of the ray w.r.t. the z-axis.
+/// * `field_id` - The ID of the field.
+#[allow(clippy::too_many_arguments)]
+fn pupil_ray_fan(
+    surfaces: &[Surface],
+    aperture_spec: &ApertureSpec,
+    paraxial_sub_view: &ParaxialSubView,
+    num_rays: usize,
+    theta: Float,
+    phi: Float,
+    field_id: usize,
+) -> Result<Vec<RayV2>> {
+    let ep = entrance_pupil(aperture_spec, paraxial_sub_view)?;
+    let obj_z = surfaces[0].pos().z();
+    let sur_z = surfaces[1].pos().z();
+    let enp_z = ep.pos().z();
+
+    let launch_point_z = axial_launch_point(obj_z, sur_z, enp_z);
+
+    // Determine the radial distance from the axis at the launch point for the
+    // center of the ray fan.
+    let dz = enp_z - launch_point_z;
+    let dy = -dz * phi.tan();
+
+    let rays = RayV2::fan(
+        num_rays,
+        ep.semi_diameter,
+        theta,
+        launch_point_z,
+        phi,
+        0.0,
+        dy,
+        field_id,
+    );
+
+    Ok(rays)
+}
+
+/// Create a square grid of rays that passes through the entrance pupil.
+///
+/// # Arguments
+///
+/// * `spacing` - The spacing between rays in the grid in normalized pupil
+///   distances, i.e. [0, 1]. A spacing of 1.0 means that one ray will lie at
+///   the pupil center (the chief ray) and the others will lie at the pupil edge
+///   (marginal rays).
+/// * `phi` - The angle of the ray w.r.t. the z-axis in radians.
+/// * `field_id` - The field ID.
+fn pupil_ray_sq_grid(
+    surfaces: &[Surface],
+    aperture_spec: &ApertureSpec,
+    paraxial_sub_view: &ParaxialSubView,
+    spacing: Float,
+    phi: Float,
+    field_id: usize,
+) -> Result<Vec<RayV2>> {
+    let ep = entrance_pupil(aperture_spec, paraxial_sub_view)?;
+    let obj_z = surfaces[0].pos().z();
+    let sur_z = surfaces[1].pos().z();
+    let enp_z = ep.pos().z();
+
+    let launch_point_z = axial_launch_point(obj_z, sur_z, enp_z);
+
+    let enp_diam = ep.semi_diameter;
+    let abs_spacing = enp_diam / 2.0 * spacing;
+
+    // Determine the radial distance from the axis at the launch point for the
+    // center of the ray fan.
+    let dz = enp_z - launch_point_z;
+    let dy = -dz * phi.tan();
+
+    let rays = RayV2::sq_grid_in_circ(
+        enp_diam / 2.0,
+        abs_spacing,
+        launch_point_z,
+        phi,
+        0.0,
+        dy,
+        field_id,
+    );
+
+    Ok(rays)
+}
+
+/// Determines the entrance pupil of the subview.
+fn entrance_pupil(
+    aperture_spec: &ApertureSpec,
+    paraxial_sub_view: &ParaxialSubView,
+) -> Result<Pupil> {
+    let semi_diameter = match aperture_spec {
+        ApertureSpec::EntrancePupil { semi_diameter } => *semi_diameter,
+    };
+
+    let entrance_pupil = paraxial_sub_view.entrance_pupil();
+    let z = entrance_pupil.pos().z();
+
+    Ok(Pupil {
+        location: z,
+        semi_diameter,
+    })
+}
+
+/// Determine the axial launch point for the rays.
+///
+/// If the object plane is at infinity, and if the first surface lies before
+/// the entrance pupil, then launch the rays from one unit to the left
+/// of the first surface. If the object plane is at infinity, and if it
+/// comes after the entrance pupil, then launch the rays from
+/// one unit in front of the entrance pupil. Otherwise, launch the rays from
+/// the object plane.
+fn axial_launch_point(obj_z: Float, sur_z: Float, enp_z: Float) -> Float {
+    if obj_z == Float::NEG_INFINITY && sur_z <= enp_z {
+        sur_z - 1.0
+    } else if obj_z == Float::NEG_INFINITY && sur_z > enp_z {
+        enp_z - 1.0
+    } else {
+        obj_z
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::Float;
+    use crate::examples::convexplano_lens::sequential_model;
+    use crate::n;
+
+    use super::*;
+
+    #[test]
+    fn test_ray_trace_3d_view() {
+        let air = n!(1.0);
+        let nbk7 = n!(1.515);
+        let wavelengths: [Float; 1] = [0.5876];
+        let sequential_model = sequential_model(air, nbk7, &wavelengths);
+
+        let aperture_spec = ApertureSpec::EntrancePupil { semi_diameter: 5.0 };
+        let field_specs = vec![
+            FieldSpec::Angle {
+                angle: 0.0,
+                pupil_sampling: PupilSampling::ChiefAndMarginalRays,
+            },
+            FieldSpec::Angle {
+                angle: 5.0,
+                pupil_sampling: PupilSampling::ChiefAndMarginalRays,
+            },
+        ];
+
+        let paraxial_view = ParaxialView::new(&sequential_model, &field_specs, false).unwrap();
+
+        let results = ray_trace_3d_view_v2(
+            &aperture_spec,
+            &field_specs,
+            &sequential_model,
+            &paraxial_view,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(results.len(), 1);
+    }
+}

--- a/raytracer/cherry-rs/src/views/ray_trace_3d_v2/mod.rs
+++ b/raytracer/cherry-rs/src/views/ray_trace_3d_v2/mod.rs
@@ -149,9 +149,36 @@ impl TraceResultsCollection {
             .collect()
     }
 
+    /// Returns whether the collection is empty.
+    pub fn is_empty(&self) -> bool {
+        self.results.is_empty()
+    }
+
     /// Returns the number of ray bundles traced through the system.
     pub fn len(&self) -> usize {
         self.results.len()
+    }
+}
+
+impl TraceResultsV2 {
+    // Returns the axis of the ray bundle.
+    pub fn axis(&self) -> Axis {
+        self.axis
+    }
+
+    // Returns the field ID of the ray bundle.
+    pub fn field_id(&self) -> usize {
+        self.field_id
+    }
+
+    // Returns the ray bundle.
+    pub fn ray_bundle(&self) -> &RayBundle {
+        &self.ray_bundle
+    }
+
+    // Returns the wavelength ID of the ray bundle.
+    pub fn wavelength_id(&self) -> usize {
+        self.wavelength_id
     }
 }
 

--- a/raytracer/cherry-rs/src/views/ray_trace_3d_v2/rays.rs
+++ b/raytracer/cherry-rs/src/views/ray_trace_3d_v2/rays.rs
@@ -1,0 +1,318 @@
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::core::{
+    math::vec3::Vec3,
+    sequential_model::{Step, Surface},
+    Float, PI,
+};
+
+/// Tolerance for convergence of the Newton-Raphson method in integer mutliples
+/// of the machine epsilon
+const TOL: Float = Float::EPSILON;
+
+/// A single ray to be traced through an optical system.
+///
+/// # Attributes
+/// - pos: Position of the ray
+/// - dir: Direction of the ray (direction cosines)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ray {
+    pos: Vec3,
+    dir: Vec3,
+    terminated: bool,
+    field_id: usize,
+}
+
+impl Ray {
+    pub fn new(pos: Vec3, dir: Vec3, field_id: usize) -> Result<Self> {
+        if !dir.is_unit() {
+            bail!("Ray direction must be a unit vector");
+        }
+        Ok(Self {
+            pos,
+            dir,
+            terminated: false,
+            field_id,
+        })
+    }
+
+    /// Finds the intersection point of a ray with a surface and the surface
+    /// normal at that point.
+    ///
+    /// If no intersection is found, then this function returns an error.
+    ///
+    /// # Arguments
+    /// - surf: Surface to intersect with
+    /// - max_iter: Maximum number of iterations for the Newton-Raphson method
+    pub fn intersect(&self, surf: &Surface, max_iter: usize) -> Result<(Vec3, Vec3)> {
+        // Initial guess for the intersection point
+        let mut s_1 = 0.0;
+
+        // Find the distance along the ray to the z=0 plane; use this as the initial
+        // value for s
+        let mut s = -self.pos.z() / self.dir.m();
+
+        let mut p: Vec3;
+        let mut sag: Float;
+        let mut norm: Vec3;
+        for ctr in 0..max_iter {
+            // Compute the current estimate of the intersection point from the distance s
+            p = self.pos + self.dir * s;
+
+            // Update the distance s using the Newton-Raphson method
+            (sag, norm) = surf.sag_norm(p);
+            s -= (p.z() - sag) / norm.dot(self.dir);
+
+            // Check for convergence by comparing the current and previous values of s
+            if (s - s_1).abs() / Float::max(s, s_1) < TOL {
+                break;
+            }
+
+            if ctr == max_iter - 1 {
+                bail!("Ray intersection did not converge");
+            }
+
+            s_1 = s;
+        }
+
+        // Compute the final intersection point and surface normal
+        p = self.pos + self.dir * s;
+        (_, norm) = surf.sag_norm(p);
+
+        Ok((p, norm))
+    }
+
+    // Redirect the ray by computing the direction cosines of the ray after
+    // interaction with a surface.
+    //
+    // This function accepts the surface normal at the intersection point as an
+    // argument to avoid recomputing it.
+    pub fn redirect(&mut self, step: &Step, norm: Vec3) {
+        // Do not match on the wildcard "_" to ensure that this function is updated when
+        // new surfaces are added
+        let (gap_0, surf, gap_1) = step;
+        let n_0 = gap_0.refractive_index.n();
+        let n_1 = if let Some(gap_1) = gap_1 {
+            gap_1.refractive_index.n()
+        } else {
+            n_0
+        };
+
+        match surf {
+            // Refracting surfaces
+            //Surface::Conic(_) | Surface::Toric(_) => {
+            Surface::Conic(_) => {
+                let mu = n_0 / n_1;
+                let cos_theta_1 = self.dir.dot(norm);
+                let term_1 = norm * (1.0 - mu * mu * (1.0 - cos_theta_1 * cos_theta_1)).sqrt();
+                let term_2 = (self.dir - norm * cos_theta_1) * mu;
+
+                self.dir = term_1 + term_2;
+            }
+            // No-op surfaces
+            Surface::Image(_) => {}
+            Surface::Object(_) => {}
+            Surface::Probe(_) => {}
+            Surface::Stop(_) => {}
+        }
+    }
+
+    /// Displace a ray to the given location.
+    pub fn displace(&mut self, pos: Vec3) {
+        self.pos = pos;
+    }
+
+    /// Transform a ray into the local coordinate system of a surface from the
+    /// global system.
+    pub fn transform(&mut self, surf: &Surface) {
+        self.pos = surf.rot_mat() * (self.pos - surf.pos());
+        self.dir = surf.rot_mat() * self.dir;
+    }
+
+    /// Transform a ray from the local coordinate system of a surface into the
+    /// global system.
+    pub fn i_transform(&mut self, surf: &Surface) {
+        self.pos = surf.rot_mat().transpose() * (self.pos + surf.pos());
+        self.dir = surf.rot_mat().transpose() * self.dir;
+    }
+
+    pub fn terminate(&mut self) {
+        self.terminated = true;
+    }
+
+    #[inline]
+    pub fn is_terminated(&self) -> bool {
+        self.terminated
+    }
+
+    /// Create a fan of uniformly spaced rays in a given z-plane at an angle phi
+    /// to the z-axis.
+    ///
+    /// The vectors have endpoints at an angle theta with respect to the x-axis
+    /// and extend from distances -r to r from the point (0, 0, z). The rays
+    /// are at an angle phi from the z-axis.
+    ///
+    /// # Arguments
+    /// - n: Number of vectors to create
+    /// - r: Radial span of vector endpoints from [-r, r]
+    /// - theta: Angle of vectors with respect to x, radians
+    /// - z: z-coordinate of endpoints
+    /// - phi: Angle of vectors with respect to z, the optics axis, radians
+    /// - radial_offset_x: Offset the radial position of the vectors by this
+    ///   amount in x
+    /// - radial_offset_y: Offset the radial position of the vectors by this
+    ///   amount in y
+    #[allow(clippy::too_many_arguments)]
+    pub fn fan(
+        n: usize,
+        r: Float,
+        theta: Float,
+        z: Float,
+        phi: Float,
+        radial_offset_x: Float,
+        radial_offset_y: Float,
+        field_id: usize,
+    ) -> Vec<Ray> {
+        let pos = Vec3::fan(n, r, theta, z, radial_offset_x, radial_offset_y);
+        let dir: Vec<Vec3> = pos
+            .iter()
+            .map(|_| {
+                let l = phi.sin() * theta.cos();
+                let m = phi.sin() * theta.sin();
+                let n = phi.cos();
+                Vec3::new(l, m, n)
+            })
+            .collect();
+
+        pos.iter()
+            .zip(dir.iter())
+            .map(|(p, d)| Ray::new(*p, *d, field_id).unwrap())
+            .collect()
+    }
+
+    /// Create a square grid of uniformly spaced rays within a circle in a given
+    /// z-plane.
+    ///
+    /// # Arguments
+    /// - `radius`: Radius of the circle
+    /// - `spacing`: Spacing between rays
+    /// - `z`: z-coordinate of endpoints
+    /// - `phi`: Angle of vectors with respect to z, the optics axis, radians
+    /// - radial_offset_x: Offset the radial position of the vectors by this
+    ///   amount in x
+    /// - radial_offset_y: Offset the radial position of the vectors by this
+    ///   amount in y
+    /// - `field_id`: Field ID of the rays.
+    pub(crate) fn sq_grid_in_circ(
+        radius: Float,
+        spacing: Float,
+        z: Float,
+        phi: Float,
+        radial_offset_x: Float,
+        radial_offset_y: Float,
+        field_id: usize,
+    ) -> Vec<Ray> {
+        let theta = PI / 2.0; // TODO: For now rays are rotated about x only
+
+        let pos: Vec<Vec3> =
+            Vec3::sq_grid_in_circ(radius, spacing, z, radial_offset_x, radial_offset_y);
+        let dir: Vec<Vec3> = pos
+            .iter()
+            .map(|_| {
+                let l = phi.sin() * theta.cos();
+                let m = phi.sin() * theta.sin();
+                let n = phi.cos();
+                Vec3::new(l, m, n)
+            })
+            .collect();
+
+        pos.iter()
+            .zip(dir.iter())
+            .map(|(p, d)| Ray::new(*p, *d, field_id).unwrap())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::specs::surfaces::{SurfaceSpec, SurfaceType};
+
+    use super::*;
+    // Test the constructor of Ray
+    #[test]
+    fn test_rays_new() {
+        let pos = Vec3::new(0.0, 0.0, 0.0);
+        let dir = Vec3::new(0.0, 0.0, 1.0);
+        let field_id = 0;
+
+        let rays = Ray::new(pos, dir, field_id);
+
+        assert!(rays.is_ok());
+    }
+
+    // Test the constructor of Ray with a non-unit direction vector
+    #[test]
+    fn test_rays_new_non_unit_dir() {
+        let pos = Vec3::new(0.0, 0.0, 0.0);
+        let dir = Vec3::new(0.0, 0.0, 2.0);
+        let field_id = 0;
+
+        let rays = Ray::new(pos, dir, field_id);
+
+        assert!(rays.is_err());
+    }
+
+    // Test the intersection of a ray with a flat surface
+    #[test]
+    fn test_ray_intersection_flat_surface() {
+        let field_id = 0;
+        let pos = Vec3::new(0.0, 0.0, 0.0);
+        let ray = Ray::new(
+            Vec3::new(0.0, 0.0, -1.0),
+            Vec3::new(0.0, 0.0, 1.0),
+            field_id,
+        )
+        .unwrap();
+        let surf_spec = SurfaceSpec::Conic {
+            semi_diameter: 4.0,
+            radius_of_curvature: Float::INFINITY,
+            conic_constant: 0.0,
+            surf_type: SurfaceType::Refracting,
+        };
+        let surf = Surface::from_spec(&surf_spec, pos);
+        let max_iter = 1000;
+
+        let (p, _) = ray.intersect(&surf, max_iter).unwrap();
+
+        assert_eq!(p, Vec3::new(0.0, 0.0, 0.0));
+    }
+
+    // Test the intersection of a ray with a circular surface
+    #[test]
+    fn test_ray_intersection_conic() {
+        let field_id = 0;
+        let pos = Vec3::new(0.0, 0.0, 0.0);
+
+        // Ray starts at z = -1.0 and travels at 45 degrees to the optics axis
+        let l = 0.7071;
+        let m = ((1.0 as Float) - 0.7071 * 0.7071).sqrt();
+        let ray = Ray::new(Vec3::new(0.0, 0.0, -1.0), Vec3::new(0.0, l, m), field_id).unwrap();
+
+        // Surface has radius of curvature -1.0 and conic constant 0.0, i.e. a circle
+        let surf_spec = SurfaceSpec::Conic {
+            semi_diameter: 4.0,
+            radius_of_curvature: -1.0,
+            conic_constant: 0.0,
+            surf_type: SurfaceType::Refracting,
+        };
+        let surf = Surface::from_spec(&surf_spec, pos);
+        let max_iter = 1000;
+
+        let (p, _) = ray.intersect(&surf, max_iter).unwrap();
+
+        assert!((p.x() - 0.0).abs() < 1e-4);
+        assert!((p.y() - (PI / 4.0).sin()).abs() < 1e-4);
+        assert!((p.z() - ((PI / 4.0).cos() - 1.0)).abs() < 1e-4);
+    }
+}

--- a/raytracer/cherry-rs/src/views/ray_trace_3d_v2/rays.rs
+++ b/raytracer/cherry-rs/src/views/ray_trace_3d_v2/rays.rs
@@ -20,7 +20,6 @@ const TOL: Float = Float::EPSILON;
 pub struct Ray {
     pos: Vec3,
     dir: Vec3,
-    terminated: bool,
 }
 
 impl Ray {
@@ -28,11 +27,18 @@ impl Ray {
         if !dir.is_unit() {
             bail!("Ray direction must be a unit vector");
         }
-        Ok(Self {
-            pos,
-            dir,
-            terminated: false,
-        })
+        Ok(Self { pos, dir })
+    }
+
+    /// Create a bundle of rays with default values.
+    pub fn new_bundle(num: usize) -> Vec<Self> {
+        vec![
+            Self {
+                pos: Vec3::new(0.0, 0.0, 0.0),
+                dir: Vec3::new(0.0, 0.0, 1.0),
+            };
+            num
+        ]
     }
 
     /// Finds the intersection point of a ray with a surface and the surface
@@ -135,13 +141,34 @@ impl Ray {
         self.dir = surf.rot_mat().transpose() * self.dir;
     }
 
-    pub fn terminate(&mut self) {
-        self.terminated = true;
+    // Return the x-coordinate of the ray position
+    pub fn x(&self) -> Float {
+        self.pos.x()
     }
 
-    #[inline]
-    pub fn is_terminated(&self) -> bool {
-        self.terminated
+    // Return the y-coordinate of the ray position
+    pub fn y(&self) -> Float {
+        self.pos.y()
+    }
+
+    // Return the z-coordinate of the ray position
+    pub fn z(&self) -> Float {
+        self.pos.z()
+    }
+
+    // Return the direction cosine k of the ray
+    pub fn k(&self) -> Float {
+        self.dir.k()
+    }
+
+    // Return the direction cosine l of the ray
+    pub fn l(&self) -> Float {
+        self.dir.l()
+    }
+
+    // Return the direction cosine m of the ray
+    pub fn m(&self) -> Float {
+        self.dir.m()
     }
 
     /// Create a fan of uniformly spaced rays in a given z-plane at an angle phi

--- a/raytracer/cherry-rs/src/views/ray_trace_3d_v2/trace.rs
+++ b/raytracer/cherry-rs/src/views/ray_trace_3d_v2/trace.rs
@@ -3,13 +3,13 @@ use anyhow::Result;
 use super::rays::Ray;
 use crate::core::sequential_model::SequentialSubModelIter;
 
-/// Results of tracing rays through a system.
+/// A set of rays traced through an optical system.
 ///
 /// The first index corresponds to the surface number, and the second index
 /// corresponds to the ray number. The value is a Result, where the Ok variant
 /// contains the ray at the intersection point and the Err variant contains an
 /// error.
-pub type TraceSubResults = Vec<Vec<Result<Ray>>>;
+pub type RayBundle = Vec<Vec<Result<Ray>>>;
 
 /// Trace a set of rays through a system using the technique of Spencer and
 /// Murty, JOSA (1962).

--- a/raytracer/cherry-rs/src/views/ray_trace_3d_v2/trace.rs
+++ b/raytracer/cherry-rs/src/views/ray_trace_3d_v2/trace.rs
@@ -1,0 +1,89 @@
+use anyhow::Result;
+
+use super::rays::Ray;
+use crate::core::sequential_model::SequentialSubModelIter;
+
+/// Results of tracing rays through a system.
+///
+/// The first index corresponds to the surface number, and the second index
+/// corresponds to the ray number. The value is a Result, where the Ok variant
+/// contains the ray at the intersection point and the Err variant contains an
+/// error.
+pub type TraceResults = Vec<Vec<Result<Ray>>>;
+
+/// Trace a set of rays through a system using the technique of Spencer and
+/// Murty, JOSA (1962).
+///
+/// The results are stored in a Vec, where the index is the surface number and
+/// the value is a Vec of Result. If the ray intersected the surface
+/// successfully, then the result contains the ray located at the intersection
+/// point and with a (possibly) new direction as determined by the
+/// surface interaction, e.g. refraction or reflection.
+///
+/// If the ray did not intersect the surface, or the intersection point did not
+/// converge, then the result contains an error.
+///
+/// Index 0 of the results corresponds to the rays' initial states. By
+/// convention, this is their locations and directions at the axial position z =
+/// 0.
+pub fn trace(
+    sequential_submodel: &mut SequentialSubModelIter,
+    mut rays: Vec<Ray>,
+) -> Vec<Vec<Result<Ray>>> {
+    // Pre-allocate the results. Include the initial ray positions as a "surface."
+    let mut results: Vec<Vec<Result<Ray>>> = Vec::with_capacity(sequential_submodel.len() + 1);
+    for _ in 0..sequential_submodel.len() + 1 {
+        // +1 for the initial ray positions
+        results.push(Vec::with_capacity(rays.len()));
+    }
+
+    // Add initial ray states to the results.
+    for ray in &rays {
+        results[0].push(Ok(ray.clone()));
+    }
+
+    for (ctr, step) in sequential_submodel.enumerate() {
+        let (_, surf, _) = step;
+
+        for ray in &mut rays {
+            // Skip rays that have already terminated
+            if ray.is_terminated() {
+                results[ctr + 1].push(Err(anyhow::anyhow!("Ray terminated")));
+                continue;
+            }
+
+            // Transform into coordinate system of the surface
+            ray.transform(surf);
+
+            // Find the ray intersection with the surface
+            let (pos, norm) = match ray.intersect(surf, 1000) {
+                Ok((pos, norm)) => (pos, norm),
+                Err(e) => {
+                    ray.terminate();
+                    results[ctr + 1].push(Err(e));
+                    continue;
+                }
+            };
+
+            // Terminate ray if the intersection point is outside the clear aperture of the
+            // surface
+            if surf.outside_clear_aperture(pos) {
+                // Terminate the ray, but keep the results so that we can plot its last end
+                // point.
+                ray.terminate();
+            }
+
+            // Displace the ray to the intersection point
+            ray.displace(pos);
+
+            // Redirect the ray due to surface interaction
+            ray.redirect(&step, norm);
+
+            // Transform back to the global coordinate system
+            ray.i_transform(surf);
+
+            results[ctr + 1].push(Ok(ray.clone()));
+        }
+    }
+    results
+}

--- a/raytracer/cherry-rs/src/views/ray_trace_3d_v2/trace.rs
+++ b/raytracer/cherry-rs/src/views/ray_trace_3d_v2/trace.rs
@@ -9,7 +9,7 @@ use crate::core::sequential_model::SequentialSubModelIter;
 /// corresponds to the ray number. The value is a Result, where the Ok variant
 /// contains the ray at the intersection point and the Err variant contains an
 /// error.
-pub type TraceResults = Vec<Vec<Result<Ray>>>;
+pub type TraceSubResults = Vec<Vec<Result<Ray>>>;
 
 /// Trace a set of rays through a system using the technique of Spencer and
 /// Murty, JOSA (1962).

--- a/raytracer/cherry-rs/src/views/ray_trace_3d_v2/trace.rs
+++ b/raytracer/cherry-rs/src/views/ray_trace_3d_v2/trace.rs
@@ -1,76 +1,67 @@
-use anyhow::Result;
+use std::collections::HashMap;
 
 use super::rays::Ray;
 use crate::core::sequential_model::SequentialSubModelIter;
 
 /// A set of rays traced through an optical system.
 ///
-/// The first index corresponds to the surface number, and the second index
-/// corresponds to the ray number. The value is a Result, where the Ok variant
-/// contains the ray at the intersection point and the Err variant contains an
-/// error.
-pub type RayBundle = Vec<Vec<Result<Ray>>>;
+/// # Attributes
+/// - *rays*: A num. of rays x num. of surfaces matrix of rays representing the
+///   surface intersection points.
+/// - *terminated*: A num. of rays vector containing the surface indexes where
+///   any rays have terminated. `0` means the ray has not terminated.
+/// - *reason_for_termination*: A hashmap containing the reason for termination.
+/// - *num_surfaces*: The number of surfaces in the optical system.
+#[derive(Debug)]
+pub struct RayBundle {
+    rays: Vec<Ray>,
+    terminated: Vec<usize>,
+    reason_for_termination: HashMap<usize, String>,
+    num_surfaces: usize,
+}
 
 /// Trace a set of rays through a system using the technique of Spencer and
 /// Murty, JOSA (1962).
-///
-/// The results are stored in a Vec, where the index is the surface number and
-/// the value is a Vec of Result. If the ray intersected the surface
-/// successfully, then the result contains the ray located at the intersection
-/// point and with a (possibly) new direction as determined by the
-/// surface interaction, e.g. refraction or reflection.
-///
-/// If the ray did not intersect the surface, or the intersection point did not
-/// converge, then the result contains an error.
-///
-/// Index 0 of the results corresponds to the rays' initial states. By
-/// convention, this is their locations and directions at the axial position z =
-/// 0.
-pub fn trace(
-    sequential_submodel: &mut SequentialSubModelIter,
-    mut rays: Vec<Ray>,
-) -> Vec<Vec<Result<Ray>>> {
-    // Pre-allocate the results. Include the initial ray positions as a "surface."
-    let mut results: Vec<Vec<Result<Ray>>> = Vec::with_capacity(sequential_submodel.len() + 1);
-    for _ in 0..sequential_submodel.len() + 1 {
-        // +1 for the initial ray positions
-        results.push(Vec::with_capacity(rays.len()));
-    }
-
-    // Add initial ray states to the results.
-    for ray in &rays {
-        results[0].push(Ok(ray.clone()));
-    }
+pub fn trace(sequential_submodel: &mut SequentialSubModelIter, mut rays: Vec<Ray>) -> RayBundle {
+    // Pre-allocate the results bundle. Include the initial ray positions as a
+    // "surface."
+    let mut terminated = vec![0; rays.len()];
+    let mut reason_for_termination: HashMap<usize, String> = HashMap::new();
+    let num_surfaces = sequential_submodel.len() + 1; // +1 for the initial ray positions
+    let mut ray_bundle = initialize_bundle(&rays, num_surfaces);
 
     for (ctr, step) in sequential_submodel.enumerate() {
         let (_, surf, _) = step;
+        let surface_id = ctr + 1;
 
-        for ray in &mut rays {
+        // Copy the ray states into here after they have been traced through the surface
+        let rays_at_surface = rays_at_surface_mut(&mut ray_bundle, surface_id, num_surfaces);
+
+        for (ray_id, ray) in rays.iter_mut().enumerate() {
             // Skip rays that have already terminated
-            if ray.is_terminated() {
-                results[ctr + 1].push(Err(anyhow::anyhow!("Ray terminated")));
+            if is_terminated(ray_id, &terminated) {
                 continue;
             }
 
             // Transform into coordinate system of the surface
             ray.transform(surf);
 
-            // Find the ray intersection with the surface
+            // Find the ray intersection with the surface.
+            // Errors if the intersection point does not converge.
             let (pos, norm) = match ray.intersect(surf, 1000) {
                 Ok((pos, norm)) => (pos, norm),
                 Err(e) => {
-                    ray.terminate();
-                    results[ctr + 1].push(Err(e));
+                    terminated[ray_id] = surface_id;
+                    reason_for_termination.insert(ray_id, e.to_string());
                     continue;
                 }
             };
 
-            // Terminate ray if the intersection point is outside the clear aperture of the
-            // surface
+            // Terminate ray if intersection is outside the clear aperture of surface
             if surf.outside_clear_aperture(pos) {
-                // Terminate the ray, but keep the results so that we can plot its last end
-                // point.
-                ray.terminate();
+                terminated[ray_id] = surface_id;
+                reason_for_termination.insert(ray_id, "Ray outside clear aperture".to_string());
+                continue;
             }
 
             // Displace the ray to the intersection point
@@ -82,8 +73,119 @@ pub fn trace(
             // Transform back to the global coordinate system
             ray.i_transform(surf);
 
-            results[ctr + 1].push(Ok(ray.clone()));
+            rays_at_surface[ray_id] = ray.clone();
         }
     }
-    results
+    RayBundle {
+        rays: ray_bundle,
+        terminated,
+        reason_for_termination,
+        num_surfaces,
+    }
+}
+
+impl RayBundle {
+    /// Returns the rays traced through the system.
+    pub fn rays(&self) -> &[Ray] {
+        &self.rays
+    }
+
+    /// Returns the rays that have terminated.
+    ///
+    /// The index of the terminated ray corresponds to the surface index where
+    /// the ray terminated.
+    pub fn terminated(&self) -> &[usize] {
+        &self.terminated
+    }
+
+    /// Returns the reason for termination of the rays.
+    pub fn reason_for_termination(&self) -> &HashMap<usize, String> {
+        &self.reason_for_termination
+    }
+
+    /// Returns the number of surfaces in the optical system.
+    pub fn num_surfaces(&self) -> usize {
+        self.num_surfaces
+    }
+}
+
+/// Initializes a ray bundle for the start of a ray trace.
+///
+/// # Arguments
+/// - *rays*: A slice of the ray states at the initial surface.
+/// - *num_surfaces*: The number of surfaces in the optical system.
+fn initialize_bundle(initial_rays: &[Ray], num_surfaces: usize) -> Vec<Ray> {
+    let num_rays = initial_rays.len();
+    let mut bundle: Vec<Ray> = Ray::new_bundle(num_rays * num_surfaces);
+
+    // Copy the initial ray states to the first surface
+    for (ray_id, ray) in initial_rays.iter().enumerate() {
+        bundle[ray_id] = ray.clone();
+    }
+    bundle
+}
+
+fn is_terminated(ray_id: usize, terminated: &[usize]) -> bool {
+    terminated[ray_id] != 0
+}
+
+/// Returns the set of rays at a given surface index.
+fn rays_at_surface_mut(bundle: &mut [Ray], surface_id: usize, num_surfaces: usize) -> &mut [Ray] {
+    let start = surface_id * bundle.len() / num_surfaces;
+    let end = (surface_id + 1) * bundle.len() / num_surfaces;
+    &mut bundle[start..end]
+}
+
+#[cfg(test)]
+mod test {
+    use crate::core::math::vec3::Vec3;
+
+    use super::*;
+
+    #[test]
+    fn test_initialize_bundle() {
+        let rays = vec![
+            Ray::new(Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0)).unwrap(),
+            Ray::new(Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 1.0)).unwrap(),
+        ];
+        let num_surfaces = 3;
+        let bundle = initialize_bundle(&rays, num_surfaces);
+        assert_eq!(bundle.len(), rays.len() * num_surfaces);
+    }
+
+    #[test]
+    fn test_is_terminated() {
+        let terminated = vec![0, 1, 0, 2];
+        assert_eq!(is_terminated(0, &terminated), false);
+        assert_eq!(is_terminated(1, &terminated), true);
+        assert_eq!(is_terminated(2, &terminated), false);
+        assert_eq!(is_terminated(3, &terminated), true);
+    }
+
+    #[test]
+    fn test_rays_at_surface_mut() {
+        let mut bundle = vec![
+            Ray::new(Vec3::new(0.0, 0.0, 0.0), Vec3::new(1.0, 0.0, 0.0)).unwrap(),
+            Ray::new(Vec3::new(0.0, 0.0, 0.0), Vec3::new(1.0, 0.0, 0.0)).unwrap(),
+            Ray::new(Vec3::new(1.0, 1.0, 1.0), Vec3::new(0.0, 1.0, 0.0)).unwrap(),
+            Ray::new(Vec3::new(1.0, 1.0, 1.0), Vec3::new(0.0, 1.0, 0.0)).unwrap(),
+            Ray::new(Vec3::new(2.0, 2.0, 2.0), Vec3::new(0.0, 0.0, 1.0)).unwrap(),
+            Ray::new(Vec3::new(2.0, 2.0, 2.0), Vec3::new(0.0, 0.0, 1.0)).unwrap(),
+        ];
+        let rays_per_surface = 2;
+        let num_surfaces = bundle.len() / rays_per_surface;
+        let surface_id = 1;
+        let rays_at_surface = rays_at_surface_mut(&mut bundle, surface_id, num_surfaces);
+
+        assert_eq!(rays_at_surface.len(), rays_per_surface);
+
+        for ray in rays_at_surface {
+            assert_eq!(ray.x(), 1.0);
+            assert_eq!(ray.y(), 1.0);
+            assert_eq!(ray.z(), 1.0);
+            assert_eq!(ray.k(), 0.0);
+            assert_eq!(ray.l(), 1.0);
+            assert_eq!(ray.m(), 0.0);
+        }
+    }
 }


### PR DESCRIPTION
I refactored the 3D ray trace algorithm to:
1. make access easier for a set of (field_id, wavelength_id, Axis) values
2. tightly pack the ray data in memory

Interestingly the two algorithms perform the same in terms of wall time, and I eventually lost the initial gain of ~300 ns from removing the `field_id`.  I'm guessing the reason is that before I did not need to initialize the memory that was preallocated for the results, whereas now I do. It could be avoided, but then I would need to keep track of ray ID information somewhere. Currently this is implicitly tracked by the index in the array.

```console
     Running benches/convexplano_lens.rs (/home/kmd/src/cherry/raytracer/target/release/deps/convexplano_lens-7fdd896d1e89460a)
Gnuplot not found, using plotters backend
3D ray trace, convexplano lens/ray_trace_3d_view
                        time:   [3.8944 µs 3.9040 µs 3.9123 µs]
                        change: [-0.1480% +0.1915% +0.5018%] (p = 0.26 > 0.05)
                        No change in performance detected.
3D ray trace, convexplano lens/ray_trace_3d_view_v2
                        time:   [3.9175 µs 3.9262 µs 3.9357 µs]
                        change: [-2.5700% -2.2728% -1.9501%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
```