### PR TITLE
feat: Allow specifying azimuth and zenith in Angle FieldSpec variant

### DIFF
--- a/crates/cherry-rs/benches/convexplano_lens.rs
+++ b/crates/cherry-rs/benches/convexplano_lens.rs
@@ -11,11 +11,13 @@ use cherry_rs::{
 const WAVELENGTHS: [f64; 1] = [0.5876]; // He d line
 const FIELD_SPECS: [FieldSpec; 2] = [
     FieldSpec::Angle {
-        angle: 0.0,
+        chi: 0.0,
+        phi: 90.0,
         pupil_sampling: PupilSampling::SquareGrid { spacing: 0.1 },
     },
     FieldSpec::Angle {
-        angle: 5.0,
+        chi: 5.0,
+        phi: 90.0,
         pupil_sampling: PupilSampling::SquareGrid { spacing: 0.1 },
     },
 ];

--- a/crates/cherry-rs/benches/f_theta_scan_lens.rs
+++ b/crates/cherry-rs/benches/f_theta_scan_lens.rs
@@ -2,7 +2,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 
 use cherry_rs::{
-    ApertureSpec, Axis, FieldSpec, ParaxialView, PupilSampling,
+    ApertureSpec, FieldSpec, ParaxialView, PupilSampling,
     examples::f_theta_scan_lens::sequential_model, n, ray_trace_3d_view,
 };
 
@@ -12,11 +12,9 @@ const APERTURE_SPEC: ApertureSpec = ApertureSpec::EntrancePupil { semi_diameter:
 fn benchmark(c: &mut Criterion) {
     let model = sequential_model(n!(1.0), n!(1.84666), &WAVELENGTHS);
     let field_specs = vec![FieldSpec::Angle {
-        angle: 20.0,
-        pupil_sampling: PupilSampling::TangentialRayFan {
-            n: 9,
-            axis: Axis::U,
-        },
+        chi: 20.0,
+        phi: 90.0,
+        pupil_sampling: PupilSampling::TangentialRayFan { n: 9 },
     }];
     let paraxial_view = ParaxialView::new(&model, &field_specs, false).unwrap();
     let mut group = c.benchmark_group("3D ray trace, f-theta scan lens");

--- a/crates/cherry-rs/src/examples/f_theta_scan_lens.rs
+++ b/crates/cherry-rs/src/examples/f_theta_scan_lens.rs
@@ -9,7 +9,7 @@
 use std::rc::Rc;
 
 use crate::{
-    Axis, FieldSpec, GapSpec, PupilSampling, RefractiveIndexSpec, Rotation3D, SequentialModel,
+    FieldSpec, GapSpec, PupilSampling, RefractiveIndexSpec, Rotation3D, SequentialModel,
     SurfaceSpec, SurfaceType,
 };
 
@@ -111,10 +111,8 @@ pub fn sequential_model(
 
 pub fn field_specs() -> Vec<FieldSpec> {
     vec![FieldSpec::Angle {
-        angle: 0.0,
-        pupil_sampling: PupilSampling::TangentialRayFan {
-            n: 3,
-            axis: Axis::U,
-        },
+        chi: 0.0,
+        phi: 90.0,
+        pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
     }]
 }

--- a/crates/cherry-rs/src/examples/petzval_lens.rs
+++ b/crates/cherry-rs/src/examples/petzval_lens.rs
@@ -1,6 +1,5 @@
 use crate::{
-    Axis, FieldSpec, GapSpec, PupilSampling, Rotation3D, SequentialModel, SurfaceSpec, SurfaceType,
-    n,
+    FieldSpec, GapSpec, PupilSampling, Rotation3D, SequentialModel, SurfaceSpec, SurfaceType, n,
 };
 
 pub fn sequential_model() -> SequentialModel {
@@ -126,18 +125,14 @@ pub fn sequential_model() -> SequentialModel {
 pub fn field_specs() -> Vec<FieldSpec> {
     vec![
         FieldSpec::Angle {
-            angle: 0.0,
-            pupil_sampling: PupilSampling::TangentialRayFan {
-                n: 3,
-                axis: Axis::U,
-            },
+            chi: 0.0,
+            phi: 90.0,
+            pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
         },
         FieldSpec::Angle {
-            angle: 5.0,
-            pupil_sampling: PupilSampling::TangentialRayFan {
-                n: 3,
-                axis: Axis::U,
-            },
+            chi: 5.0,
+            phi: 90.0,
+            pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
         },
     ]
 }

--- a/crates/cherry-rs/src/gui/compute.rs
+++ b/crates/cherry-rs/src/gui/compute.rs
@@ -4,7 +4,7 @@ use std::sync::mpsc::{Receiver, Sender};
 use std::{collections::HashMap, rc::Rc};
 
 use crate::{
-    Axis, ParaxialView, SequentialModel, components_view, cross_section_view, ray_trace_3d_view,
+    ParaxialView, SequentialModel, components_view, cross_section_view, ray_trace_3d_view,
 };
 
 use super::{
@@ -153,17 +153,14 @@ fn run_compute(
     };
 
     let n = req.specs.cross_section_n_rays as usize;
-    let mut cs_trace: Option<crate::TraceResultsCollection> = None;
-    for axis in [Axis::U, Axis::R] {
-        let sampling = Some(crate::specs::fields::PupilSampling::TangentialRayFan { n, axis });
-        match ray_trace_3d_view(&parsed.aperture, &parsed.fields, &seq, &pv, sampling) {
-            Ok(t) => match cs_trace.as_mut() {
-                Some(existing) => existing.extend(t),
-                None => cs_trace = Some(t),
-            },
-            Err(e) => log::warn!("Cross-section ray trace ({axis:?}) failed: {e}"),
+    let sampling = Some(crate::specs::fields::PupilSampling::TangentialRayFan { n });
+    let cs_trace = match ray_trace_3d_view(&parsed.aperture, &parsed.fields, &seq, &pv, sampling) {
+        Ok(t) => Some(t),
+        Err(e) => {
+            log::warn!("Cross-section ray trace failed: {e}");
+            None
         }
-    }
+    };
 
     let components = components_view(&seq, parsed.background.clone()).unwrap_or_default();
     let cross_section = Some(cross_section_view(&seq, cs_trace.as_ref(), &components));
@@ -209,8 +206,8 @@ fn build_field_descs(fields: &[crate::FieldSpec]) -> Vec<super::result_package::
         .iter()
         .map(|f| {
             let label = match f {
-                crate::FieldSpec::Angle { angle, .. } => {
-                    format!("{angle:.3}\u{00b0}")
+                crate::FieldSpec::Angle { chi, phi, .. } => {
+                    format!("\u{03c7}={chi:.3}\u{00b0}, \u{03c6}={phi:.3}\u{00b0}")
                 }
                 crate::FieldSpec::PointSource { x, y, .. } => {
                     format!("({x}, {y}) mm")
@@ -262,22 +259,24 @@ mod tests {
         use crate::{FieldSpec, specs::fields::PupilSampling};
         let fields = vec![
             FieldSpec::Angle {
-                angle: 0.0,
-                pupil_sampling: PupilSampling::TangentialRayFan {
-                    n: 3,
-                    axis: crate::Axis::U,
-                },
+                chi: 0.0,
+                phi: 90.0,
+                pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
             },
             FieldSpec::Angle {
-                angle: 5.0,
-                pupil_sampling: PupilSampling::TangentialRayFan {
-                    n: 3,
-                    axis: crate::Axis::U,
-                },
+                chi: 5.0,
+                phi: 90.0,
+                pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
             },
         ];
         let descs = build_field_descs(&fields);
-        assert_eq!(descs[0].label, "0.000\u{00b0}");
-        assert_eq!(descs[1].label, "5.000\u{00b0}");
+        assert_eq!(
+            descs[0].label,
+            "\u{03c7}=0.000\u{00b0}, \u{03c6}=90.000\u{00b0}"
+        );
+        assert_eq!(
+            descs[1].label,
+            "\u{03c7}=5.000\u{00b0}, \u{03c6}=90.000\u{00b0}"
+        );
     }
 }

--- a/crates/cherry-rs/src/gui/convert.rs
+++ b/crates/cherry-rs/src/gui/convert.rs
@@ -150,15 +150,16 @@ fn convert_specs_inner(
 
         let field = match specs.field_mode {
             FieldMode::Angle => {
-                let angle =
-                    parse_float(&frow.value).with_context(|| format!("field {i}: angle"))?;
+                let chi = parse_float(&frow.chi).with_context(|| format!("field {i}: chi"))?;
+                let phi = parse_float(&frow.phi).with_context(|| format!("field {i}: phi"))?;
                 FieldSpec::Angle {
-                    angle,
+                    chi,
+                    phi,
                     pupil_sampling,
                 }
             }
             FieldMode::PointSource => {
-                let y = parse_float(&frow.value).with_context(|| format!("field {i}: y"))?;
+                let y = parse_float(&frow.chi).with_context(|| format!("field {i}: y"))?;
                 let x = parse_float(&frow.x).with_context(|| format!("field {i}: x"))?;
                 FieldSpec::PointSource {
                     x,

--- a/crates/cherry-rs/src/gui/examples.rs
+++ b/crates/cherry-rs/src/gui/examples.rs
@@ -33,7 +33,8 @@ pub fn mirrors_figure_z() -> SystemSpecs {
             SurfaceRow::new_image(),
         ],
         fields: vec![FieldRow {
-            value: "0.0".into(),
+            chi: "0.0".into(),
+            phi: "90.0".into(),
             x: "0.0".into(),
             pupil_spacing: "0.1".into(),
         }],
@@ -66,12 +67,14 @@ pub fn petzval_lens() -> SystemSpecs {
         ],
         fields: vec![
             FieldRow {
-                value: "0.0".into(),
+                chi: "0.0".into(),
+                phi: "90.0".into(),
                 x: "0.0".into(),
                 pupil_spacing: "0.1".into(),
             },
             FieldRow {
-                value: "5.0".into(),
+                chi: "5.0".into(),
+                phi: "90.0".into(),
                 x: "0.0".into(),
                 pupil_spacing: "0.1".into(),
             },
@@ -99,12 +102,14 @@ pub fn biconvex_lens() -> SystemSpecs {
         ],
         fields: vec![
             FieldRow {
-                value: "0.0".into(),
+                chi: "0.0".into(),
+                phi: "90.0".into(),
                 x: "0.0".into(),
                 pupil_spacing: "0.1".into(),
             },
             FieldRow {
-                value: "5.0".into(),
+                chi: "5.0".into(),
+                phi: "90.0".into(),
                 x: "0.0".into(),
                 pupil_spacing: "0.1".into(),
             },
@@ -165,12 +170,14 @@ pub fn convexplano_lens_with_materials() -> SystemSpecs {
         ],
         fields: vec![
             FieldRow {
-                value: "0.0".into(),
+                chi: "0.0".into(),
+                phi: "90.0".into(),
                 x: "0.0".into(),
                 pupil_spacing: "0.1".into(),
             },
             FieldRow {
-                value: "5.0".into(),
+                chi: "5.0".into(),
+                phi: "90.0".into(),
                 x: "0.0".into(),
                 pupil_spacing: "0.1".into(),
             },
@@ -292,7 +299,8 @@ pub fn f_theta_scan_lens() -> SystemSpecs {
             SurfaceRow::new_image(),
         ],
         fields: vec![FieldRow {
-            value: "0".into(),
+            chi: "0".into(),
+            phi: "90.0".into(),
             x: "0.0".into(),
             pupil_spacing: "0.1".into(),
         }],
@@ -331,12 +339,14 @@ pub fn concave_mirror() -> SystemSpecs {
         ],
         fields: vec![
             FieldRow {
-                value: "0.0".into(),
+                chi: "0.0".into(),
+                phi: "90.0".into(),
                 x: "0.0".into(),
                 pupil_spacing: "0.1".into(),
             },
             FieldRow {
-                value: "5.0".into(),
+                chi: "5.0".into(),
+                phi: "90.0".into(),
                 x: "0.0".into(),
                 pupil_spacing: "0.1".into(),
             },

--- a/crates/cherry-rs/src/gui/model.rs
+++ b/crates/cherry-rs/src/gui/model.rs
@@ -150,11 +150,19 @@ impl SurfaceRow {
     }
 }
 
+fn default_phi() -> String {
+    "90.0".into()
+}
+
 /// A single row in the fields table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FieldRow {
-    /// Angle in degrees (Angle mode) or Y position (PointSource mode).
-    pub value: String,
+    /// χ (chi): zenith angle in degrees (Angle mode) or Y position (PointSource
+    /// mode).
+    pub chi: String,
+    /// φ (phi): azimuthal angle in degrees (Angle mode only). Defaults to 90.0.
+    #[serde(default = "default_phi")]
+    pub phi: String,
     /// X position (PointSource mode only).
     pub x: String,
     /// Pupil sampling grid spacing.
@@ -230,7 +238,8 @@ impl Default for SystemSpecs {
                 SurfaceRow::new_image(),
             ],
             fields: vec![FieldRow {
-                value: "0.0".into(),
+                chi: "0.0".into(),
+                phi: "90.0".into(),
                 x: "0.0".into(),
                 pupil_spacing: "0.1".into(),
             }],

--- a/crates/cherry-rs/src/gui/panels/fields.rs
+++ b/crates/cherry-rs/src/gui/panels/fields.rs
@@ -36,11 +36,8 @@ pub fn fields_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
             .resizable(true)
             .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
             .column(Column::auto().at_least(30.0)) // #
-            .column(Column::initial(100.0).resizable(true)) // Value (angle or y)
-            .columns(
-                Column::initial(100.0).resizable(true),
-                if is_angle { 0 } else { 1 }, // X (only for PointSource)
-            )
+            .column(Column::initial(100.0).resizable(true)) // χ (angle) or Y (point source)
+            .column(Column::initial(100.0).resizable(true)) // φ (angle mode) or X (point source)
             .column(Column::initial(100.0).resizable(true)) // Pupil spacing
             .column(Column::auto().at_least(50.0)); // Actions
 
@@ -51,16 +48,18 @@ pub fn fields_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
                 });
                 header.col(|ui| {
                     if is_angle {
-                        ui.strong("Angle (deg)");
+                        ui.strong("\u{03c7} (\u{00b0})");
                     } else {
                         ui.strong("Y");
                     }
                 });
-                if !is_angle {
-                    header.col(|ui| {
+                header.col(|ui| {
+                    if is_angle {
+                        ui.strong("\u{03c6} (\u{00b0})");
+                    } else {
                         ui.strong("X");
-                    });
-                }
+                    }
+                });
                 header.col(|ui| {
                     ui.strong("Pupil Spacing");
                 });
@@ -86,7 +85,7 @@ pub fn fields_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
                             if is_angle {
                                 changed |= drag_value(
                                     ui,
-                                    &mut field.value,
+                                    &mut field.chi,
                                     row_idx,
                                     "val",
                                     -90.0..=90.0,
@@ -95,7 +94,7 @@ pub fn fields_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
                             } else {
                                 changed |= drag_value(
                                     ui,
-                                    &mut field.value,
+                                    &mut field.chi,
                                     row_idx,
                                     "val",
                                     f64::NEG_INFINITY..=f64::INFINITY,
@@ -104,9 +103,18 @@ pub fn fields_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
                             }
                         });
 
-                        // X column (PointSource only)
-                        if !is_angle {
-                            row.col(|ui| {
+                        // φ column (Angle mode) or X column (PointSource mode)
+                        row.col(|ui| {
+                            if is_angle {
+                                changed |= drag_value(
+                                    ui,
+                                    &mut field.phi,
+                                    row_idx,
+                                    "phi",
+                                    -180.0..=180.0,
+                                    1.0,
+                                );
+                            } else {
                                 changed |= drag_value(
                                     ui,
                                     &mut field.x,
@@ -115,8 +123,8 @@ pub fn fields_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
                                     f64::NEG_INFINITY..=f64::INFINITY,
                                     1.0,
                                 );
-                            });
-                        }
+                            }
+                        });
 
                         // Pupil spacing
                         row.col(|ui| {
@@ -148,7 +156,8 @@ pub fn fields_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
                     specs.fields.insert(
                         idx + 1,
                         FieldRow {
-                            value: "0.0".into(),
+                            chi: "0.0".into(),
+                            phi: "90.0".into(),
                             x: "0.0".into(),
                             pupil_spacing: "0.1".into(),
                         },

--- a/crates/cherry-rs/src/gui/windows/spot_diagram.rs
+++ b/crates/cherry-rs/src/gui/windows/spot_diagram.rs
@@ -424,7 +424,8 @@ mod tests {
 
         let mut specs = SystemSpecs::default();
         specs.fields.push(FieldRow {
-            value: "5.0".into(),
+            chi: "5.0".into(),
+            phi: "90.0".into(),
             x: "0.0".into(),
             pupil_spacing: "0.1".into(),
         });

--- a/crates/cherry-rs/src/lib.rs
+++ b/crates/cherry-rs/src/lib.rs
@@ -95,11 +95,13 @@
 //! // with a square grid with a spacing of 0.1 in normalized pupil coordinates.
 //! let field_specs = vec![
 //!     FieldSpec::Angle {
-//!         angle: 0.0,
+//!         chi: 0.0,
+//!         phi: 90.0,
 //!         pupil_sampling: PupilSampling::SquareGrid { spacing: 0.1 },
 //!     },
 //!     FieldSpec::Angle {
-//!         angle: 5.0,
+//!         chi: 5.0,
+//!         phi: 90.0,
 //!         pupil_sampling: PupilSampling::SquareGrid { spacing: 0.1 },
 //!     },
 //! ];

--- a/crates/cherry-rs/src/specs/fields.rs
+++ b/crates/cherry-rs/src/specs/fields.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::core::{Float, sequential_model::Axis};
+use crate::core::{Float, PI};
 
 /// Specifies a pupil sampling method.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -18,17 +18,28 @@ pub enum PupilSampling {
     SquareGrid { spacing: Float },
 
     /// A tangential ray fan of `n` evenly-spaced rays from one pupil edge to
-    /// the other, spanning the given axis (YZ plane for `Axis::U`, XZ plane
-    /// for `Axis::R`).
-    TangentialRayFan { n: usize, axis: Axis },
+    /// the other. The fan lies in the meridional plane, whose orientation is
+    /// determined by the field spec via [`FieldSpec::tangential_fan_phi`].
+    TangentialRayFan { n: usize },
 }
 
 /// Specifies an object field.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum FieldSpec {
-    /// The angle the field makes with the optical axis, in degrees.
+    /// The 2D direction of the field, specified in spherical coordinates.
+    ///
+    /// - `chi`: polar (zenith) angle from the optical axis, in degrees. Range
+    ///   `[-90, 90]`. Negative chi places the field on the opposite side of the
+    ///   phi direction, which allows smooth scanning through zero without
+    ///   flipping phi.
+    /// - `phi`: azimuthal angle in the RU (XY) plane, in degrees. Range `(-180,
+    ///   180]`. Consistent with phi = rotation about F (z-axis). φ = 0 → R/XZ
+    ///   plane; φ = 90 → U/YZ plane (default).
+    ///
+    /// Chief ray direction: `(sin χ · cos φ, sin χ · sin φ, cos χ)`.
     Angle {
-        angle: Float,
+        chi: Float,
+        phi: Float,
         pupil_sampling: PupilSampling,
     },
 
@@ -68,18 +79,55 @@ impl Default for PupilSampling {
 }
 
 impl FieldSpec {
+    /// Returns the azimuthal angle (in radians) of the tangential ray fan in
+    /// the pupil plane.
+    ///
+    /// The tangential fan lies in the meridional plane, which is defined by the
+    /// optical axis and the field direction. For an `Angle` field this is
+    /// simply `phi` converted to radians. For a `PointSource` field it is
+    /// `atan2(y, x)`, with a fallback of `π/2` (U/YZ plane) when the source
+    /// is on-axis.
+    pub fn tangential_fan_phi(&self) -> Float {
+        match self {
+            FieldSpec::Angle { phi, .. } => phi.to_radians(),
+            FieldSpec::PointSource { x, y, .. } => {
+                if *x == 0.0 && *y == 0.0 {
+                    PI / 2.0
+                } else {
+                    y.atan2(*x)
+                }
+            }
+        }
+    }
+
+    /// Returns the azimuthal angle (in radians) of the sagittal ray fan in the
+    /// pupil plane.
+    ///
+    /// The sagittal fan is perpendicular to the tangential fan, so this is
+    /// `tangential_fan_phi() + π/2`.
+    pub fn sagittal_fan_phi(&self) -> Float {
+        self.tangential_fan_phi() + PI / 2.0
+    }
+
     /// Validate the field specification.
     pub fn validate(&self) -> Result<()> {
         match self {
             FieldSpec::Angle {
-                angle,
+                chi,
+                phi,
                 pupil_sampling,
             } => {
-                if angle.is_nan() {
-                    anyhow::bail!("Field angle must be a number");
+                if chi.is_nan() {
+                    anyhow::bail!("Field chi must be a number");
                 }
-                if *angle < -90.0 || *angle > 90.0 {
-                    anyhow::bail!("Field angle must be in the range [-90.0, 90]");
+                if *chi < -90.0 || *chi > 90.0 {
+                    anyhow::bail!("Field chi must be in the range [-90, 90]");
+                }
+                if phi.is_nan() {
+                    anyhow::bail!("Field phi must be a number");
+                }
+                if *phi <= -180.0 || *phi > 180.0 {
+                    anyhow::bail!("Field phi must be in the range (-180, 180]");
                 }
                 pupil_sampling.validate()?;
             }
@@ -125,38 +173,47 @@ mod test {
 
     #[test]
     fn test_field_spec_validate() {
+        // chi=5° off-axis, phi=90° (U/YZ direction)
         let angle = FieldSpec::Angle {
-            angle: 45.0,
+            chi: 5.0,
+            phi: 90.0,
             pupil_sampling: PupilSampling::SquareGrid { spacing: 0.1 },
         };
         assert!(angle.validate().is_ok());
 
+        // chi out of range (> 90)
         let angle = FieldSpec::Angle {
-            angle: 95.0,
+            chi: 95.0,
+            phi: 90.0,
             pupil_sampling: PupilSampling::SquareGrid { spacing: 0.1 },
         };
         assert!(angle.validate().is_err());
 
+        // negative chi is valid
         let angle = FieldSpec::Angle {
-            angle: -5.0,
+            chi: -5.0,
+            phi: 90.0,
             pupil_sampling: PupilSampling::SquareGrid { spacing: 0.1 },
         };
         assert!(angle.validate().is_ok());
 
         let angle = FieldSpec::Angle {
-            angle: 45.0,
+            chi: 5.0,
+            phi: 90.0,
             pupil_sampling: PupilSampling::SquareGrid { spacing: 1.1 },
         };
         assert!(angle.validate().is_err());
 
         let angle = FieldSpec::Angle {
-            angle: 45.0,
+            chi: 5.0,
+            phi: 90.0,
             pupil_sampling: PupilSampling::SquareGrid { spacing: -0.1 },
         };
         assert!(angle.validate().is_err());
 
         let angle = FieldSpec::Angle {
-            angle: 45.0,
+            chi: 5.0,
+            phi: 90.0,
             pupil_sampling: PupilSampling::SquareGrid {
                 spacing: Float::NAN,
             },
@@ -211,5 +268,165 @@ mod test {
             pupil_sampling: PupilSampling::SquareGrid { spacing: 1.0 },
         };
         assert!(height.validate().is_err());
+    }
+
+    #[test]
+    fn test_tangential_fan_phi() {
+        use std::f64::consts::{FRAC_PI_2, PI};
+
+        // Angle field: tangential_fan_phi returns phi in radians
+        let f = FieldSpec::Angle {
+            chi: 5.0,
+            phi: 90.0,
+            pupil_sampling: PupilSampling::ChiefRay,
+        };
+        approx::assert_abs_diff_eq!(f.tangential_fan_phi(), FRAC_PI_2, epsilon = 1e-10);
+
+        // phi = 0 → R/XZ plane
+        let f = FieldSpec::Angle {
+            chi: 5.0,
+            phi: 0.0,
+            pupil_sampling: PupilSampling::ChiefRay,
+        };
+        approx::assert_abs_diff_eq!(f.tangential_fan_phi(), 0.0, epsilon = 1e-10);
+
+        // phi = 45° → diagonal
+        let f = FieldSpec::Angle {
+            chi: 5.0,
+            phi: 45.0,
+            pupil_sampling: PupilSampling::ChiefRay,
+        };
+        approx::assert_abs_diff_eq!(f.tangential_fan_phi(), PI / 4.0, epsilon = 1e-10);
+
+        // negative chi: fan phi is still just phi in radians (sign of chi doesn't flip
+        // phi)
+        let f = FieldSpec::Angle {
+            chi: -5.0,
+            phi: 90.0,
+            pupil_sampling: PupilSampling::ChiefRay,
+        };
+        approx::assert_abs_diff_eq!(f.tangential_fan_phi(), FRAC_PI_2, epsilon = 1e-10);
+
+        // sagittal is tangential + π/2
+        let f = FieldSpec::Angle {
+            chi: 5.0,
+            phi: 90.0,
+            pupil_sampling: PupilSampling::ChiefRay,
+        };
+        approx::assert_abs_diff_eq!(f.sagittal_fan_phi(), FRAC_PI_2 + FRAC_PI_2, epsilon = 1e-10);
+
+        // PointSource: atan2(y, x)
+        let f = FieldSpec::PointSource {
+            x: 0.0,
+            y: 1.0,
+            pupil_sampling: PupilSampling::ChiefRay,
+        };
+        approx::assert_abs_diff_eq!(f.tangential_fan_phi(), FRAC_PI_2, epsilon = 1e-10);
+
+        let f = FieldSpec::PointSource {
+            x: 1.0,
+            y: 0.0,
+            pupil_sampling: PupilSampling::ChiefRay,
+        };
+        approx::assert_abs_diff_eq!(f.tangential_fan_phi(), 0.0, epsilon = 1e-10);
+
+        // PointSource at origin: fallback to π/2 (U/YZ plane)
+        let f = FieldSpec::PointSource {
+            x: 0.0,
+            y: 0.0,
+            pupil_sampling: PupilSampling::ChiefRay,
+        };
+        approx::assert_abs_diff_eq!(f.tangential_fan_phi(), FRAC_PI_2, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_field_spec_angle_chi_phi_validate() {
+        // valid: chi=5° off-axis, phi=90° (U/YZ direction)
+        assert!(
+            FieldSpec::Angle {
+                chi: 5.0,
+                phi: 90.0,
+                pupil_sampling: PupilSampling::SquareGrid { spacing: 0.1 },
+            }
+            .validate()
+            .is_ok()
+        );
+
+        // chi out of range (+): polar angle > 90° is not allowed
+        assert!(
+            FieldSpec::Angle {
+                chi: 95.0,
+                phi: 90.0,
+                pupil_sampling: PupilSampling::SquareGrid { spacing: 0.1 },
+            }
+            .validate()
+            .is_err()
+        );
+
+        // chi out of range (-): polar angle < -90° is not allowed
+        assert!(
+            FieldSpec::Angle {
+                chi: -91.0,
+                phi: 90.0,
+                pupil_sampling: PupilSampling::SquareGrid { spacing: 0.1 },
+            }
+            .validate()
+            .is_err()
+        );
+
+        // negative chi is valid: field on the opposite side of the phi direction
+        assert!(
+            FieldSpec::Angle {
+                chi: -5.0,
+                phi: 90.0,
+                pupil_sampling: PupilSampling::SquareGrid { spacing: 0.1 },
+            }
+            .validate()
+            .is_ok()
+        );
+
+        // phi = 180° is valid (upper bound is inclusive)
+        assert!(
+            FieldSpec::Angle {
+                chi: 0.0,
+                phi: 180.0,
+                pupil_sampling: PupilSampling::SquareGrid { spacing: 0.1 },
+            }
+            .validate()
+            .is_ok()
+        );
+
+        // phi = -180° is invalid (lower bound is exclusive: range is (-180, 180])
+        assert!(
+            FieldSpec::Angle {
+                chi: 0.0,
+                phi: -180.0,
+                pupil_sampling: PupilSampling::SquareGrid { spacing: 0.1 },
+            }
+            .validate()
+            .is_err()
+        );
+
+        // chi NaN
+        assert!(
+            FieldSpec::Angle {
+                chi: Float::NAN,
+                phi: 90.0,
+                pupil_sampling: PupilSampling::SquareGrid { spacing: 0.1 },
+            }
+            .validate()
+            .is_err()
+        );
+
+        // phi NaN
+        assert!(
+            FieldSpec::Angle {
+                chi: 5.0,
+                phi: Float::NAN,
+                pupil_sampling: PupilSampling::SquareGrid { spacing: 0.1 },
+            }
+            .validate()
+            .is_err()
+        );
     }
 }

--- a/crates/cherry-rs/src/views/cross_section.rs
+++ b/crates/cherry-rs/src/views/cross_section.rs
@@ -3,7 +3,7 @@
 use std::collections::HashSet;
 
 use crate::{
-    Axis, SequentialModel,
+    SequentialModel,
     core::{Float, math::vec3::Vec3, sequential_model::Surface},
     views::{components::Component, ray_trace_3d::TraceResultsCollection},
 };
@@ -216,11 +216,7 @@ fn build_plane_geometry(
     let mut ray_paths: Vec<Vec<Vec<[f64; 2]>>> = vec![Vec::new(); n_wavelengths];
 
     if let Some(tc) = trace {
-        let trace_axis = match axis {
-            GlobalAxis::Y => Axis::U,
-            GlobalAxis::X => Axis::R,
-        };
-        for result in tc.get_by_axis(trace_axis) {
+        for result in tc.iter() {
             let wl_id = result.wavelength_id();
             if wl_id >= n_wavelengths {
                 continue;
@@ -407,6 +403,40 @@ mod tests {
             // Just ensure we got points back
         }
         assert_eq!(pts.len(), 10);
+    }
+
+    #[test]
+    fn xz_rays_come_from_u_axis_results() {
+        // After removing axis-based filtering, a TangentialRayFan trace (which
+        // produces Axis::U results) should contribute ray paths to the XZ plane
+        // cross-section via projection, not just the YZ plane.
+        use crate::{
+            ApertureSpec, FieldSpec, ParaxialView, specs::fields::PupilSampling,
+            views::ray_trace_3d::ray_trace_3d_view,
+        };
+        let air = n!(1.0);
+        let nbk7 = n!(1.515);
+        let wavelengths: [Float; 1] = [0.5876];
+        let model = convexplano_lens::sequential_model(air.clone(), nbk7, &wavelengths);
+        // phi=90° places the tangential fan in the YZ plane (Axis::U results).
+        let fields = vec![FieldSpec::Angle {
+            chi: 0.0,
+            phi: 90.0,
+            pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
+        }];
+        let aperture = ApertureSpec::EntrancePupil {
+            semi_diameter: 12.5,
+        };
+        let pv = ParaxialView::new(&model, &fields, false).unwrap();
+        let sampling = Some(PupilSampling::TangentialRayFan { n: 5 });
+        let trace = ray_trace_3d_view(&aperture, &fields, &model, &pv, sampling).unwrap();
+        let components = components_view(&model, air).unwrap();
+        let cs = cross_section_view(&model, Some(&trace), &components);
+        // XZ plane should have ray paths from the U-axis trace projected onto X.
+        assert!(
+            !cs.xz.ray_paths.iter().all(|w| w.is_empty()),
+            "XZ plane should have ray paths from trace projection"
+        );
     }
 
     #[test]

--- a/crates/cherry-rs/src/views/paraxial.rs
+++ b/crates/cherry-rs/src/views/paraxial.rs
@@ -179,10 +179,11 @@ fn max_field(obj_pupil_separation: Float, field_specs: &[FieldSpec]) -> (Float, 
     for field_spec in field_specs {
         let (height, paraxial_angle) = match field_spec {
             FieldSpec::Angle {
-                angle,
+                chi,
+                phi: _,
                 pupil_sampling: _,
             } => {
-                let paraxial_angle = angle.to_radians().tan();
+                let paraxial_angle = chi.to_radians().tan();
                 let height = -obj_pupil_separation * paraxial_angle;
                 (height, paraxial_angle)
             }
@@ -983,11 +984,13 @@ mod test {
             .expect("Submodel not found.");
         let field_specs = vec![
             FieldSpec::Angle {
-                angle: 0.0,
+                chi: 0.0,
+                phi: 90.0,
                 pupil_sampling: crate::PupilSampling::SquareGrid { spacing: 0.1 },
             },
             FieldSpec::Angle {
-                angle: 5.0,
+                chi: 5.0,
+                phi: 90.0,
                 pupil_sampling: crate::PupilSampling::SquareGrid { spacing: 0.1 },
             },
         ];

--- a/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
@@ -92,14 +92,9 @@ pub fn ray_trace_3d_view(
 ) -> Result<TraceResultsCollection> {
     validate_field_specs(sequential_model, field_specs)?;
 
-    // When the sampling override is a TangentialRayFan, trace only along its
-    // axis. This lets the caller request YZ and XZ fans independently.
-    // For rotationally symmetric systems (Axis::U submodels only), fall back
-    // to the Y submodel when the requested axis has no submodel.
-    let axes: Vec<Axis> = match pupil_sampling {
-        Some(PupilSampling::TangentialRayFan { axis, .. }) => vec![axis],
-        _ => sequential_model.axes(),
-    };
+    // Trace over all model axes. The tangential fan orientation is determined
+    // per-field via FieldSpec::tangential_fan_phi(), not by an axis override.
+    let axes: Vec<Axis> = sequential_model.axes();
 
     let combinations = all_combinations(field_specs, sequential_model.wavelengths(), &axes);
 
@@ -199,6 +194,11 @@ impl TraceResultsCollection {
         self.results.extend(other.results);
     }
 
+    /// Returns an iterator over all results in the collection.
+    pub fn iter(&self) -> impl Iterator<Item = &TraceResults> {
+        self.results.iter()
+    }
+
     /// Returns whether the collection is empty.
     pub fn is_empty(&self) -> bool {
         self.results.is_empty()
@@ -277,10 +277,12 @@ fn rays(
 ) -> Result<Vec<Ray>> {
     let rays: Vec<Ray> = match field_spec {
         FieldSpec::Angle {
-            angle,
+            chi,
+            phi,
             pupil_sampling,
         } => {
-            let angle = angle.to_radians();
+            let chi_rad = chi.to_radians();
+            let phi_rad = phi.to_radians();
 
             let pupil_sampling = match sampling {
                 Some(sampling) => sampling,
@@ -292,22 +294,26 @@ fn rays(
                     surfaces,
                     aperture_spec,
                     paraxial_subview,
-                    PI / 2.0,
-                    angle,
+                    phi_rad,
+                    chi_rad,
                 )?,
                 PupilSampling::SquareGrid { spacing } => parallel_ray_bundle_on_sq_grid(
                     surfaces,
                     aperture_spec,
                     paraxial_subview,
                     spacing,
-                    angle,
+                    chi_rad,
                 )?,
-                PupilSampling::TangentialRayFan { n, axis } => {
-                    let theta = match axis {
-                        Axis::U => PI / 2.0,
-                        Axis::R => 0.0,
-                    };
-                    parallel_ray_fan(surfaces, aperture_spec, paraxial_subview, n, theta, angle)?
+                PupilSampling::TangentialRayFan { n } => {
+                    let fan_phi = field_spec.tangential_fan_phi();
+                    parallel_ray_fan(
+                        surfaces,
+                        aperture_spec,
+                        paraxial_subview,
+                        n,
+                        fan_phi,
+                        chi_rad,
+                    )?
                 }
             }
         }
@@ -344,16 +350,9 @@ fn rays(
                     spacing,
                     &origin,
                 )?,
-                PupilSampling::TangentialRayFan { n, axis } => {
-                    let theta = if *y == 0.0 && *x == 0.0 {
-                        match axis {
-                            Axis::U => PI / 2.0,
-                            Axis::R => 0.0,
-                        }
-                    } else {
-                        y.atan2(*x)
-                    };
-                    point_source_ray_fan(aperture_spec, paraxial_subview, n, theta, &origin)?
+                PupilSampling::TangentialRayFan { n } => {
+                    let fan_phi = field_spec.tangential_fan_phi();
+                    point_source_ray_fan(aperture_spec, paraxial_subview, n, fan_phi, &origin)?
                 }
             }
         }
@@ -569,9 +568,9 @@ fn validate_field_specs(
 ) -> Result<()> {
     for field_spec in field_specs {
         match field_spec {
-            FieldSpec::Angle { angle, .. } => {
-                if !angle.is_finite() {
-                    return Err(anyhow!("Field angle must be finite"));
+            FieldSpec::Angle { chi, .. } => {
+                if !chi.is_finite() {
+                    return Err(anyhow!("Field chi must be finite"));
                 }
             }
             FieldSpec::PointSource { .. } => {
@@ -709,18 +708,14 @@ mod tests {
         };
         let field_specs = vec![
             FieldSpec::Angle {
-                angle: 0.0,
-                pupil_sampling: PupilSampling::TangentialRayFan {
-                    n: 3,
-                    axis: Axis::U,
-                },
+                chi: 0.0,
+                phi: 90.0,
+                pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
             },
             FieldSpec::Angle {
-                angle: 5.0,
-                pupil_sampling: PupilSampling::TangentialRayFan {
-                    n: 3,
-                    axis: Axis::U,
-                },
+                chi: 5.0,
+                phi: 90.0,
+                pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
             },
         ];
 
@@ -774,10 +769,7 @@ mod tests {
         let field_spec = FieldSpec::PointSource {
             x: 0.0,
             y: 0.0,
-            pupil_sampling: PupilSampling::TangentialRayFan {
-                n: 3,
-                axis: Axis::U,
-            },
+            pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
         };
 
         let result = rays(
@@ -968,11 +960,9 @@ mod tests {
         let s = setup();
 
         let field_specs = vec![FieldSpec::Angle {
-            angle: 0.0,
-            pupil_sampling: PupilSampling::TangentialRayFan {
-                n: 3,
-                axis: Axis::U,
-            },
+            chi: 0.0,
+            phi: 90.0,
+            pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
         }];
 
         let result = validate_field_specs(&s.sequential_model, &field_specs);
@@ -985,10 +975,7 @@ mod tests {
         let field_specs = vec![FieldSpec::PointSource {
             x: 0.0,
             y: 0.0,
-            pupil_sampling: PupilSampling::TangentialRayFan {
-                n: 3,
-                axis: Axis::U,
-            },
+            pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
         }];
 
         let result = validate_field_specs(&s.sequential_model, &field_specs);
@@ -1003,18 +990,14 @@ mod tests {
     fn test_all_combinations() {
         let field_specs = vec![
             FieldSpec::Angle {
-                angle: 0.0,
-                pupil_sampling: PupilSampling::TangentialRayFan {
-                    n: 3,
-                    axis: Axis::U,
-                },
+                chi: 0.0,
+                phi: 90.0,
+                pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
             },
             FieldSpec::Angle {
-                angle: 5.0,
-                pupil_sampling: PupilSampling::TangentialRayFan {
-                    n: 3,
-                    axis: Axis::U,
-                },
+                chi: 5.0,
+                phi: 90.0,
+                pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
             },
         ];
 
@@ -1036,5 +1019,45 @@ mod tests {
         assert!(combinations.contains(&(1, 1, Axis::U)));
         assert!(combinations.contains(&(1, 2, Axis::R)));
         assert!(combinations.contains(&(1, 2, Axis::U)));
+    }
+
+    /// A tangential fan at phi=45° should produce rays whose pupil positions
+    /// are spread along the (1,1)/√2 diagonal, not along the Y or X axis.
+    #[test]
+    fn test_diagonal_tangential_fan_orientation() {
+        let s = setup();
+
+        let field_spec = FieldSpec::Angle {
+            chi: 5.0,
+            phi: 45.0, // diagonal: fan should run along (1,1)/√2
+            pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
+        };
+
+        let generated = rays(
+            s.sequential_model.surfaces(),
+            &s.aperture_spec,
+            s.paraxial_view
+                .subviews()
+                .get(&SubModelID(0, Axis::U))
+                .unwrap(),
+            &field_spec,
+            None,
+        )
+        .expect("rays should be generated for diagonal field");
+
+        assert_eq!(generated.len(), 3);
+
+        // The three fan rays should be spread along the (1,1)/√2 direction.
+        // That means x and y offsets from the center ray should be equal in magnitude.
+        // Chief ray is the middle ray of the fan (index 1 of 3)
+        let center_x = generated[1].x();
+        let center_y = generated[1].y();
+        let outer_x = generated[2].x();
+        let outer_y = generated[2].y();
+        let dx = outer_x - center_x;
+        let dy = outer_y - center_y;
+
+        // For a 45° fan, dy/dx should equal tan(45°) = 1.0
+        approx::assert_abs_diff_eq!(dy / dx, 1.0, epsilon = 1e-6);
     }
 }

--- a/crates/cherry-rs/tests/biconvex_lens_finite_object.rs
+++ b/crates/cherry-rs/tests/biconvex_lens_finite_object.rs
@@ -10,18 +10,12 @@ const FIELD_SPECS: [FieldSpec; 2] = [
     FieldSpec::PointSource {
         x: 0.0,
         y: 0.0,
-        pupil_sampling: PupilSampling::TangentialRayFan {
-            n: 3,
-            axis: cherry_rs::Axis::U,
-        },
+        pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
     },
     FieldSpec::PointSource {
         x: 0.0,
         y: 5.0,
-        pupil_sampling: PupilSampling::TangentialRayFan {
-            n: 3,
-            axis: cherry_rs::Axis::U,
-        },
+        pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
     },
 ];
 

--- a/crates/cherry-rs/tests/concave_mirror.rs
+++ b/crates/cherry-rs/tests/concave_mirror.rs
@@ -7,18 +7,14 @@ use ndarray::{Array3, arr3};
 const WAVELENGTHS: [f64; 1] = [0.5876]; // He d line
 const FIELD_SPECS: [FieldSpec; 2] = [
     FieldSpec::Angle {
-        angle: 0.0,
-        pupil_sampling: PupilSampling::TangentialRayFan {
-            n: 3,
-            axis: cherry_rs::Axis::U,
-        },
+        chi: 0.0,
+        phi: 90.0,
+        pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
     },
     FieldSpec::Angle {
-        angle: 5.0,
-        pupil_sampling: PupilSampling::TangentialRayFan {
-            n: 3,
-            axis: cherry_rs::Axis::U,
-        },
+        chi: 5.0,
+        phi: 90.0,
+        pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
     },
 ];
 

--- a/crates/cherry-rs/tests/convexplano_lens_materials.rs
+++ b/crates/cherry-rs/tests/convexplano_lens_materials.rs
@@ -27,18 +27,14 @@ mod test_ri_info {
     const WAVELENGTHS: [f64; 3] = [0.4861, 0.5876, 0.6563]; // Fraunhofer F, d, and C lines
     const FIELD_SPECS: [FieldSpec; 2] = [
         FieldSpec::Angle {
-            angle: 0.0,
-            pupil_sampling: PupilSampling::TangentialRayFan {
-                n: 3,
-                axis: cherry_rs::Axis::U,
-            },
+            chi: 0.0,
+            phi: 90.0,
+            pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
         },
         FieldSpec::Angle {
-            angle: 5.0,
-            pupil_sampling: PupilSampling::TangentialRayFan {
-                n: 3,
-                axis: cherry_rs::Axis::U,
-            },
+            chi: 5.0,
+            phi: 90.0,
+            pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
         },
     ];
 

--- a/crates/cherry-rs/tests/convexplano_lens_ri.rs
+++ b/crates/cherry-rs/tests/convexplano_lens_ri.rs
@@ -7,18 +7,14 @@ use ndarray::{Array3, arr3};
 const WAVELENGTHS: [f64; 1] = [0.5876]; // He d line
 const FIELD_SPECS: [FieldSpec; 2] = [
     FieldSpec::Angle {
-        angle: 0.0,
-        pupil_sampling: PupilSampling::TangentialRayFan {
-            n: 3,
-            axis: cherry_rs::Axis::U,
-        },
+        chi: 0.0,
+        phi: 90.0,
+        pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
     },
     FieldSpec::Angle {
-        angle: 5.0,
-        pupil_sampling: PupilSampling::TangentialRayFan {
-            n: 3,
-            axis: cherry_rs::Axis::U,
-        },
+        chi: 5.0,
+        phi: 90.0,
+        pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
     },
 ];
 

--- a/crates/cherry-rs/tests/f_theta_scan_lens.rs
+++ b/crates/cherry-rs/tests/f_theta_scan_lens.rs
@@ -1,5 +1,5 @@
 use cherry_rs::examples::f_theta_scan_lens::{field_specs, sequential_model};
-use cherry_rs::{ApertureSpec, Axis, FieldSpec, ParaxialView, PupilSampling, n, ray_trace_3d_view};
+use cherry_rs::{ApertureSpec, FieldSpec, ParaxialView, PupilSampling, n, ray_trace_3d_view};
 
 const WAVELENGTHS: [f64; 1] = [0.5876]; // He d line
 
@@ -43,25 +43,19 @@ fn test_ray_trace_3d_off_axis() {
 
     let off_axis_fields = vec![
         FieldSpec::Angle {
-            angle: 5.0,
-            pupil_sampling: PupilSampling::TangentialRayFan {
-                n: 9,
-                axis: Axis::U,
-            },
+            chi: 5.0,
+            phi: 90.0,
+            pupil_sampling: PupilSampling::TangentialRayFan { n: 9 },
         },
         FieldSpec::Angle {
-            angle: 10.0,
-            pupil_sampling: PupilSampling::TangentialRayFan {
-                n: 9,
-                axis: Axis::U,
-            },
+            chi: 10.0,
+            phi: 90.0,
+            pupil_sampling: PupilSampling::TangentialRayFan { n: 9 },
         },
         FieldSpec::Angle {
-            angle: 20.0,
-            pupil_sampling: PupilSampling::TangentialRayFan {
-                n: 9,
-                axis: Axis::U,
-            },
+            chi: 20.0,
+            phi: 90.0,
+            pupil_sampling: PupilSampling::TangentialRayFan { n: 9 },
         },
     ];
 
@@ -83,7 +77,8 @@ fn test_ray_trace_3d_square_grid() {
     let (model, aperture_spec, _, paraxial_view) = setup();
 
     let fields = vec![FieldSpec::Angle {
-        angle: 10.0,
+        chi: 10.0,
+        phi: 90.0,
         pupil_sampling: PupilSampling::SquareGrid { spacing: 0.5 },
     }];
 

--- a/crates/cherry-rs/tests/mirrors_figure_z.rs
+++ b/crates/cherry-rs/tests/mirrors_figure_z.rs
@@ -3,11 +3,9 @@ use cherry_rs::{Axis, FieldSpec, ParaxialView, PupilSampling, examples::mirrors_
 
 const WAVELENGTHS: [f64; 1] = [0.5876];
 const FIELD_SPECS: [FieldSpec; 1] = [FieldSpec::Angle {
-    angle: 0.0,
-    pupil_sampling: PupilSampling::TangentialRayFan {
-        n: 3,
-        axis: cherry_rs::Axis::U,
-    },
+    chi: 0.0,
+    phi: 90.0,
+    pupil_sampling: PupilSampling::TangentialRayFan { n: 3 },
 }];
 
 // Aperture stop is the first mirror (surface 1, track = 0).


### PR DESCRIPTION
This is a precursor to implementing transverse ray aberration plots, a.k.a. ray fans.

The user now can specify the angle in spherical coordinates of a `FieldSpec::Angle`, which allows 3D angle specifications instead of forcing the angle to the YZ plane as was done previously.

Since the entrance pupil can vary in size between R and U axes in folded systems, I now interpolate pupil diameter based on the azimuth angle of the incident ray fan.

When drawing rays in the cross section view, tangential ray fans w.r.t. to the FieldSpec are now always plotted. We no longer make accommodation for which cutting plane is in use. The effect is that ray fans can now be seen with perspective. In the extreme case, they appear as a line because they lie perpendicular to the cutting plane.

This change will make it easier to implement transverse ray aberration plots because the tangential ray fan orientation is now fully defined by the FieldSpec, even if the system is not rotationally symmetric; there's no need to assume it's in the YZ plane.

Notation:

- phi: azimuth (when in spherical coordinates; this is rotation about z/F in Cartesian)
- chi: zenith