### PR TITLE
Add biconvex lens example

### DIFF
--- a/raytracer/CHANGELOG.md
+++ b/raytracer/CHANGELOG.md
@@ -13,15 +13,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A `primary_axial_color` method to `ParaxialView` for computing the axial primary color aberration of a lens.
 - An `axes` method on `SequentialModel` to return the set of axes that the system is modeled over.
 - `RayBundle`, `TraceResultsCollection` were added as part of refactoring the `ray_trace_3d_view`.
+- A f = +100 mm biconvex lens example with an object at a finite distance.
 
 ### Changed
 
 - `RefractiveIndexSpec` is now a trait which supports getting refractive index data from any generic materials database.
 - `ray_trace_3d_view` now returns a `TraceResultsCollection` of modified `TraceResults` structs. This allows for better access to a given set of values for (field_id, wavelength_id, Axis). `Ray` was also modified and now contains only position and direction information.
+- `Ray::fan` was removed from the public API and is now public only from within the crate.
+- Renamed the `ObjectHeight` field spec to `PointSource` to reflect that it is a point source of light. Its inputs are now the (x, y) position of the point source within the object plane.
+- Renamed the `ChiefAndMarginalRays` `PupilSampling` variant to `TangentialRayFan`.
 
 ### Fixed
 
 - Fixed an import error in the `n` macro.
+- `Vec3::normalize` is now a no-op when a zero-length vector is provided. This avoids the introduction of NaNs into calculations.
+- Radius vs. diameter mixup when computing paralel ray bundles on a square grid on the entrance pupil in the `ray_trace_3d_view`.
+- Chief ray calculations for finite object fields by `ParaxialSubview` now return the correct sign for the initial paraxial angle.
 
 ## [0.2.0] 2024-12-09
 

--- a/raytracer/cherry-js/src/system.rs
+++ b/raytracer/cherry-js/src/system.rs
@@ -128,7 +128,7 @@ impl System {
             &self.field_specs,
             &self.sequential_model,
             &self.paraxial_view,
-            Some(PupilSampling::ChiefAndMarginalRays),
+            Some(PupilSampling::TangentialRayFan),
         )
     }
 }

--- a/raytracer/cherry-rs/src/core/math/vec3.rs
+++ b/raytracer/cherry-rs/src/core/math/vec3.rs
@@ -67,8 +67,19 @@ impl Vec3 {
         self.e.iter().map(|e| e * e).sum()
     }
 
+    /// Create a vector with a length of 1.0 in the same direction as the
+    /// original vector.
+    ///
+    /// If the vector has a length of 0.0, the original vector is returned
+    /// instead of a Result type. This is to avoid the overhead of unwrapping
+    /// the Result type in the calling code.
     pub fn normalize(&self) -> Self {
         let length = self.length();
+
+        if length == 0.0 {
+            return *self;
+        }
+
         Self::new(self.e[0] / length, self.e[1] / length, self.e[2] / length)
     }
 
