### PR TITLE
feat: Add Rayon to parallelize over ray bundles

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -756,7 +756,9 @@ dependencies = [
  "egui_kittest",
  "env_logger",
  "gloo-net",
+ "js-sys",
  "log",
+ "rayon",
  "rfd",
  "ria",
  "serde",
@@ -765,6 +767,7 @@ dependencies = [
  "tracing-subscriber",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-rayon",
  "wasm_thread",
 ]
 
@@ -976,6 +979,15 @@ checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
  "itertools",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2971,6 +2983,7 @@ checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
+ "wasm_sync",
 ]
 
 [[package]]
@@ -2981,6 +2994,7 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+ "wasm_sync",
 ]
 
 [[package]]
@@ -3846,6 +3860,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-rayon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a16c60a56c81e4dc3b9c43d76ba5633e1c0278211d59a9cb07d61b6cd1c6583"
+dependencies = [
+ "crossbeam-channel",
+ "js-sys",
+ "rayon",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-shared"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3874,6 +3900,17 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm_sync"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff360cade7fec41ff0e9d2cda57fe58258c5f16def0e21302394659e6bbb0ea"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/cherry-rs/Cargo.toml
+++ b/crates/cherry-rs/Cargo.toml
@@ -26,6 +26,7 @@ ri-info = [ "dep:ria", "dep:bitcode", "dep:serde_json" ]
 
 [dependencies]
 anyhow = "1.0"
+rayon = "1"
 serde = { version = "1", features = [ "derive" ] }
 tracing = "0.1"
 
@@ -55,7 +56,9 @@ eframe = { version = "0.32", default-features = false, optional = true, features
 
 # WASM-only
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3"
 wasm-bindgen = "0.2"
+wasm-bindgen-rayon = { version = "1", features = ["no-bundler"] }
 wasm_thread = "0.3"
 gloo-net = { version = "0.6", features = ["http"] }
 wasm-bindgen-futures = "0.4"

--- a/crates/cherry-rs/src/bin/cherry.rs
+++ b/crates/cherry-rs/src/bin/cherry.rs
@@ -33,6 +33,34 @@ pub async fn wasm_start() {
 
     use eframe::web_sys;
     use wasm_bindgen::JsCast;
+
+    // SharedArrayBuffer requires cross-origin isolation (COOP + COEP headers).
+    // If it is absent, threading cannot work at all — show a clear message
+    // rather than panicking silently.
+    let shared_array_buffer = js_sys::Reflect::get(
+        &js_sys::global(),
+        &wasm_bindgen::JsValue::from_str("SharedArrayBuffer"),
+    )
+    .unwrap_or(wasm_bindgen::JsValue::UNDEFINED);
+
+    if shared_array_buffer.is_undefined() {
+        let document = web_sys::window().unwrap().document().unwrap();
+        let body = document.body().unwrap();
+        let div = document.create_element("div").unwrap();
+        div.set_attribute(
+            "style",
+            "font-family: sans-serif; padding: 2em; color: #c00;",
+        )
+        .unwrap();
+        div.set_text_content(Some(
+            "Cherry requires SharedArrayBuffer, which is only available in \
+             cross-origin isolated contexts. Please ensure the page is served \
+             with the required COOP and COEP headers.",
+        ));
+        body.append_child(&div).unwrap();
+        return;
+    }
+
     let canvas = web_sys::window()
         .unwrap()
         .document()
@@ -41,6 +69,15 @@ pub async fn wasm_start() {
         .unwrap()
         .dyn_into::<web_sys::HtmlCanvasElement>()
         .unwrap();
+
+    wasm_bindgen_futures::JsFuture::from(wasm_bindgen_rayon::init_thread_pool(
+        web_sys::window()
+            .unwrap()
+            .navigator()
+            .hardware_concurrency() as usize,
+    ))
+    .await
+    .expect("failed to initialize rayon thread pool");
 
     eframe::WebRunner::new()
         .start(

--- a/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
@@ -3,8 +3,9 @@ mod rays;
 mod trace;
 
 use anyhow::{Result, anyhow};
+use rayon::prelude::*;
 use serde::Serialize;
-use tracing::{trace, trace_span};
+use tracing::trace;
 
 use crate::{
     Axis, Pupil,
@@ -25,15 +26,6 @@ pub use rays::Ray;
 pub use trace::RayBundle;
 
 use super::paraxial::{ParaxialSubView, ParaxialView};
-
-/// The default capacity for the results collection.
-///
-/// Increase this to avoid reallocations if you expect to have more results. The
-/// tradeoff is larger memory usage.
-///
-/// Its current value was derived from: 3 wavelengths * 3 fields * 2 (for
-/// overhead).
-const RESULTS_CAPACITY: usize = 18;
 
 /// Configuration for the pupil sampling used in a 3D ray trace.
 #[derive(Debug, Clone, Copy)]
@@ -112,12 +104,14 @@ pub fn ray_trace_3d_view(
     // Use Axis::U as the canonical submodel for all field/wavelength combinations.
     // For rotationally symmetric systems only Axis::U exists; for non-symmetric
     // systems this is the fallback that is always present.
-    let mut results: Vec<TraceResults> = Vec::with_capacity(RESULTS_CAPACITY);
+    let n_wavelengths = sequential_model.wavelengths().len();
+    let pairs: Vec<(usize, usize)> = (0..field_specs.len())
+        .flat_map(|f| (0..n_wavelengths).map(move |w| (f, w)))
+        .collect();
 
-    for (field_id, _) in field_specs.iter().enumerate() {
-        for (wavelength_id, _) in sequential_model.wavelengths().iter().enumerate() {
-            let _trace_bundle_span = trace_span!("trace_bundle", field_id, wavelength_id).entered();
-
+    let results: Vec<TraceResults> = pairs
+        .into_par_iter()
+        .map(|(field_id, wavelength_id)| -> Result<TraceResults> {
             tracing::trace!(
                 "Tracing rays for field_id={}, wavelength_id={}",
                 field_id,
@@ -176,16 +170,6 @@ pub fn ray_trace_3d_view(
                 },
             )?;
 
-            results.push(TraceResults {
-                wavelength_id,
-                field_id,
-                axis: Axis::U,
-                chief_ray,
-                full_pupil,
-                tangential_fan,
-                sagittal_fan,
-            });
-
             trace!(
                 field_id,
                 wavelength_id,
@@ -193,8 +177,18 @@ pub fn ray_trace_3d_view(
                 field_id,
                 wavelength_id
             );
-        }
-    }
+
+            Ok(TraceResults {
+                wavelength_id,
+                field_id,
+                axis: Axis::U,
+                chief_ray,
+                full_pupil,
+                tangential_fan,
+                sagittal_fan,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
 
     Ok(TraceResultsCollection::new(results))
 }

--- a/justfile
+++ b/justfile
@@ -1,14 +1,23 @@
 set working-directory := "crates"
 
+alias b := bench-all
+alias c := ci
 alias f := fmt
 alias g := gui
 alias l := lint
 alias s := serve
-alias t := test
+alias t := test-all
 
-[doc("Run a benchmark test. Example: 'just bench f_theta_scan_lens'")]
+[doc("Run a specific benchmark test. Example: 'just bench f_theta_scan_lens'")]
 bench bench_name:
   cargo bench --bench {{bench_name}}
+
+[doc("Run all benchmark tests")]
+bench-all:
+  cargo bench
+
+[doc("Run all CI-level checks")]
+ci: fmt lint test-all
 
 [doc("Launches the desktop GUI")]
 gui:
@@ -31,7 +40,7 @@ list-tests:
 serve:
   trunk serve
 
-test:
+test-all:
   cargo test --all-features --all-targets
 
 [doc("Run an integration test with tracing. Filter example: '[{ray_id=0}]=trace'")]


### PR DESCRIPTION
This adds Rayon to both the desktop and WASM apps to parallelize ray tracing over ray bundles. It resulted in a 10% speed improvement in the convexplano lens bench, but negligible improvement in the f_theta_scan_lens. The ray fans in the second example are quite small, which likely explains why improvement is negligible.

I tried parallelizing the inner loop over rays, but rayon's overhead resulted in a net performance decrease. Individual rays take nanoseconds to trace; we'd need to trace hundreds of thousands or more to see any benefit at this level. But this number of rays is usually traced for non-sequential ray tracers. Cherry is a sequential ray tracer.

I also added an error message to the WASM app to politely inform the user if SharedArrayBuffer is not supported.