### PR TITLE
fix: Use non-normalized surface normals in Newton-Raphson updates

### DIFF
--- a/crates/cherry-rs/Cargo.toml
+++ b/crates/cherry-rs/Cargo.toml
@@ -79,3 +79,7 @@ criterion = { version = "0.7", features = [ "html_reports" ] }
 [[bench]]
 name = "convexplano_lens"
 harness = false
+
+[[bench]]
+name = "f_theta_scan_lens"
+harness = false

--- a/crates/cherry-rs/benches/f_theta_scan_lens.rs
+++ b/crates/cherry-rs/benches/f_theta_scan_lens.rs
@@ -1,0 +1,40 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use cherry_rs::{
+    ApertureSpec, Axis, FieldSpec, ParaxialView, PupilSampling,
+    examples::f_theta_scan_lens::sequential_model, n, ray_trace_3d_view,
+};
+
+const WAVELENGTHS: [f64; 1] = [0.5876]; // He d line
+const APERTURE_SPEC: ApertureSpec = ApertureSpec::EntrancePupil { semi_diameter: 0.5 };
+
+fn benchmark(c: &mut Criterion) {
+    let model = sequential_model(n!(1.0), n!(1.84666), &WAVELENGTHS);
+    let field_specs = vec![FieldSpec::Angle {
+        angle: 20.0,
+        pupil_sampling: PupilSampling::TangentialRayFan {
+            n: 9,
+            axis: Axis::U,
+        },
+    }];
+    let paraxial_view = ParaxialView::new(&model, &field_specs, false).unwrap();
+    let mut group = c.benchmark_group("3D ray trace, f-theta scan lens");
+
+    group.bench_function("ray_trace_3d_view, 20 deg off-axis", |b| {
+        b.iter(|| {
+            ray_trace_3d_view(
+                black_box(&APERTURE_SPEC),
+                black_box(&field_specs),
+                black_box(&model),
+                black_box(&paraxial_view),
+                black_box(None),
+            )
+            .unwrap();
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/crates/cherry-rs/src/core/sequential_model.rs
+++ b/crates/cherry-rs/src/core/sequential_model.rs
@@ -5,6 +5,7 @@ use std::ops::Range;
 
 use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize, Serializer};
+use tracing::trace;
 
 use crate::core::{
     Float,
@@ -293,7 +294,12 @@ impl Conic {
         let dfdx = -r * self.radius_of_curvature * theta.cos() / denom;
         let dfdy = -r * self.radius_of_curvature * theta.sin() / denom;
         let dfdz = 1.0 as Float;
-        let norm = Vec3::new(dfdx, dfdy, dfdz).normalize();
+
+        // Do not normalize the normal vector!
+        // Its magnitude is important for Newton-Raphson ray tracing calculations.
+        let norm = Vec3::new(dfdx, dfdy, dfdz);
+
+        trace!(sag, dfdx, dfdy, dfdz, "conic sag_norm");
 
         (sag, norm)
     }
@@ -858,6 +864,9 @@ impl Surface {
     /// position.
     ///
     /// The position is given in the local coordinate system of the surface.
+    ///
+    /// The normal vector is not normalized. Its magnitude is important for
+    /// Newton-Raphson ray tracing calculations.
     pub(crate) fn sag_norm(&self, pos: Vec3) -> (Float, Vec3) {
         match self {
             Self::Conic(conic) => conic.sag_norm(pos),

--- a/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
@@ -4,7 +4,7 @@ mod trace;
 
 use anyhow::{Result, anyhow};
 use serde::Serialize;
-use tracing::trace_span;
+use tracing::{trace, trace_span};
 
 use crate::{
     Axis, Pupil,
@@ -150,6 +150,12 @@ pub fn ray_trace_3d_view(
             ray_bundle,
             chief_ray,
         });
+
+        trace!(
+            field_id, 
+            wavelength_id,
+            axis = ?axis,
+            "Finished tracing ray bundle for field {}, wavelength {}, axis {:?}", field_id, wavelength_id, axis);
     }
 
     Ok(TraceResultsCollection::new(results))

--- a/crates/cherry-rs/src/views/ray_trace_3d/rays.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/rays.rs
@@ -13,7 +13,11 @@ use crate::{
 
 /// Tolerance for convergence of the Newton-Raphson method in integer mutliples
 /// of the machine epsilon
-const TOL: Float = Float::EPSILON;
+const TOL: Float = 10.0 * Float::EPSILON;
+
+/// Maximum number of bisections when backtracking to find a non-NaN sag value
+/// during ray intersection
+const MAX_BISECT: usize = 64;
 
 /// A single ray to be traced through an optical system.
 ///
@@ -62,6 +66,17 @@ impl Ray {
         // value for s
         let mut s = -self.pos.z() / self.dir.n();
 
+        trace!(
+            pos_x = self.pos.x(),
+            pos_y = self.pos.y(),
+            pos_z = self.pos.z(),
+            dir_l = self.dir.l(),
+            dir_m = self.dir.m(),
+            dir_n = self.dir.n(),
+            s_init = s,
+            "intersect_init"
+        );
+
         let mut p: Vec3;
         let mut sag: Float;
         let mut norm: Vec3;
@@ -71,8 +86,56 @@ impl Ray {
 
             // Update the distance s using the Newton-Raphson method
             (sag, norm) = surf.sag_norm(p);
+
+            // sag can be NaN for points outside the clear aperture due to sqrt of a
+            // negative number Bisect s backwards until we find a point where
+            // sag is not NaN, or until we reach the initial guess
+            let mut bisect_counter: usize = 0;
+            while sag.is_nan() {
+                s /= 2.0;
+                p = self.pos + self.dir * s;
+                (sag, norm) = surf.sag_norm(p);
+
+                trace!(
+                    ctr,
+                    s_original = s * 2.0,
+                    s_bisected = s,
+                    "sag was NaN at current point, bisected s to find a point with non-NaN sag"
+                );
+
+                bisect_counter += 1;
+                if bisect_counter > MAX_BISECT {
+                    error!(
+                        ctr,
+                        s, "Ray intersection did not converge: sag is NaN for all bisected points"
+                    );
+                    bail!(
+                        "Ray intersection did not converge: sag is NaN (point may be outside clear aperture)"
+                    );
+                }
+            }
+
             let residual = p.z() - sag;
+
+            trace!(
+                ctr,
+                norm_x = norm.x(),
+                norm_y = norm.y(),
+                norm_z = norm.z(),
+                "normal at current point"
+            );
             let denom = norm.dot(&self.dir);
+
+            if denom == 0.0 {
+                error!(
+                    ctr,
+                    s,
+                    residual,
+                    "nr_failed: denominator is zero (ray perpendicular to surface normal)"
+                );
+                bail!("Ray intersection did not converge: denominator is zero");
+            }
+
             s -= residual / denom;
 
             trace!(
@@ -88,8 +151,10 @@ impl Ray {
                 "newton-raphson iteration data"
             );
 
-            // Check for convergence by comparing the current and previous values of s
-            if (s - s_1).abs() / s.abs().max(s_1.abs()) < TOL {
+            // Check for convergence by comparing the current and previous values of s,
+            // or by checking that the residual is at machine epsilon (handles near-grazing
+            // rays where a small residual still produces a step larger than TOL * |s|)
+            if (s - s_1).abs() / s.abs().max(s_1.abs()) < TOL || residual.abs() < TOL {
                 break;
             }
 
@@ -123,6 +188,9 @@ impl Ray {
         } else {
             n_0
         };
+
+        // Ensure the normal vector is normalized for the redirect calculations.
+        let norm = norm.normalize();
 
         match surf {
             //Surface::Conic(_) | Surface::Toric(_) => {

--- a/crates/cherry-rs/src/views/ray_trace_3d/trace.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/trace.rs
@@ -6,6 +6,8 @@ use tracing::{error, trace_span, warn};
 use super::rays::Ray;
 use crate::core::sequential_model::SequentialSubModelIter;
 
+const MAX_INTERSECTION_ITER: usize = 100;
+
 /// A set of rays traced through an optical system.
 ///
 /// # Attributes
@@ -43,15 +45,20 @@ pub fn trace(sequential_submodel: &mut SequentialSubModelIter, mut rays: Vec<Ray
         for (ray_id, ray) in rays.iter_mut().enumerate() {
             let _ray_span = trace_span!("trace_ray", ray_id, surface_id).entered();
 
+            // Short circuit on terminated rays
+            if ray_is_terminated(ray_id, &terminated) {
+                continue;
+            }
+
             // Transform into coordinate system of the surface
             ray.transform(surf);
 
             // Find the ray intersection with the surface.
             // Errors if the intersection point does not converge.
-            let (pos, norm) = match ray.intersect(surf, 1000) {
+            let (pos, norm) = match ray.intersect(surf, MAX_INTERSECTION_ITER) {
                 Ok((pos, norm)) => (pos, norm),
                 Err(e) => {
-                    if ray_is_not_terminated(ray_id, &terminated) {
+                    if !ray_is_terminated(ray_id, &terminated) {
                         terminated[ray_id] = surface_id;
                         reason_for_termination.insert(ray_id, e.to_string());
                         error!(ray_id, surface_id, reason = %e, "Ray terminated due to intersection failure");
@@ -61,7 +68,7 @@ pub fn trace(sequential_submodel: &mut SequentialSubModelIter, mut rays: Vec<Ray
             };
 
             // Terminate ray if intersection is outside the clear aperture of surface
-            if surf.outside_clear_aperture(pos) && ray_is_not_terminated(ray_id, &terminated) {
+            if surf.outside_clear_aperture(pos) {
                 terminated[ray_id] = surface_id;
                 reason_for_termination.insert(ray_id, "Ray outside clear aperture".to_string());
                 warn!(
@@ -135,8 +142,8 @@ fn initialize_bundle(initial_rays: &[Ray], num_surfaces: usize) -> Vec<Ray> {
     bundle
 }
 
-fn ray_is_not_terminated(ray_id: usize, terminated: &[usize]) -> bool {
-    terminated[ray_id] == 0
+fn ray_is_terminated(ray_id: usize, terminated: &[usize]) -> bool {
+    terminated[ray_id] != 0
 }
 
 /// Returns the set of rays at a given surface index.
@@ -164,12 +171,12 @@ mod test {
     }
 
     #[test]
-    fn test_ray_is_not_terminated() {
+    fn test_ray_is_terminated() {
         let terminated = vec![0, 1, 0, 2];
-        assert!(ray_is_not_terminated(0, &terminated));
-        assert!(!ray_is_not_terminated(1, &terminated));
-        assert!(ray_is_not_terminated(2, &terminated));
-        assert!(!ray_is_not_terminated(3, &terminated));
+        assert!(!ray_is_terminated(0, &terminated));
+        assert!(ray_is_terminated(1, &terminated));
+        assert!(!ray_is_terminated(2, &terminated));
+        assert!(ray_is_terminated(3, &terminated));
     }
 
     #[test]

--- a/justfile
+++ b/justfile
@@ -1,3 +1,16 @@
+[doc("Run a benchmark test. Example: 'just bench f_theta_scan_lens'")]
+[working-directory: "crates"]
+bench bench_name:
+  cargo bench --bench {{bench_name}}
+
+[working-directory: "crates"]
+list-benches:
+  cargo bench -- --list
+
+[working-directory: "crates"]
+list-tests:
+  cargo test --test '*' -- --list
+
 [doc("Run an integration test with tracing. Filter example: '[{ray_id=0}]=trace'")]
 [arg("filter", long, short="f")]
 [arg("test_name", long, short="n")]


### PR DESCRIPTION
The Surface::sag_norm method was returning unit, a.k.a. normalized, surface normal vectors which had the effect of modifying the denominator term in the Newton-Raphson update step and causing oscillations at angles of incidence greater than ~10 degrees on highly curved surfaces.

Now, the magnitude of the normal vectors is retained and convergence has improved such that there is a 40% speed improvement in the convexplano lens and the f-theta scan lens no longer has convergence failures.

I also added a fallback branch of the NR routine that uses a bisection method when sag is NaN to bring the ray back into a valid numerical regime.

Finally, the NR routine now terminates early if a ray is terminated. This originally caused a slight increase in the benchmark tests due to branch prediction failures, but it was more than compensated for by improving the convergence rate and reducing the error rate in individual ray/surface intersection calculations.