### PR TITLE
Add ChiefRay pupil sampling variant

### DIFF
--- a/raytracer/CHANGELOG.md
+++ b/raytracer/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An `axes` method on `SequentialModel` to return the set of axes that the system is modeled over.
 - `RayBundle`, `TraceResultsCollection` were added as part of refactoring the `ray_trace_3d_view`.
 - A f = +100 mm biconvex lens example with an object at a finite distance.
+- A `PupilSampling::ChiefRay` pupil sampling variant to always trace a single chief ray for a given field point.
 
 ### Changed
 

--- a/raytracer/cherry-rs/src/specs/fields.rs
+++ b/raytracer/cherry-rs/src/specs/fields.rs
@@ -6,6 +6,9 @@ use crate::core::Float;
 /// Specifies a pupil sampling method.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum PupilSampling {
+    /// A pupil consisting of only a chief ray that pierces the pupil center.
+    ChiefRay,
+
     /// A square grid of rays in the the entrance pupil.
     ///
     /// Spacing is the spacing between rays in the grid in normalized pupil
@@ -41,6 +44,7 @@ impl PupilSampling {
     /// Validate the pupil sampling method.
     pub fn validate(&self) -> Result<()> {
         match self {
+            PupilSampling::ChiefRay => {}
             PupilSampling::SquareGrid { spacing } => {
                 if spacing.is_nan() {
                     anyhow::bail!("Pupil grid spacing must be a number");


### PR DESCRIPTION
The chief ray trace is now always accessible from a `TraceResults` instance. This will make it easy to locate the centers of spot diagrams.

Addresses #222 