@@ -131,8 +142,8 @@ impl Vec3 {
     /// # Arguments
     /// - n: Number of vectors to create
     /// - r: Radial span of vector endpoints from [-r, r]
-    /// - theta: Angle of vectors with respect to x
     /// - z: z-coordinate of endpoints
+    /// - theta: Angle of vectors with respect to x
     /// - radial_offset_x: Offset the radial position of the vectors by this
     ///   amount in x
     /// - radial_offset_y: Offset the radial position of the vectors by this
@@ -140,8 +151,8 @@ impl Vec3 {
     pub fn fan(
         n: usize,
         r: Float,
-        theta: Float,
         z: Float,
+        theta: Float,
         radial_offset_x: Float,
         radial_offset_y: Float,
     ) -> Vec<Self> {
@@ -216,6 +227,23 @@ impl std::ops::Mul<Float> for Vec3 {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_normalize() {
+        let v = Vec3::new(1.0, 1.0, 1.0);
+        let norm = v.normalize();
+
+        assert_ne!(v.length(), 1.0);
+        assert_eq!(norm.length(), 1.0);
+    }
+
+    #[test]
+    fn test_normalize_zero_length() {
+        let v = Vec3::new(0.0, 0.0, 0.0);
+        let norm = v.normalize();
+
+        assert_eq!(norm.length(), 0.0);
+    }
 
     #[test]
     fn test_sample_circle_sq_grid_unit_circle() {

--- a/raytracer/cherry-rs/src/examples/biconvex_lens_finite_object.rs
+++ b/raytracer/cherry-rs/src/examples/biconvex_lens_finite_object.rs
@@ -1,0 +1,44 @@
+//! A f = +100 mm biconvex lens with an object at a finite distance.
+//!
+//! Thorlabs Part No.: LB1676-A
+use std::rc::Rc;
+
+use crate::{GapSpec, RefractiveIndexSpec, SequentialModel, SurfaceSpec, SurfaceType};
+
+pub fn sequential_model(
+    n_air: Rc<dyn RefractiveIndexSpec>,
+    n_glass: Rc<dyn RefractiveIndexSpec>,
+    wavelengths: &[f64],
+) -> SequentialModel {
+    let gap_0 = GapSpec {
+        thickness: 200.0,
+        refractive_index: n_air.clone(),
+    };
+    let gap_1 = GapSpec {
+        thickness: 3.6,
+        refractive_index: n_glass,
+    };
+    let gap_2 = GapSpec {
+        thickness: 196.1684,
+        refractive_index: n_air,
+    };
+    let gaps = vec![gap_0, gap_1, gap_2];
+
+    let surf_0 = SurfaceSpec::Object;
+    let surf_1 = SurfaceSpec::Conic {
+        semi_diameter: 12.7,
+        radius_of_curvature: 102.4,
+        conic_constant: 0.0,
+        surf_type: SurfaceType::Refracting,
+    };
+    let surf_2 = SurfaceSpec::Conic {
+        semi_diameter: 12.7,
+        radius_of_curvature: -102.4,
+        conic_constant: 0.0,
+        surf_type: SurfaceType::Refracting,
+    };
+    let surf_3 = SurfaceSpec::Image;
+    let surfaces = vec![surf_0, surf_1, surf_2, surf_3];
+
+    SequentialModel::new(&gaps, &surfaces, wavelengths).unwrap()
+}

--- a/raytracer/cherry-rs/src/examples/mod.rs
+++ b/raytracer/cherry-rs/src/examples/mod.rs
@@ -1,3 +1,4 @@
 //! Example lens data for various lenses and optical setups.
+pub mod biconvex_lens_finite_object;
 pub mod convexplano_lens;
 pub mod petzval_lens;

--- a/raytracer/cherry-rs/src/examples/petzval_lens.rs
+++ b/raytracer/cherry-rs/src/examples/petzval_lens.rs
@@ -113,11 +113,11 @@ pub fn field_specs() -> Vec<FieldSpec> {
     vec![
         FieldSpec::Angle {
             angle: 0.0,
-            pupil_sampling: PupilSampling::ChiefAndMarginalRays,
+            pupil_sampling: PupilSampling::TangentialRayFan,
         },
         FieldSpec::Angle {
             angle: 5.0,
-            pupil_sampling: PupilSampling::ChiefAndMarginalRays,
+            pupil_sampling: PupilSampling::TangentialRayFan,
         },
     ]
 }

--- a/raytracer/cherry-rs/src/views/cutaway.rs
+++ b/raytracer/cherry-rs/src/views/cutaway.rs
@@ -69,7 +69,7 @@ impl Surface {
 
         // Sample the surface in in the y,z plane by creating uniformally spaced (0,y,z)
         // coordinates
-        let sample_points = Vec3::fan(num_samples, semi_diameter, PI / 2.0, 0.0, 0.0, 0.0);
+        let sample_points = Vec3::fan(num_samples, semi_diameter, 0.0, PI / 2.0, 0.0, 0.0);
 
         let mut sample: Vec3;
         let mut rot_sample: Vec3;

--- a/raytracer/cherry-rs/src/views/paraxial.rs
+++ b/raytracer/cherry-rs/src/views/paraxial.rs
@@ -163,13 +163,13 @@ fn z_intercepts(rays: ParaxialRaysView) -> Result<Array1<Float>> {
 /// The maximum field angle is the maximum absolute value of the paraxial angle.
 ///
 /// # Arguments
-/// * `obj_pupil_sepration` - The separation between the object and the entrance
-///   pupil.
+/// * `obj_pupil_separation` - The separation between the object and the
+///   entrance pupil.
 /// * `field_specs` - The field specs.
 ///
 /// # Returns
 /// A tuple containing the maximum field angle and the height of the field.
-fn max_field(obj_pupil_sepration: Float, field_specs: &[FieldSpec]) -> (Float, Float) {
+fn max_field(obj_pupil_separation: Float, field_specs: &[FieldSpec]) -> (Float, Float) {
     let mut max_angle = 0.0;
     let mut max_height = 0.0;
 
@@ -180,20 +180,22 @@ fn max_field(obj_pupil_sepration: Float, field_specs: &[FieldSpec]) -> (Float, F
                 pupil_sampling: _,
             } => {
                 let paraxial_angle = angle.to_radians().tan();
-                let height = -obj_pupil_sepration * paraxial_angle;
+                let height = -obj_pupil_separation * paraxial_angle;
                 (height, paraxial_angle)
             }
-            FieldSpec::ObjectHeight {
-                height,
+            FieldSpec::PointSource {
+                x,
+                y,
                 pupil_sampling: _,
             } => {
-                let paraxial_angle = -height / obj_pupil_sepration;
-                (*height, paraxial_angle)
+                let height = (x.powi(2) + y.powi(2)).sqrt();
+                let paraxial_angle = -height / obj_pupil_separation;
+                (height, paraxial_angle)
             }
         };
 
         if paraxial_angle.abs() > max_angle {
-            max_angle = paraxial_angle.abs();
+            max_angle = paraxial_angle;
             max_height = height;
         }
     }

--- a/raytracer/cherry-rs/src/views/ray_trace_3d/rays.rs
+++ b/raytracer/cherry-rs/src/views/ray_trace_3d/rays.rs
@@ -179,26 +179,26 @@ impl Ray {
     /// are at an angle phi from the z-axis.
     ///
     /// # Arguments
-    /// - n: Number of vectors to create
-    /// - r: Radial span of vector endpoints from [-r, r]
-    /// - theta: Angle of vectors with respect to x, radians
-    /// - z: z-coordinate of endpoints
-    /// - phi: Angle of vectors with respect to z, the optics axis, radians
-    /// - radial_offset_x: Offset the radial position of the vectors by this
+    /// * `n`: Number of vectors to create
+    /// * `r`: Radial span of vector endpoints from [-r, r]
+    /// * `z`: z-coordinate of endpoints
+    /// * `theta` : The polar angle of the ray fan in the x-y plane.
+    /// * `phi``: Angle of vectors with respect to z, the optics axis, radians
+    /// * `radial_offset_x`: Offset the radial position of the vectors by this
     ///   amount in x
-    /// - radial_offset_y: Offset the radial position of the vectors by this
+    /// * `radial_offset_y`: Offset the radial position of the vectors by this
     ///   amount in y
     #[allow(clippy::too_many_arguments)]
-    pub fn fan(
+    pub(crate) fn parallel_ray_fan(
         n: usize,
         r: Float,
-        theta: Float,
         z: Float,
+        theta: Float,
         phi: Float,
         radial_offset_x: Float,
         radial_offset_y: Float,
     ) -> Vec<Ray> {
-        let pos = Vec3::fan(n, r, theta, z, radial_offset_x, radial_offset_y);
+        let pos = Vec3::fan(n, r, z, theta, radial_offset_x, radial_offset_y);
         let dir: Vec<Vec3> = pos
             .iter()
             .map(|_| {
@@ -215,19 +215,20 @@ impl Ray {
             .collect()
     }
 
-    /// Create a square grid of uniformly spaced rays within a circle in a given
-    /// z-plane.
+    /// Creates a bundle of parallel rays on a square grid.
+    ///
+    /// The rays are uniformly spaced within a circle in a given z-plane.
     ///
     /// # Arguments
-    /// - `radius`: Radius of the circle
-    /// - `spacing`: Spacing between rays
-    /// - `z`: z-coordinate of endpoints
-    /// - `phi`: Angle of vectors with respect to z, the optics axis, radians
-    /// - radial_offset_x: Offset the radial position of the vectors by this
+    /// * `radius`: Radius of the circle
+    /// * `spacing`: Spacing between rays
+    /// * `z`: z-coordinate of endpoints
+    /// * `phi`: Angle of vectors with respect to z, the optics axis, radians
+    /// * `radial_offset_x`: Offset the radial position of the vectors by this
     ///   amount in x
-    /// - radial_offset_y: Offset the radial position of the vectors by this
+    /// * `radial_offset_y`: Offset the radial position of the vectors by this
     ///   amount in y
-    pub(crate) fn sq_grid_in_circ(
+    pub(crate) fn parallel_ray_bundle_on_sq_grid(
         radius: Float,
         spacing: Float,
         z: Float,

--- a/raytracer/cherry-rs/tests/biconvex_lens_finite_object.rs
+++ b/raytracer/cherry-rs/tests/biconvex_lens_finite_object.rs
@@ -1,88 +1,74 @@
 use approx::assert_abs_diff_eq;
-use cherry_rs::examples::convexplano_lens::sequential_model;
-use cherry_rs::{n, FieldSpec, ImagePlane, ParaxialView, Pupil, PupilSampling};
 use ndarray::{arr3, Array3};
+
+use cherry_rs::examples::biconvex_lens_finite_object::sequential_model;
+use cherry_rs::{n, FieldSpec, ImagePlane, ParaxialView, Pupil, PupilSampling};
 
 // Inputs
 const WAVELENGTHS: [f64; 1] = [0.5876]; // He d line
 const FIELD_SPECS: [FieldSpec; 2] = [
-    FieldSpec::Angle {
-        angle: 0.0,
+    FieldSpec::PointSource {
+        x: 0.0,
+        y: 0.0,
         pupil_sampling: PupilSampling::TangentialRayFan,
     },
-    FieldSpec::Angle {
-        angle: 5.0,
+    FieldSpec::PointSource {
+        x: 0.0,
+        y: 5.0,
         pupil_sampling: PupilSampling::TangentialRayFan,
     },
 ];
 
 // Paraxial property values
 const APERTURE_STOP: usize = 1;
-const BACK_FOCAL_DISTANCE: f64 = 46.5987;
-const BACK_PRINCIPAL_PLANE: f64 = 1.8017;
-const EFFECTIVE_FOCAL_LENGTH: f64 = 50.097;
+const BACK_FOCAL_DISTANCE: f64 = 98.4360;
+const BACK_PRINCIPAL_PLANE: f64 = 2.4063;
+const EFFECTIVE_FOCAL_LENGTH: f64 = 99.6297;
 const ENTRANCE_PUPIL: Pupil = Pupil {
     location: 0.0,
-    semi_diameter: 12.5,
+    semi_diameter: 12.7,
 };
 const EXIT_PUPIL: Pupil = Pupil {
-    location: 1.8017,
-    semi_diameter: 12.5,
+    location: 1.1981,
+    semi_diameter: 12.8540,
 };
-const FRONT_FOCAL_DISTANCE: f64 = -EFFECTIVE_FOCAL_LENGTH;
-const FRONT_PRINCIPAL_PLANE: f64 = 0.0;
+const FRONT_FOCAL_DISTANCE: f64 = -98.4360;
+const FRONT_PRINCIPAL_PLANE: f64 = 1.1937;
 
-// For a 5 degree field angle
 const PARAXIAL_IMAGE_PLANE: ImagePlane = ImagePlane {
-    location: 51.8987,
-    semi_diameter: 4.3829,
+    location: 199.7684,
+    semi_diameter: 4.9048,
 };
 
-// For a 5 degree field angle
+// For a 5 mm field point
 // Paraxial angle = tan(field angle)
 fn chief_ray() -> Array3<f64> {
     arr3(&[
-        [[0.0], [0.087489]],
-        [[0.0], [0.0577482]],
-        [[0.306067], [0.087489]],
-        [[4.382944], [0.087489]],
+        [[5.0], [-0.025]],
+        [[0.0], [-0.01648]],
+        [[-0.0593], [-0.02470]],
+        [[-4.9048], [-0.02470]],
     ])
 }
 
 fn marginal_ray() -> Array3<f64> {
     arr3(&[
-        [[12.5000], [0.0]],
-        [[12.5000], [-0.1647]],
-        [[11.6271], [-0.2495]],
-        [[-0.0003], [-0.2495]],
+        [[0.0], [0.0635]],
+        [[12.7000], [-0.0004088]],
+        [[12.6985], [-0.06473]],
+        [[0.0], [-0.06473]],
     ])
 }
 
 #[test]
-fn test_paraxial_view_chief_ray() {
-    let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let sub_models = model.submodels();
-    let view =
-        ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
-    let chief_ray = chief_ray();
-
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
-        let result = sub_view.chief_ray();
-
-        assert_abs_diff_eq!(chief_ray, result, epsilon = 1e-4);
-    }
-}
-
-#[test]
 fn test_paraxial_view_aperture_stop() {
-    let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let sub_models = model.submodels();
+    let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
+    let submodels = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for submodel_id in submodels.keys() {
+        let sub_view = view.subviews().get(submodel_id).unwrap();
         let result = sub_view.aperture_stop();
 
         assert_eq!(APERTURE_STOP, *result)
@@ -91,13 +77,13 @@ fn test_paraxial_view_aperture_stop() {
 
 #[test]
 fn test_paraxial_view_back_focal_distance() {
-    let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let sub_models = model.submodels();
+    let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
+    let submodels = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for (sub_model_id, _) in sub_models {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for (submodel_id, _) in submodels {
+        let sub_view = view.subviews().get(submodel_id).unwrap();
         let result = sub_view.back_focal_distance();
 
         assert_abs_diff_eq!(BACK_FOCAL_DISTANCE, *result, epsilon = 1e-4)
@@ -106,13 +92,13 @@ fn test_paraxial_view_back_focal_distance() {
 
 #[test]
 fn test_paraxial_view_back_principal_plane() {
-    let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let sub_models = model.submodels();
+    let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
+    let submodels = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for (sub_model_id, _) in sub_models {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for (submodel_id, _) in submodels {
+        let sub_view = view.subviews().get(submodel_id).unwrap();
         let result = sub_view.back_principal_plane();
 
         assert_abs_diff_eq!(BACK_PRINCIPAL_PLANE, *result, epsilon = 1e-4)
@@ -121,13 +107,13 @@ fn test_paraxial_view_back_principal_plane() {
 
 #[test]
 fn test_paraxial_view_entrance_pupil() {
-    let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let sub_models = model.submodels();
+    let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
+    let submodels = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for (sub_model_id, _) in sub_models {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for (submodel_id, _) in submodels {
+        let sub_view = view.subviews().get(submodel_id).unwrap();
         let result = sub_view.entrance_pupil();
 
         assert_eq!(ENTRANCE_PUPIL, *result)
@@ -136,13 +122,13 @@ fn test_paraxial_view_entrance_pupil() {
 
 #[test]
 fn test_paraxial_view_exit_pupil() {
-    let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let sub_models = model.submodels();
+    let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
+    let submodels = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for (sub_model_id, _) in sub_models {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for (submodel_id, _) in submodels {
+        let sub_view = view.subviews().get(submodel_id).unwrap();
         let result = sub_view.exit_pupil();
 
         assert_abs_diff_eq!(EXIT_PUPIL.location, result.location, epsilon = 1e-4);
@@ -156,13 +142,13 @@ fn test_paraxial_view_exit_pupil() {
 
 #[test]
 fn test_paraxial_view_effective_focal_length() {
-    let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let sub_models = model.submodels();
+    let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
+    let submodels = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for (sub_model_id, _) in sub_models {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for (submodel_id, _) in submodels {
+        let sub_view = view.subviews().get(submodel_id).unwrap();
         let result = sub_view.effective_focal_length();
 
         assert_abs_diff_eq!(EFFECTIVE_FOCAL_LENGTH, *result, epsilon = 1e-4)
@@ -171,13 +157,13 @@ fn test_paraxial_view_effective_focal_length() {
 
 #[test]
 fn test_paraxial_view_front_focal_distance() {
-    let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let sub_models = model.submodels();
+    let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
+    let submodels = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for (sub_model_id, _) in sub_models {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for (submodel_id, _) in submodels {
+        let sub_view = view.subviews().get(submodel_id).unwrap();
         let result = sub_view.front_focal_distance();
 
         assert_abs_diff_eq!(FRONT_FOCAL_DISTANCE, *result, epsilon = 1e-4)
@@ -186,13 +172,13 @@ fn test_paraxial_view_front_focal_distance() {
 
 #[test]
 fn test_paraxial_view_front_principal_plane() {
-    let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
+    let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
     let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for (sub_model_id, _) in sub_models {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for (submodel_id, _) in sub_models {
+        let sub_view = view.subviews().get(submodel_id).unwrap();
         let result = sub_view.front_principal_plane();
 
         assert_abs_diff_eq!(FRONT_PRINCIPAL_PLANE, *result, epsilon = 1e-4)
@@ -201,13 +187,13 @@ fn test_paraxial_view_front_principal_plane() {
 
 #[test]
 fn test_paraxial_view_image_plane() {
-    let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
+    let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
     let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for (sub_model_id, _) in sub_models {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for (submodel_id, _) in sub_models {
+        let sub_view = view.subviews().get(submodel_id).unwrap();
         let result = sub_view.paraxial_image_plane();
 
         assert_abs_diff_eq!(
@@ -225,16 +211,32 @@ fn test_paraxial_view_image_plane() {
 
 #[test]
 fn test_paraxial_view_marginal_ray() {
-    let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
+    let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
     let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
     let marginal_ray = marginal_ray();
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for submodel_id in sub_models.keys() {
+        let sub_view = view.subviews().get(submodel_id).unwrap();
         let result = sub_view.marginal_ray();
 
         assert_abs_diff_eq!(marginal_ray, result, epsilon = 1e-4);
+    }
+}
+
+#[test]
+fn test_paraxial_view_chief_ray() {
+    let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
+    let sub_models = model.submodels();
+    let view =
+        ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
+    let chief_ray = chief_ray();
+
+    for submodel_id in sub_models.keys() {
+        let sub_view = view.subviews().get(submodel_id).unwrap();
+        let result = sub_view.chief_ray();
+
+        assert_abs_diff_eq!(chief_ray, result, epsilon = 1e-4);
     }
 }

--- a/raytracer/cherry-rs/tests/convexplano_lens_materials.rs
+++ b/raytracer/cherry-rs/tests/convexplano_lens_materials.rs
@@ -28,11 +28,11 @@ mod test_ri_info {
     const FIELD_SPECS: [FieldSpec; 2] = [
         FieldSpec::Angle {
             angle: 0.0,
-            pupil_sampling: PupilSampling::ChiefAndMarginalRays,
+            pupil_sampling: PupilSampling::TangentialRayFan,
         },
         FieldSpec::Angle {
             angle: 5.0,
-            pupil_sampling: PupilSampling::ChiefAndMarginalRays,
+            pupil_sampling: PupilSampling::TangentialRayFan,
         },
     ];
 


### PR DESCRIPTION
This change adds a biconvex lens example with finite object distances.

The `ray_trace_3d_view` and `FieldSpecs` have been significantly refactored to support point source fields at a finite distance to the lens. Notably, the `PupilSampling::ChiefAndMarginalRays` variant has been renamed to `TangentialRayFan` to correctly reflect the nature of the ray fan being traced.