### PR TITLE
Use Bulma's table-container to prevent table overflow

### DIFF
--- a/www/js/src/App.js
+++ b/www/js/src/App.js
@@ -176,35 +176,34 @@ function App({ wasmModule }) {
                 materialsService={materialsService}
                 computeService={computeService}
             />
-            <div className="explorers">
-                <div className="section">
 
-                    <div className="tabs is-centered is-small is-toggle is-toggle-rounded">
-                        <ul>
-                            <li className={activeExplorersTab === 'specs' ? 'is-active' : ''}>
-                                <a onClick={() => handleExplorersTabClick('specs')}>Specs</a>
-                            </li>
-                            <li className={activeExplorersTab === 'materials' ? 'is-active' : ''}>
-                                <a onClick={() => handleExplorersTabClick('materials')}>Materials</a>
-                            </li>
-                        </ul>
-                    </div>
+            <div className="section">
+                <div className="tabs is-centered is-small is-toggle is-toggle-rounded">
+                    <ul>
+                        <li className={activeExplorersTab === 'specs' ? 'is-active' : ''}>
+                            <a onClick={() => handleExplorersTabClick('specs')}>Specs</a>
+                        </li>
+                        <li className={activeExplorersTab === 'materials' ? 'is-active' : ''}>
+                            <a onClick={() => handleExplorersTabClick('materials')}>Materials</a>
+                        </li>
+                    </ul>
+                </div>
 
-                    {renderSpecsExplorerTabContent()}
+                {renderSpecsExplorerTabContent()}
+            </div>
+
+            <div className="section">
+                <div className="tabs is-centered is-small is-toggle is-toggle-rounded">
+                    <ul>
+                        <li className={activeAnalysisTab === 'cutaway' ? 'is-active' : ''}>
+                            <a onClick={() => handleAnalysisTabClick('cutaway')}>Cutaway</a>
+                        </li>
+                        <li className={activeAnalysisTab === 'spot-diagram' ? 'is-active' : ''}>
+                            <a onClick={() => handleAnalysisTabClick('spot-diagram')}>Spot Diagram</a>
+                        </li>
+                    </ul>
                 </div>
-                <div className="section">
-                    <div className="tabs is-centered is-small is-toggle is-toggle-rounded">
-                        <ul>
-                            <li className={activeAnalysisTab === 'cutaway' ? 'is-active' : ''}>
-                                <a onClick={() => handleAnalysisTabClick('cutaway')}>Cutaway</a>
-                            </li>
-                            <li className={activeAnalysisTab === 'spot-diagram' ? 'is-active' : ''}>
-                                <a onClick={() => handleAnalysisTabClick('spot-diagram')}>Spot Diagram</a>
-                            </li>
-                        </ul>
-                    </div>
-                    {renderAnalysisTabContent()}
-                </div>
+                {renderAnalysisTabContent()}
             </div>
         </div>
     );

--- a/www/js/src/components/explorers/tables/ApertureTable.js
+++ b/www/js/src/components/explorers/tables/ApertureTable.js
@@ -102,8 +102,8 @@ const ApertureTable = ({ aperture, setAperture, invalidFields, setInvalidFields 
     };
 
     return (
-        <div className="px-4" style={{ maxWidth: '800px' }}>
-            <table className="table" style={{ width: '100%' }}>
+        <div className="table-container">
+            <table className="table is-hoverable">
                 <thead>
                     <tr>
                         <th className="has-text-weight-semibold has-text-right" style={{ border: 'none', paddingLeft: 0 }}>

--- a/www/js/src/components/explorers/tables/FieldsTable.jsx
+++ b/www/js/src/components/explorers/tables/FieldsTable.jsx
@@ -309,26 +309,28 @@ const renderEditableCell = (value, index, property) => {
             </div>
         </div>
   
-        <table className="table is-fullwidth">
-          <thead>
-            <tr>
-              <th className="has-text-weight-semibold has-text-right">{fieldTypeHeader}</th>
-              <th className="has-text-weight-semibold has-text-right">Pupil Sampling</th>
-              <th className="has-text-weight-semibold has-text-right">Spacing</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {fields.map((field, index) => (
-              <tr key={index}>
-                <td>{renderEditableCell(data(field), index, propertyName)}</td>
-                {renderSamplingTypeCell(pupilSampling(field), index)}
-                <td>{renderEditableCell(spacing(field), index, 'spacing')}</td>
-                {renderActionButtons(index)}
+        <div className="table-container">
+          <table className="table is-hoverable">
+            <thead>
+              <tr>
+                <th className="has-text-weight-semibold has-text-right">{fieldTypeHeader}</th>
+                <th className="has-text-weight-semibold has-text-right">Pupil Sampling</th>
+                <th className="has-text-weight-semibold has-text-right">Spacing</th>
+                <th>Actions</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {fields.map((field, index) => (
+                <tr key={index}>
+                  <td>{renderEditableCell(data(field), index, propertyName)}</td>
+                  {renderSamplingTypeCell(pupilSampling(field), index)}
+                  <td>{renderEditableCell(spacing(field), index, 'spacing')}</td>
+                  {renderActionButtons(index)}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
     );
   };

--- a/www/js/src/components/explorers/tables/SurfacesTable.jsx
+++ b/www/js/src/components/explorers/tables/SurfacesTable.jsx
@@ -262,7 +262,7 @@ const SurfacesTable = ({ surfaces, setSurfaces, invalidFields, setInvalidFields,
         </div>
 
         <div className="table-container">
-        <table className="table">
+        <table className="table is-fullwidth is-hoverable">
           <thead>
             <tr>
               <th className="has-text-weight-semibold has-text-right">Surface Type</th>

--- a/www/js/src/components/explorers/tables/SurfacesTable.jsx
+++ b/www/js/src/components/explorers/tables/SurfacesTable.jsx
@@ -261,7 +261,8 @@ const SurfacesTable = ({ surfaces, setSurfaces, invalidFields, setInvalidFields,
           </div>
         </div>
 
-        <table className="table is-fullwidth">
+        <div className="table-container">
+        <table className="table">
           <thead>
             <tr>
               <th className="has-text-weight-semibold has-text-right">Surface Type</th>
@@ -288,6 +289,7 @@ const SurfacesTable = ({ surfaces, setSurfaces, invalidFields, setInvalidFields,
             ))}
           </tbody>
         </table>
+        </div>
       </div>
     );
   };

--- a/www/js/src/css/cherry.css
+++ b/www/js/src/css/cherry.css
@@ -5,13 +5,3 @@
     text-align: right;
     vertical-align: middle;
 }
-
-.explorers {
-    display: grid;
-    grid-template-columns: 1fr;
-    
-    @media (min-width: 1650px) {
-        grid-template-columns: 1fr 1fr;
-    }
-
-}


### PR DESCRIPTION
This fixes a longstanding problem where the surface specs table would overflow and cause display issues on mobile. It is now fixed by using Bulma's table-container class, which makes the table scrollable when it becomes larger than the viewport width.

I also made some minor changes:
- The table rows now become darker upon mouse-over.
- The fields and aperture table are no longer full-width tables.