### PR TITLE
refactor: Remove Axis enum so that FieldSpecs define tangential planes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Optical system design in the browser
 
-*This is alpha software. Emphasis is currently placed on feature development, not on fixing bugs or on improving code quality.*
+*This software has not yet stabilized. Do not expect backwards compatibility with previously-saved designs.*
 
 ## Quickstart
 
@@ -43,6 +43,6 @@ trunk serve
 
 ## License
 
-Copyright (c) 2024-2026, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE, Switzerland, Laboratory of Experimental Biophysics (LEB)
+Copyright (c) 2024-2026, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE, Switzerland, Laboratory of Experimental Biophysics (LEB).
 
 The cherry-rs library is licensed under the [GNU Lesser General Public License v3.0 or later](LICENSE.txt) (LGPL-3.0-or-later). The compiled `cherry` GUI binary is licensed under the GNU General Public License v3.0 or later (GPL-3.0-or-later).

--- a/crates/cherry-rs/src/core/sequential_model.rs
+++ b/crates/cherry-rs/src/core/sequential_model.rs
@@ -4,7 +4,6 @@ use std::fmt::{Display, Formatter};
 use std::ops::Range;
 
 use anyhow::{Result, anyhow};
-use serde::{Deserialize, Serialize, Serializer};
 use tracing::trace;
 
 use crate::core::{
@@ -16,17 +15,6 @@ use crate::specs::{
     gaps::GapSpec,
     surfaces::{SurfaceSpec, SurfaceType},
 };
-
-/// The transverse direction along which system properties will be computed with
-/// respect to the cursor reference frame of the system.
-///
-/// `R` is the cursor-right (initially global X) direction; `U` is the
-/// cursor-up (initially global Y) direction.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum Axis {
-    R,
-    U,
-}
 
 /// A gap between two surfaces in a sequential system.
 #[derive(Debug)]
@@ -46,7 +34,7 @@ pub struct Gap {
 #[derive(Debug)]
 pub struct SequentialModel {
     surfaces: Vec<Surface>,
-    submodels: HashMap<SubModelID, SequentialSubModelBase>,
+    submodels: HashMap<usize, SequentialSubModelBase>,
     wavelengths: Vec<Float>,
     axis_directions: Vec<Vec3>,
 }
@@ -150,14 +138,6 @@ pub struct SequentialSubModelSlice<'a> {
     gaps: &'a [Gap],
 }
 
-/// A unique identifier for a submodel.
-///
-/// The first element is the index of the wavelength in the system's list of
-/// wavelengths. The second element is the transverse axis along which the model
-/// is computed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct SubModelID(pub usize, pub Axis);
-
 /// An iterator over the surfaces and gaps in a submodel.
 ///
 /// Most operations in sequential modeling involve use of this iterator.
@@ -248,6 +228,37 @@ pub struct Stop {
 //    surface_type: SurfaceType,
 //}
 
+/// Propagates a tangential direction unit vector through the mirror surfaces of
+/// a system using the vector law of reflection.
+///
+/// Returns one `Vec3` per surface (same indexing as `surfaces`). Each entry is
+/// the **incident** direction at that surface (before any reflection). At a
+/// reflecting surface the returned vector is the direction arriving at the
+/// surface; subsequent surfaces receive the post-reflection direction as their
+/// incident vector. The vector is expressed in global coordinates throughout.
+pub(crate) fn propagate_tangential_vec(v_init: Vec3, surfaces: &[Surface]) -> Vec<Vec3> {
+    use crate::specs::surfaces::SurfaceType;
+    let mut v = v_init;
+    surfaces
+        .iter()
+        .map(|surf| {
+            let v_incident = v;
+            if let SurfaceType::Reflecting = surf.surface_type() {
+                // Normal in global frame: third column of inv_rotation_matrix
+                // (maps local Z to global).
+                let n = surf.inv_rot_mat() * Vec3::new(0.0, 0.0, 1.0);
+                let dot = v.x() * n.x() + v.y() * n.y() + v.z() * n.z();
+                v = Vec3::new(
+                    v.x() - 2.0 * dot * n.x(),
+                    v.y() - 2.0 * dot * n.y(),
+                    v.z() - 2.0 * dot * n.z(),
+                );
+            }
+            v_incident
+        })
+        .collect()
+}
+
 /// Returns the index of the first physical surface in the system.
 /// This is the first surface that is not an object, image, or probe surface.
 /// If no such surface exists, then the function returns None.
@@ -336,13 +347,10 @@ impl SequentialModel {
 
         let (surfaces, axis_directions) = Self::surf_specs_to_surfs(surface_specs, gap_specs);
 
-        let model_ids: Vec<SubModelID> = Self::calc_model_ids(&surfaces, wavelengths);
-        let mut models: HashMap<SubModelID, SequentialSubModelBase> = HashMap::new();
-        for model_id in model_ids.iter() {
-            let wavelength = wavelengths[model_id.0];
+        let mut models: HashMap<usize, SequentialSubModelBase> = HashMap::new();
+        for (wav_idx, &wavelength) in wavelengths.iter().enumerate() {
             let gaps = Self::gap_specs_to_gaps(gap_specs, wavelength)?;
-            let model = SequentialSubModelBase::new(gaps);
-            models.insert(*model_id, model);
+            models.insert(wav_idx, SequentialSubModelBase::new(gaps));
         }
 
         Ok(Self {
@@ -351,22 +359,6 @@ impl SequentialModel {
             wavelengths: wavelengths.to_vec(),
             axis_directions,
         })
-    }
-
-    /// Returns the axes along which the system is modeled.
-    pub fn axes(&self) -> Vec<Axis> {
-        // Loop over submodel IDs and extract all axes
-        let mut axes = Vec::new();
-        for id in self.submodels.keys() {
-            // Avoid duplicates just in case
-            if axes.contains(&id.1) {
-                continue;
-            }
-
-            axes.push(id.1);
-        }
-
-        axes
     }
 
     /// Returns the largest semi-diameter of any surface in the system.
@@ -390,8 +382,13 @@ impl SequentialModel {
         &self.surfaces
     }
 
-    /// Returns the submodels in the system.
-    pub fn submodels(&self) -> &HashMap<SubModelID, impl SequentialSubModel + use<>> {
+    /// Returns the wavelength-indexed submodels of the system.
+    ///
+    /// Each entry is keyed by the wavelength index (0-based, matching the order
+    /// passed to `new`). Tangential-direction splitting is handled by
+    /// `ParaxialView`, which builds one paraxial subview per wavelength ×
+    /// tangential-vector combination.
+    pub fn submodels(&self) -> &HashMap<usize, impl SequentialSubModel + use<>> {
         &self.submodels
     }
 
@@ -405,25 +402,6 @@ impl SequentialModel {
         &self.axis_directions
     }
 
-    /// Computes the unique IDs for each paraxial model.
-    fn calc_model_ids(surfaces: &[Surface], wavelengths: &[Float]) -> Vec<SubModelID> {
-        let mut ids = Vec::new();
-
-        let axes: Vec<Axis> = if Self::is_rotationally_symmetric(surfaces) {
-            vec![Axis::U]
-        } else {
-            vec![Axis::R, Axis::U]
-        };
-
-        for (idx, _wavelength) in wavelengths.iter().enumerate() {
-            for axis in axes.iter() {
-                let id = SubModelID(idx, *axis);
-                ids.push(id);
-            }
-        }
-        ids
-    }
-
     fn gap_specs_to_gaps(gap_specs: &[GapSpec], wavelength: Float) -> Result<Vec<Gap>> {
         let mut gaps = Vec::new();
         for gap_spec in gap_specs.iter() {
@@ -435,7 +413,7 @@ impl SequentialModel {
 
     /// Returns true if the system is rotationally symmetric about the optical
     /// axis.
-    fn is_rotationally_symmetric(surfaces: &[Surface]) -> bool {
+    pub fn is_rotationally_symmetric(surfaces: &[Surface]) -> bool {
         !surfaces.iter().any(|surf| {
             let r_surf = match surf {
                 Surface::Conic(c) => {
@@ -550,26 +528,6 @@ impl SequentialSubModel for SequentialSubModelSlice<'_> {
 
     fn try_iter<'b>(&'b self, surfaces: &'b [Surface]) -> Result<SequentialSubModelIter<'b>> {
         SequentialSubModelIter::new(surfaces, self.gaps)
-    }
-}
-
-impl Serialize for SubModelID {
-    // Serialize as a string like "0:Y" because tuples as map keys are difficult to
-    // work with in languages like Javascript.
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        // Serialize as a string like "0:Y"
-        let key = format!(
-            "{}:{}",
-            self.0,
-            match self.1 {
-                Axis::R => "R",
-                Axis::U => "U",
-            }
-        );
-        serializer.serialize_str(&key)
     }
 }
 
@@ -795,11 +753,8 @@ impl Surface {
         r_transv > r_max * r_max
     }
 
-    pub(crate) fn roc(&self, axis: &Axis) -> Float {
-        match axis {
-            Axis::R => self.rocx(),
-            Axis::U => self.rocy(),
-        }
+    pub(crate) fn roc(&self) -> Float {
+        self.rocx()
     }
 
     /// The radius of curvature in the horizontal direction.
@@ -807,15 +762,6 @@ impl Surface {
         match self {
             Self::Conic(conic) => conic.radius_of_curvature,
             //Self::Toric(toric) => toric.radius_of_curvature_x,
-            _ => Float::INFINITY,
-        }
-    }
-
-    /// The radius of curvature in the vertical direction.
-    fn rocy(&self) -> Float {
-        match self {
-            Self::Conic(conic) => conic.radius_of_curvature,
-            //Self::Toric(toric) => toric.radius_of_curvature_y,
             _ => Float::INFINITY,
         }
     }
@@ -887,16 +833,19 @@ impl Surface {
     }
 
     /// Returns the semi-diameter of the surface as seen by a paraxial ray
-    /// traveling along the cursor axis in the given transverse direction.
+    /// traveling along the cursor axis in the tangential plane defined by `v`.
+    ///
+    /// `v` is a unit vector in the global frame that lies in the transverse
+    /// (R–U) plane and defines the meridional plane of interest (e.g.
+    /// `(1, 0, 0)` for the R/XZ plane, `(0, 1, 0)` for the U/YZ plane).
     ///
     /// For a tilted surface, the clear aperture radius `r` is in the surface's
     /// local plane.  A paraxial ray at cursor height `h` intersects the surface
     /// at a transverse distance larger than `h` by a foreshortening factor, so
-    /// the effective limit on cursor height is `r · |n_F| / sqrt(n_axis² +
-    /// n_F²)` where `(n_R, n_U, n_F)` are the surface-normal components in
-    /// the cursor frame and `n_axis` is the component along the queried
-    /// axis.
-    pub(crate) fn projected_semi_diameter(&self, axis: &Axis) -> Float {
+    /// the effective limit on cursor height is `r · |n_F| / sqrt(n_φ² + n_F²)`
+    /// where `(n_R, n_U, n_F)` are the surface-normal components in the cursor
+    /// frame and `n_φ = n_R · v_x + n_U · v_y` is the component along `v`.
+    pub(crate) fn projected_semi_diameter(&self, v: Vec3) -> Float {
         let (r, rotation_matrix, rotation_matrix_global_to_cursor) = match self {
             Self::Conic(c) => (
                 c.semi_diameter,
@@ -920,10 +869,9 @@ impl Surface {
         let n_u = r_surf.e[2][1];
         let n_f = r_surf.e[2][2];
 
-        let denom = match axis {
-            Axis::U => (n_u * n_u + n_f * n_f).sqrt(),
-            Axis::R => (n_r * n_r + n_f * n_f).sqrt(),
-        };
+        // Component of the surface normal along the tangential direction v.
+        let n_phi = n_r * v.x() + n_u * v.y();
+        let denom = (n_phi * n_phi + n_f * n_f).sqrt();
 
         if denom < 1e-12 {
             return 0.0;
@@ -957,10 +905,7 @@ impl Display for Surface {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        EulerAngles, Rotation3D, core::Float, examples::convexplano_lens::sequential_model, n,
-        specs::surfaces::SurfaceType,
-    };
+    use crate::{EulerAngles, Rotation3D, core::Float, n, specs::surfaces::SurfaceType};
 
     // Helper: build a Conic surface with the given semi-diameter and rotation spec
     // in an identity cursor frame.
@@ -986,15 +931,17 @@ mod tests {
         let r = 10.0;
         let surf = conic_with_rotation(r, Rotation3D::None);
         let tol = 1e-12;
+        let v_u = Vec3::new(0.0, 1.0, 0.0);
+        let v_r = Vec3::new(1.0, 0.0, 0.0);
         assert!(
-            (surf.projected_semi_diameter(&Axis::U) - r).abs() < tol,
+            (surf.projected_semi_diameter(v_u) - r).abs() < tol,
             "U axis: expected {r}, got {}",
-            surf.projected_semi_diameter(&Axis::U)
+            surf.projected_semi_diameter(v_u)
         );
         assert!(
-            (surf.projected_semi_diameter(&Axis::R) - r).abs() < tol,
+            (surf.projected_semi_diameter(v_r) - r).abs() < tol,
             "R axis: expected {r}, got {}",
-            surf.projected_semi_diameter(&Axis::R)
+            surf.projected_semi_diameter(v_r)
         );
     }
 
@@ -1008,16 +955,18 @@ mod tests {
             Rotation3D::IntrinsicPassiveRUF(EulerAngles(theta, 0.0, 0.0)),
         );
         let tol = 1e-10;
+        let v_u = Vec3::new(0.0, 1.0, 0.0);
+        let v_r = Vec3::new(1.0, 0.0, 0.0);
         assert!(
-            (surf.projected_semi_diameter(&Axis::U) - r * theta.cos()).abs() < tol,
+            (surf.projected_semi_diameter(v_u) - r * theta.cos()).abs() < tol,
             "U axis: expected {}, got {}",
             r * theta.cos(),
-            surf.projected_semi_diameter(&Axis::U)
+            surf.projected_semi_diameter(v_u)
         );
         assert!(
-            (surf.projected_semi_diameter(&Axis::R) - r).abs() < tol,
+            (surf.projected_semi_diameter(v_r) - r).abs() < tol,
             "R axis: expected {r}, got {}",
-            surf.projected_semi_diameter(&Axis::R)
+            surf.projected_semi_diameter(v_r)
         );
     }
 
@@ -1031,16 +980,18 @@ mod tests {
             Rotation3D::IntrinsicPassiveRUF(EulerAngles(0.0, psi, 0.0)),
         );
         let tol = 1e-10;
+        let v_u = Vec3::new(0.0, 1.0, 0.0);
+        let v_r = Vec3::new(1.0, 0.0, 0.0);
         assert!(
-            (surf.projected_semi_diameter(&Axis::R) - r * psi.cos()).abs() < tol,
+            (surf.projected_semi_diameter(v_r) - r * psi.cos()).abs() < tol,
             "R axis: expected {}, got {}",
             r * psi.cos(),
-            surf.projected_semi_diameter(&Axis::R)
+            surf.projected_semi_diameter(v_r)
         );
         assert!(
-            (surf.projected_semi_diameter(&Axis::U) - r).abs() < tol,
+            (surf.projected_semi_diameter(v_u) - r).abs() < tol,
             "U axis: expected {r}, got {}",
-            surf.projected_semi_diameter(&Axis::U)
+            surf.projected_semi_diameter(v_u)
         );
     }
 
@@ -1056,21 +1007,55 @@ mod tests {
         let r = 12.7_f64;
         let expected_u = r * (30.0_f64.to_radians()).cos();
         let tol = 1e-10;
+        let v_u = Vec3::new(0.0, 1.0, 0.0);
+        let v_r = Vec3::new(1.0, 0.0, 0.0);
 
         // Surface indices: 0 = Object, 1 = Mirror 1, 2 = Mirror 2, 3 = Image
         for &mirror_idx in &[1usize, 2usize] {
             let surf = &surfaces[mirror_idx];
             assert!(
-                (surf.projected_semi_diameter(&Axis::U) - expected_u).abs() < tol,
+                (surf.projected_semi_diameter(v_u) - expected_u).abs() < tol,
                 "Mirror {mirror_idx} U: expected {expected_u}, got {}",
-                surf.projected_semi_diameter(&Axis::U)
+                surf.projected_semi_diameter(v_u)
             );
             assert!(
-                (surf.projected_semi_diameter(&Axis::R) - r).abs() < tol,
+                (surf.projected_semi_diameter(v_r) - r).abs() < tol,
                 "Mirror {mirror_idx} R: expected {r}, got {}",
-                surf.projected_semi_diameter(&Axis::R)
+                surf.projected_semi_diameter(v_r)
             );
         }
+    }
+
+    /// Each entry in the result is the *incident* direction at that surface.
+    ///
+    /// Mirror normal in global frame (30° passive rotation about X):
+    ///   n = (0, −sin30°, cos30°) = (0, −0.5, √3/2)
+    ///
+    /// Incident at Mirror 1 (surface 1): v = v_init = (0, 1, 0)
+    /// Reflected by Mirror 1: v' = Y − 2(−0.5)·n = (0, 0.5, √3/2)
+    /// Incident at Mirror 2 (surface 2): v = (0, 0.5, √3/2)
+    #[test]
+    fn propagate_tangential_vec_through_fold() {
+        use crate::examples::mirrors_figure_z;
+        use approx::assert_abs_diff_eq;
+
+        let model = mirrors_figure_z::sequential_model(n!(1.0), &[0.5876]);
+        let surfaces = model.surfaces();
+        let v_init = Vec3::new(0.0, 1.0, 0.0); // phi = 90°
+
+        let vecs = propagate_tangential_vec(v_init, surfaces);
+
+        let sqrt3_over_2 = (3.0_f64 / 4.0_f64).sqrt();
+
+        // Incident at Mirror 1 (surface 1): unchanged from v_init
+        assert_abs_diff_eq!(vecs[1].x(), 0.0, epsilon = 1e-10);
+        assert_abs_diff_eq!(vecs[1].y(), 1.0, epsilon = 1e-10);
+        assert_abs_diff_eq!(vecs[1].z(), 0.0, epsilon = 1e-10);
+
+        // Incident at Mirror 2 (surface 2): reflected from Mirror 1 = (0, 0.5, √3/2)
+        assert_abs_diff_eq!(vecs[2].x(), 0.0, epsilon = 1e-10);
+        assert_abs_diff_eq!(vecs[2].y(), 0.5, epsilon = 1e-10);
+        assert_abs_diff_eq!(vecs[2].z(), sqrt3_over_2, epsilon = 1e-10);
     }
 
     #[test]
@@ -1113,32 +1098,6 @@ mod tests {
         assert!(!SequentialModel::is_rotationally_symmetric(
             figure_z.surfaces()
         ));
-    }
-
-    #[test]
-    fn test_calc_model_ids() {
-        let air = n!(1.0);
-        let nbk7 = n!(1.515);
-        let wavelengths: [Float; 2] = [0.4, 0.6];
-        let sequential_model = sequential_model(air, nbk7, &wavelengths);
-        let surfaces = sequential_model.surfaces();
-
-        let model_ids = SequentialModel::calc_model_ids(surfaces, &wavelengths);
-
-        assert_eq!(model_ids.len(), 2); // Two wavelengths, rotationally
-        // symmetric
-    }
-
-    #[test]
-    fn test_axes() {
-        let air = n!(1.0);
-        let nbk7 = n!(1.515);
-        let wavelengths: [Float; 1] = [0.5876];
-        let sequential_model = sequential_model(air, nbk7, &wavelengths);
-        let axes = sequential_model.axes();
-
-        assert_eq!(axes.len(), 1); // Rotationally symmetric
-        assert_eq!(axes[0], Axis::U);
     }
 
     #[test]

--- a/crates/cherry-rs/src/gui/windows/paraxial.rs
+++ b/crates/cherry-rs/src/gui/windows/paraxial.rs
@@ -1,9 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{
-    Axis, core::sequential_model::SubModelID, gui::result_package::ResultPackage,
-    views::paraxial::ParaxialSubView,
-};
+use crate::{SubModelID, gui::result_package::ResultPackage, views::paraxial::ParaxialSubView};
 
 /// Floating paraxial summary output window.
 pub struct ParaxialWindow;
@@ -34,46 +31,47 @@ fn render_paraxial_content(ui: &mut egui::Ui, r: &ResultPackage) {
     let pv = r.paraxial.as_ref().unwrap();
     let subviews = pv.subviews();
 
-    // Collect unique axes, sorted R before U.
-    let mut axes: Vec<Axis> = subviews.keys().map(|id| id.1).collect();
-    axes.sort_by_key(|a| if *a == Axis::R { 0u8 } else { 1 });
-    axes.dedup();
-    let n_axes = axes.len();
+    // Collect unique v_indices, sorted ascending (ascending phi).
+    let mut v_indices: Vec<usize> = subviews.keys().map(|id| id.1).collect();
+    v_indices.sort_unstable();
+    v_indices.dedup();
+    let n_v = v_indices.len();
 
-    for (i, axis) in axes.iter().enumerate() {
-        if n_axes > 1 {
+    for (i, &v_idx) in v_indices.iter().enumerate() {
+        if n_v > 1 {
             if i > 0 {
                 ui.separator();
             }
-            let label = if *axis == Axis::R { "R Axis" } else { "U Axis" };
-            ui.heading(label);
+            let phi_deg = pv.phi_deg(v_idx);
+            ui.heading(format!("\u{03c6} = {phi_deg:.0}\u{00b0}"));
         }
 
-        // Subview IDs for this axis, sorted by wavelength_id.
+        // Subview IDs for this v_index, sorted by wavelength_id.
         let mut ids: Vec<SubModelID> = subviews
             .keys()
-            .filter(|id| id.1 == *axis)
+            .filter(|id| id.1 == v_idx)
             .copied()
             .collect();
         ids.sort_by_key(|id| id.0);
 
-        render_axis_table(ui, r, &ids, subviews);
+        render_v_table(ui, r, v_idx, &ids, subviews);
         ui.add_space(8.0);
     }
 
     // Primary Axial Color (only when there are multiple wavelengths).
     if r.wavelengths.len() > 1 {
         let pac = pv.primary_axial_color();
-        for axis in &axes {
-            if let Some(&color) = pac.get(axis) {
-                let axis_suffix = if n_axes > 1 {
-                    format!(" ({})", if *axis == Axis::R { "R" } else { "U" })
+        for &v_idx in &v_indices {
+            if let Some(&color) = pac.get(&v_idx) {
+                let phi_suffix = if n_v > 1 {
+                    let phi_deg = pv.phi_deg(v_idx);
+                    format!(" (\u{03c6} = {phi_deg:.0}\u{00b0})")
                 } else {
                     String::new()
                 };
                 ui.label(format!(
                     "Primary Axial Color{}: {}",
-                    axis_suffix,
+                    phi_suffix,
                     format_value(color)
                 ));
             }
@@ -82,99 +80,96 @@ fn render_paraxial_content(ui: &mut egui::Ui, r: &ResultPackage) {
     }
 }
 
-fn render_axis_table(
+fn render_v_table(
     ui: &mut egui::Ui,
     r: &ResultPackage,
+    v_idx: usize,
     ids: &[SubModelID],
     subviews: &HashMap<SubModelID, ParaxialSubView>,
 ) {
     let n_wl = ids.len();
     let n_cols = 1 + n_wl;
 
-    egui::Grid::new(format!(
-        "paraxial_{}",
-        ids.first()
-            .map_or("empty", |id| { if id.1 == Axis::R { "r" } else { "u" } })
-    ))
-    .num_columns(n_cols)
-    .spacing([20.0, 4.0])
-    .show(ui, |ui| {
-        // Wavelength header row — only when there are multiple wavelengths.
-        if n_wl > 1 {
-            ui.label(""); // empty label cell
+    egui::Grid::new(format!("paraxial_{v_idx}"))
+        .num_columns(n_cols)
+        .spacing([20.0, 4.0])
+        .show(ui, |ui| {
+            // Wavelength header row — only when there are multiple wavelengths.
+            if n_wl > 1 {
+                ui.label(""); // empty label cell
+                for id in ids {
+                    let wl_label = r
+                        .wavelengths
+                        .get(id.0)
+                        .map(|wl| format!("{wl:.4} \u{00b5}m"))
+                        .unwrap_or_else(|| format!("WL {}", id.0));
+                    ui.label(wl_label);
+                }
+                ui.end_row();
+                // Separator row.
+                for _ in 0..n_cols {
+                    ui.separator();
+                }
+                ui.end_row();
+            }
+
+            multi_row(ui, "EFL", ids, subviews, |sv| *sv.effective_focal_length());
+            multi_row(ui, "BFD", ids, subviews, |sv| *sv.back_focal_distance());
+            multi_row(ui, "FFD", ids, subviews, |sv| *sv.front_focal_distance());
+
+            sep_row(ui, n_cols);
+
+            multi_row(
+                ui,
+                "Entrance pupil dist. from first surface",
+                ids,
+                subviews,
+                |sv| sv.entrance_pupil().location,
+            );
+            multi_row(ui, "Entrance pupil semi-diameter", ids, subviews, |sv| {
+                sv.entrance_pupil().semi_diameter
+            });
+            multi_row(
+                ui,
+                "Exit pupil dist. from last surface",
+                ids,
+                subviews,
+                |sv| sv.exit_pupil().location,
+            );
+            multi_row(ui, "Exit pupil semi-diameter", ids, subviews, |sv| {
+                sv.exit_pupil().semi_diameter
+            });
+
+            sep_row(ui, n_cols);
+
+            multi_row(
+                ui,
+                "Front principal plane dist. from first surface",
+                ids,
+                subviews,
+                |sv| *sv.front_principal_plane(),
+            );
+            multi_row(
+                ui,
+                "Back principal plane dist. from last surface",
+                ids,
+                subviews,
+                |sv| *sv.back_principal_plane(),
+            );
+
+            sep_row(ui, n_cols);
+
+            // Aperture stop is an integer index; format it without decimals.
+            ui.label("Aperture stop (surface)");
             for id in ids {
-                let wl_label = r
-                    .wavelengths
-                    .get(id.0)
-                    .map(|wl| format!("{wl:.4} \u{00b5}m"))
-                    .unwrap_or_else(|| format!("WL {}", id.0));
-                ui.label(wl_label);
+                if let Some(sv) = subviews.get(id) {
+                    ui.label(sv.aperture_stop().to_string());
+                } else {
+                    ui.label("\u{2014}");
+                }
             }
             ui.end_row();
-            // Separator row.
-            for _ in 0..n_cols {
-                ui.separator();
-            }
-            ui.end_row();
-        }
-
-        multi_row(ui, "EFL", ids, subviews, |sv| *sv.effective_focal_length());
-        multi_row(ui, "BFD", ids, subviews, |sv| *sv.back_focal_distance());
-        multi_row(ui, "FFD", ids, subviews, |sv| *sv.front_focal_distance());
-
-        sep_row(ui, n_cols);
-
-        multi_row(
-            ui,
-            "Entrance pupil dist. from first surface",
-            ids,
-            subviews,
-            |sv| sv.entrance_pupil().location,
-        );
-        multi_row(ui, "Entrance pupil semi-diameter", ids, subviews, |sv| {
-            sv.entrance_pupil().semi_diameter
         });
-        multi_row(
-            ui,
-            "Exit pupil dist. from last surface",
-            ids,
-            subviews,
-            |sv| sv.exit_pupil().location,
-        );
-        multi_row(ui, "Exit pupil semi-diameter", ids, subviews, |sv| {
-            sv.exit_pupil().semi_diameter
-        });
-
-        sep_row(ui, n_cols);
-
-        multi_row(
-            ui,
-            "Front principal plane dist. from first surface",
-            ids,
-            subviews,
-            |sv| *sv.front_principal_plane(),
-        );
-        multi_row(
-            ui,
-            "Back principal plane dist. from last surface",
-            ids,
-            subviews,
-            |sv| *sv.back_principal_plane(),
-        );
-
-        sep_row(ui, n_cols);
-
-        // Aperture stop is an integer index; format it without decimals.
-        ui.label("Aperture stop (surface)");
-        for id in ids {
-            if let Some(sv) = subviews.get(id) {
-                ui.label(sv.aperture_stop().to_string());
-            } else {
-                ui.label("\u{2014}");
-            }
-        }
-        ui.end_row();
-    });
 }
 
 fn sep_row(ui: &mut egui::Ui, n_cols: usize) {

--- a/crates/cherry-rs/src/lib.rs
+++ b/crates/cherry-rs/src/lib.rs
@@ -101,8 +101,7 @@
 //! let paraxial_view = ParaxialView::new(&sequential_model, &field_specs, false).unwrap();
 //!
 //! // Compute the effective focal length of the lens for each submodel.
-//! for (sub_model_id, _) in sequential_model.submodels() {
-//!     let sub_view = paraxial_view.subviews().get(sub_model_id).unwrap();
+//! for (sub_model_id, sub_view) in paraxial_view.subviews() {
 //!     let result = sub_view.effective_focal_length();
 //!
 //!     println!("Submodel ID: {:?}, Effective focal length: {}", sub_model_id, result);
@@ -135,7 +134,7 @@ pub mod examples;
 pub use core::{
     math::linalg::rotations::{EulerAngles, Rotation3D},
     math::vec3::Vec3,
-    sequential_model::{Axis, SequentialModel, SequentialSubModel, Step, SubModelID},
+    sequential_model::{SequentialModel, SequentialSubModel, Step},
 };
 pub use specs::{
     aperture::ApertureSpec,
@@ -151,7 +150,7 @@ pub use views::{
     },
     paraxial::{
         ImagePlane, ParaxialRay, ParaxialRayBundle, ParaxialSubView, ParaxialSubViewDescription,
-        ParaxialView, ParaxialViewDescription, Pupil,
+        ParaxialView, ParaxialViewDescription, Pupil, SubModelID,
     },
     ray_trace_3d::{
         Ray, RayBundle, SamplingConfig, TraceResults, TraceResultsCollection, ray_trace_3d_view,

--- a/crates/cherry-rs/src/specs/fields.rs
+++ b/crates/cherry-rs/src/specs/fields.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::core::{Float, PI};
+use crate::core::{Float, PI, math::vec3::Vec3};
 
 /// Specifies a pupil sampling method.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -49,6 +49,25 @@ pub enum FieldSpec {
     ///
     /// (0, 0) corresponds to the optical axis.
     PointSource { x: Float, y: Float },
+}
+
+/// Returns the unique tangential direction vectors for a set of field specs,
+/// sorted by ascending phi (radians).
+///
+/// Each `FieldSpec` contributes one phi key via `tangential_fan_phi()`. Keys
+/// are deduplicated by exact float equality (bit-identical values share a
+/// submodel). Returns `vec![(0, 1, 0)]` (v = Y, phi = 90°) when `field_specs`
+/// is empty.
+pub fn unique_tangential_vecs(field_specs: &[FieldSpec]) -> Vec<Vec3> {
+    if field_specs.is_empty() {
+        return vec![Vec3::new(0.0, 1.0, 0.0)];
+    }
+    let mut phis: Vec<Float> = field_specs.iter().map(|f| f.tangential_fan_phi()).collect();
+    phis.sort_by(|a, b| a.total_cmp(b));
+    phis.dedup();
+    phis.iter()
+        .map(|&phi| Vec3::new(phi.cos(), phi.sin(), 0.0))
+        .collect()
 }
 
 impl PupilSampling {

--- a/crates/cherry-rs/src/views/components/mod.rs
+++ b/crates/cherry-rs/src/views/components/mod.rs
@@ -64,9 +64,7 @@ pub fn components_view(
 
     let sequential_sub_model = sequential_model
         .submodels()
-        .iter()
-        .find(|(id, _)| id.0 == 0)
-        .map(|(_, m)| m)
+        .get(&0usize)
         .ok_or(anyhow!("No submodel found for wavelength index 0."))?;
     let gaps = sequential_sub_model.gaps();
 

--- a/crates/cherry-rs/src/views/paraxial.rs
+++ b/crates/cherry-rs/src/views/paraxial.rs
@@ -10,22 +10,49 @@
 use std::{borrow::Borrow, collections::HashMap};
 
 use anyhow::{Result, anyhow};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 
 use crate::{
     FieldSpec,
     core::{
         Float,
-        math::linalg::mat2x2::Mat2x2,
+        math::{linalg::mat2x2::Mat2x2, vec3::Vec3},
         sequential_model::{
-            Axis, SequentialModel, SequentialSubModel, Step, SubModelID, Surface,
-            first_physical_surface, last_physical_surface, reversed_surface_id,
+            SequentialModel, SequentialSubModel, Step, Surface, first_physical_surface,
+            last_physical_surface, propagate_tangential_vec, reversed_surface_id,
         },
     },
-    specs::surfaces::SurfaceType,
+    specs::{fields::unique_tangential_vecs, surfaces::SurfaceType},
 };
 
+/// A unique identifier for a paraxial submodel.
+///
+/// The first element is the index of the wavelength in the system's list of
+/// wavelengths. The second element is the index into `ParaxialView`'s
+/// tangential-vector table, which is built from the field specs at view
+/// construction time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SubModelID(pub usize, pub usize);
+
+impl Serialize for SubModelID {
+    // Serialize as a string like "0:0" because tuple keys are awkward in JSON.
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{}:{}", self.0, self.1))
+    }
+}
+
 const DEFAULT_THICKNESS: Float = 0.0;
+
+/// A unit vector in the global frame that defines a meridional (tangential)
+/// plane. It lies in the transverse R–U plane (z-component = 0 at the object)
+/// and is propagated through fold mirrors via the vector law of reflection.
+///
+/// For phi=0°: `(1, 0, 0)` (cursor-R / global X).
+/// For phi=90°: `(0, 1, 0)` (cursor-U / global Y).
+type TangentialVector = Vec3;
 
 /// A single paraxial ray with height and angle components.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -84,9 +111,11 @@ type RayTransferMatrix = Mat2x2;
 /// properties of an optical system, such as the entrance and exit pupils, the
 /// back and front focal distances, and the effective focal length.
 ///
-/// Subviews are indexed by a pair of submodel IDs.
+/// Subviews are indexed by `SubModelID(wavelength_idx, v_index)` where
+/// `v_index` refers to an entry in `tangential_vecs`.
 #[derive(Debug)]
 pub struct ParaxialView {
+    tangential_vecs: Vec<TangentialVector>,
     subviews: HashMap<SubModelID, ParaxialSubView>,
     wavelengths: Vec<Float>,
 }
@@ -97,7 +126,8 @@ pub struct ParaxialView {
 #[derive(Debug, Serialize)]
 pub struct ParaxialViewDescription {
     subviews: HashMap<SubModelID, ParaxialSubViewDescription>,
-    primary_axial_color: HashMap<Axis, Float>,
+    /// Keyed by v_index (index into the tangential-vector table).
+    primary_axial_color: HashMap<usize, Float>,
 }
 
 /// A paraxial subview of an optical system.
@@ -248,27 +278,32 @@ impl ParaxialView {
         field_specs: &[FieldSpec],
         is_obj_space_telecentric: bool,
     ) -> Result<Self> {
-        let subviews: Result<HashMap<SubModelID, ParaxialSubView>> = sequential_model
-            .submodels()
-            .iter()
-            .map(|(id, submodel)| {
-                let surfaces = sequential_model.surfaces();
-                let axis = id.1;
-                Ok((
-                    *id,
-                    ParaxialSubView::new(
-                        submodel,
-                        surfaces,
-                        axis,
-                        field_specs,
-                        is_obj_space_telecentric,
-                    )?,
-                ))
-            })
-            .collect();
+        let surfaces = sequential_model.surfaces();
+        let tangential_vecs: Vec<TangentialVector> =
+            if SequentialModel::is_rotationally_symmetric(surfaces) {
+                vec![Vec3::new(0.0, 1.0, 0.0)]
+            } else {
+                unique_tangential_vecs(field_specs)
+            };
+
+        let mut subviews = HashMap::new();
+        for (&wav_idx, submodel) in sequential_model.submodels() {
+            for (v_idx, &v) in tangential_vecs.iter().enumerate() {
+                let id = SubModelID(wav_idx, v_idx);
+                let subview = ParaxialSubView::new(
+                    submodel,
+                    surfaces,
+                    v,
+                    field_specs,
+                    is_obj_space_telecentric,
+                )?;
+                subviews.insert(id, subview);
+            }
+        }
 
         Ok(Self {
-            subviews: subviews?,
+            tangential_vecs,
+            subviews,
             wavelengths: sequential_model.wavelengths().to_vec(),
         })
     }
@@ -276,9 +311,6 @@ impl ParaxialView {
     /// Returns a description of the paraxial view.
     ///
     /// This is used primarily for serialization of data for export.
-    ///
-    /// # Returns
-    /// A description of the paraxial view.
     pub fn describe(&self) -> ParaxialViewDescription {
         ParaxialViewDescription {
             subviews: self
@@ -291,28 +323,46 @@ impl ParaxialView {
     }
 
     /// Returns the subviews of the paraxial view.
-    ///
-    /// Each subview corresponds to a submodel of the sequential model.
-    ///
-    /// # Returns
-    /// The subviews of the paraxial view.
     pub fn subviews(&self) -> &HashMap<SubModelID, ParaxialSubView> {
         &self.subviews
     }
 
+    /// Returns the tangential direction vector for a given v_index.
+    pub fn tangential_vec(&self, v_index: usize) -> TangentialVector {
+        self.tangential_vecs[v_index]
+    }
+
+    /// Returns the azimuthal angle in degrees for a given v_index.
+    pub fn phi_deg(&self, v_index: usize) -> Float {
+        let v = self.tangential_vecs[v_index];
+        v.y().atan2(v.x()).to_degrees()
+    }
+
+    /// Returns the v_index whose tangential vector is closest (by dot product)
+    /// to the given azimuthal angle in radians.
+    ///
+    /// For the common case where `phi_rad` exactly matches a stored phi key
+    /// (bit-identical `tangential_fan_phi()` value), this finds the exact
+    /// entry. Falls back to index 0 if the table is empty.
+    pub fn v_index_for_phi(&self, phi_rad: Float) -> usize {
+        let target: TangentialVector = Vec3::new(phi_rad.cos(), phi_rad.sin(), 0.0);
+        self.tangential_vecs
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| {
+                let da = a.x() * target.x() + a.y() * target.y();
+                let db = b.x() * target.x() + b.y() * target.y();
+                da.total_cmp(&db)
+            })
+            .map(|(i, _)| i)
+            .unwrap_or(0)
+    }
+
     /// Computes the primary axial color aberration of the optical system.
     ///
-    /// Here, primary axial color is the difference in focal length
-    /// between the maximum and minimum wavelengths. If the traditional
-    /// defintion of axial primary color is desired, then the user must
-    /// enter the wavelengths for the Fraunhofer F and C lines as minimum and
-    /// maximum wavelengths to the underlying sequential model.
-    ///
-    /// # Returns
-    /// A HashMap containing the axial primary color for each axis.
-    pub fn primary_axial_color(&self) -> HashMap<Axis, Float> {
-        // Find the indexes of the minimum and maximum wavelengths. Return with the
-        // empty axial primary color if there are no wavelengths.
+    /// Primary axial color is the absolute difference in EFL between the
+    /// maximum and minimum wavelengths, reported per tangential-vector index.
+    pub fn primary_axial_color(&self) -> HashMap<usize, Float> {
         let min_wav_index = self
             .wavelengths
             .iter()
@@ -328,7 +378,6 @@ impl ParaxialView {
             .map(|(index, _)| index)
             .unwrap_or_default();
 
-        let mut primary_axial_color: HashMap<Axis, Float> = HashMap::new();
         let mut efls_min_wav: HashMap<SubModelID, Float> = HashMap::new();
         let mut efls_max_wav: HashMap<SubModelID, Float> = HashMap::new();
 
@@ -340,14 +389,12 @@ impl ParaxialView {
             }
         }
 
-        // Subtract EFLs that have the same Axis value for their submodel ID. They won't
-        // have the same wavelength, so we can't use the same key to access them from
-        // the EFLs HashMaps.
-        for (id_min, efl_min) in efls_min_wav.iter() {
-            for (id_max, efl_max) in efls_max_wav.iter() {
+        // Pair entries that share the same v_index.
+        let mut primary_axial_color: HashMap<usize, Float> = HashMap::new();
+        for (id_min, efl_min) in &efls_min_wav {
+            for (id_max, efl_max) in &efls_max_wav {
                 if id_min.1 == id_max.1 {
-                    let apc = (efl_max - efl_min).abs();
-                    primary_axial_color.insert(id_min.1, apc);
+                    primary_axial_color.insert(id_min.1, (efl_max - efl_min).abs());
                 }
             }
         }
@@ -357,32 +404,37 @@ impl ParaxialView {
 }
 
 impl ParaxialSubView {
-    /// Create a new paraxial view of an optical system.
+    /// Create a new paraxial subview for the given tangential direction.
+    ///
+    /// `v` is a `TangentialVector` in the global frame defining the meridional
+    /// plane (e.g. `(0,1,0)` for phi=90°). It is propagated through mirror
+    /// surfaces internally to compute per-surface foreshortening.
     fn new(
         sequential_sub_model: &impl SequentialSubModel,
         surfaces: &[Surface],
-        axis: Axis,
+        v: TangentialVector,
         field_specs: &[FieldSpec],
         is_obj_space_telecentric: bool,
     ) -> Result<Self> {
-        let pseudo_marginal_ray =
-            Self::calc_pseudo_marginal_ray(sequential_sub_model, surfaces, axis)?;
-        let parallel_ray = Self::calc_parallel_ray(sequential_sub_model, surfaces, axis)?;
-        let reverse_parallel_ray =
-            Self::calc_reverse_parallel_ray(sequential_sub_model, surfaces, axis)?;
+        // Propagate v through mirror surfaces to get per-surface tangential vectors.
+        let per_surf_v: Vec<TangentialVector> = propagate_tangential_vec(v, surfaces);
 
-        let aperture_stop = Self::calc_aperture_stop(surfaces, &pseudo_marginal_ray, &axis);
+        let pseudo_marginal_ray = Self::calc_pseudo_marginal_ray(sequential_sub_model, surfaces)?;
+        let parallel_ray = Self::calc_parallel_ray(sequential_sub_model, surfaces)?;
+        let reverse_parallel_ray = Self::calc_reverse_parallel_ray(sequential_sub_model, surfaces)?;
+
+        let aperture_stop = Self::calc_aperture_stop(surfaces, &pseudo_marginal_ray, &per_surf_v);
         let back_focal_distance = Self::calc_back_focal_distance(surfaces, &parallel_ray)?;
         let front_focal_distance =
             Self::calc_front_focal_distance(surfaces, &reverse_parallel_ray)?;
         let marginal_ray =
-            Self::calc_marginal_ray(surfaces, &pseudo_marginal_ray, &aperture_stop, &axis);
+            Self::calc_marginal_ray(surfaces, &pseudo_marginal_ray, &aperture_stop, &per_surf_v);
         let entrance_pupil = Self::calc_entrance_pupil(
             sequential_sub_model,
             surfaces,
             is_obj_space_telecentric,
             &aperture_stop,
-            &axis,
+            &per_surf_v,
             &marginal_ray,
         )?;
         let exit_pupil = Self::calc_exit_pupil(
@@ -401,7 +453,7 @@ impl ParaxialSubView {
         let chief_ray = Self::calc_chief_ray(
             surfaces,
             sequential_sub_model,
-            &axis,
+            v,
             field_specs,
             &entrance_pupil,
         )?;
@@ -492,7 +544,7 @@ impl ParaxialSubView {
     fn calc_aperture_stop(
         surfaces: &[Surface],
         pseudo_marginal_ray: &ParaxialRayBundle,
-        axis: &Axis,
+        per_surf_v: &[TangentialVector],
     ) -> usize {
         // Get all the projected semi-diameters of the surfaces. For tilted surfaces,
         // projected_semi_diameter accounts for the foreshortening of the clear aperture
@@ -503,7 +555,8 @@ impl ParaxialSubView {
         let last_surface_height = pseudo_marginal_ray.last_surface().unwrap()[0].height;
         let ratios: Vec<Float> = surfaces
             .iter()
-            .map(|s| (s.projected_semi_diameter(axis) / last_surface_height).abs())
+            .zip(per_surf_v.iter())
+            .map(|(s, &v)| (s.projected_semi_diameter(v) / last_surface_height).abs())
             .collect();
 
         // Do not include the object or image surfaces when computing the aperture stop.
@@ -547,11 +600,15 @@ impl ParaxialSubView {
         Ok(delta)
     }
 
-    /// Computes the paraxial chief ray for a given field.
+    /// Computes the paraxial chief ray for a given tangential direction.
+    ///
+    /// Only field specs whose phi angle matches `v` are used. This ensures each
+    /// submodel's chief ray is computed from the fields that lie in its
+    /// meridional plane.
     fn calc_chief_ray(
         surfaces: &[Surface],
         sequential_sub_model: &impl SequentialSubModel,
-        axis: &Axis,
+        v: TangentialVector,
         field_specs: &[FieldSpec],
         entrance_pupil: &Pupil,
     ) -> Result<ParaxialRayBundle> {
@@ -566,7 +623,15 @@ impl ParaxialSubView {
             enp_loc - obj_loc
         };
 
-        let (paraxial_angle, height) = max_field(sep, field_specs);
+        // Filter to only the field specs whose phi matches this submodel's v.
+        let v_phi = v.y().atan2(v.x());
+        let matching: Vec<FieldSpec> = field_specs
+            .iter()
+            .copied()
+            .filter(|f| (f.tangential_fan_phi() - v_phi).abs() < 1e-9)
+            .collect();
+
+        let (paraxial_angle, height) = max_field(sep, &matching);
 
         if paraxial_angle.is_infinite() {
             return Err(anyhow!(
@@ -578,7 +643,7 @@ impl ParaxialSubView {
             height,
             angle: paraxial_angle,
         }];
-        Self::trace(initial_ray, sequential_sub_model, surfaces, axis, false)
+        Self::trace(initial_ray, sequential_sub_model, surfaces, false)
     }
 
     fn calc_effective_focal_length(parallel_ray: &ParaxialRayBundle) -> Float {
@@ -603,7 +668,7 @@ impl ParaxialSubView {
         surfaces: &[Surface],
         is_obj_space_telecentric: bool,
         aperture_stop: &usize,
-        axis: &Axis,
+        per_surf_v: &[TangentialVector],
         marginal_ray: &ParaxialRayBundle,
     ) -> Result<Pupil> {
         // In case the object space is telecentric, the entrance pupil is at infinity.
@@ -618,7 +683,7 @@ impl ParaxialSubView {
         if *aperture_stop == 1usize {
             return Ok(Pupil {
                 location: 0.0,
-                semi_diameter: surfaces[1].projected_semi_diameter(axis),
+                semi_diameter: surfaces[1].projected_semi_diameter(per_surf_v[1]),
             });
         }
 
@@ -632,7 +697,6 @@ impl ParaxialSubView {
             ray,
             &sequential_sub_model.slice(0..*aperture_stop),
             &surfaces[0..aperture_stop + 1],
-            axis,
             true,
         )?;
         let location = axis_intercepts(results.last_surface().unwrap())?[0];
@@ -682,7 +746,6 @@ impl ParaxialSubView {
             ray,
             &sequential_sub_model.slice(*aperture_stop..sequential_sub_model.len()),
             &surfaces[*aperture_stop..],
-            &Axis::U,
             false,
         )?;
 
@@ -740,12 +803,13 @@ impl ParaxialSubView {
         surfaces: &[Surface],
         pseudo_marginal_ray: &ParaxialRayBundle,
         aperture_stop: &usize,
-        axis: &Axis,
+        per_surf_v: &[TangentialVector],
     ) -> ParaxialRayBundle {
         let ratios: Vec<Float> = surfaces
             .iter()
             .zip(pseudo_marginal_ray.iter_surfaces())
-            .map(|(s, rays)| s.projected_semi_diameter(axis) / rays[0].height)
+            .zip(per_surf_v.iter())
+            .map(|((s, rays), &v)| s.projected_semi_diameter(v) / rays[0].height)
             .collect();
         let scale_factor = ratios[*aperture_stop];
 
@@ -768,14 +832,13 @@ impl ParaxialSubView {
     fn calc_parallel_ray(
         sequential_sub_model: &impl SequentialSubModel,
         surfaces: &[Surface],
-        axis: Axis,
     ) -> Result<ParaxialRayBundle> {
         let ray = vec![ParaxialRay {
             height: 1.0,
             angle: 0.0,
         }];
 
-        Self::trace(ray, sequential_sub_model, surfaces, &axis, false)
+        Self::trace(ray, sequential_sub_model, surfaces, false)
     }
 
     /// Compute the paraxial image plane.
@@ -811,7 +874,6 @@ impl ParaxialSubView {
     fn calc_pseudo_marginal_ray(
         sequential_sub_model: &impl SequentialSubModel,
         surfaces: &[Surface],
-        axis: Axis,
     ) -> Result<ParaxialRayBundle> {
         let ray = if sequential_sub_model.is_obj_at_inf() {
             // Ray parallel to axis at a height of 1
@@ -827,28 +889,26 @@ impl ParaxialSubView {
             }]
         };
 
-        Self::trace(ray, sequential_sub_model, surfaces, &axis, false)
+        Self::trace(ray, sequential_sub_model, surfaces, false)
     }
 
     /// Compute the reverse parallel ray.
     fn calc_reverse_parallel_ray(
         sequential_sub_model: &impl SequentialSubModel,
         surfaces: &[Surface],
-        axis: Axis,
     ) -> Result<ParaxialRayBundle> {
         let ray = vec![ParaxialRay {
             height: 1.0,
             angle: 0.0,
         }];
 
-        Self::trace(ray, sequential_sub_model, surfaces, &axis, true)
+        Self::trace(ray, sequential_sub_model, surfaces, true)
     }
 
     /// Compute the ray transfer matrix for each gap/surface pair.
     fn rtms(
         sequential_sub_model: &impl SequentialSubModel,
         surfaces: &[Surface],
-        axis: &Axis,
         reverse: bool,
     ) -> Result<Vec<RayTransferMatrix>> {
         let mut txs: Vec<RayTransferMatrix> = Vec::new();
@@ -874,7 +934,7 @@ impl ParaxialSubView {
                 reflected as Float * gap_0.thickness
             };
 
-            let roc = surface.roc(axis);
+            let roc = surface.roc();
             if let SurfaceType::Reflecting = surface.surface_type() {
                 reflected *= -1;
             }
@@ -897,10 +957,9 @@ impl ParaxialSubView {
         initial_rays: Vec<ParaxialRay>,
         sequential_sub_model: &impl SequentialSubModel,
         surfaces: &[Surface],
-        axis: &Axis,
         reverse: bool,
     ) -> Result<ParaxialRayBundle> {
-        let txs = Self::rtms(sequential_sub_model, surfaces, axis, reverse)?;
+        let txs = Self::rtms(sequential_sub_model, surfaces, reverse)?;
         let num_surfaces = txs.len() + 1;
         let num_rays = initial_rays.len();
         let mut flat: Vec<ParaxialRay> = Vec::with_capacity(num_surfaces * num_rays);
@@ -976,10 +1035,7 @@ mod test {
     use approx::assert_abs_diff_eq;
 
     use crate::examples::convexplano_lens;
-    use crate::{
-        core::{Float, sequential_model::SubModelID},
-        n,
-    };
+    use crate::{core::Float, n};
 
     use super::*;
 
@@ -1067,7 +1123,7 @@ mod test {
         let sequential_model = convexplano_lens::sequential_model(air, nbk7, &wavelengths);
         let seq_sub_model = sequential_model
             .submodels()
-            .get(&SubModelID(0usize, Axis::U))
+            .get(&0usize)
             .expect("Submodel not found.");
         let field_specs = vec![
             FieldSpec::Angle {
@@ -1084,7 +1140,7 @@ mod test {
             ParaxialSubView::new(
                 seq_sub_model,
                 sequential_model.surfaces(),
-                Axis::U,
+                Vec3::new(0.0, 1.0, 0.0), // v = Y (phi=90°)
                 &field_specs,
                 false,
             )
@@ -1148,14 +1204,11 @@ mod test {
         let sequential_model = convexplano_lens::sequential_model(air, nbk7, &wavelengths);
         let seq_sub_model = sequential_model
             .submodels()
-            .get(&SubModelID(0usize, Axis::U))
+            .get(&0usize)
             .expect("Submodel not found.");
-        let pseudo_marginal_ray = ParaxialSubView::calc_pseudo_marginal_ray(
-            seq_sub_model,
-            sequential_model.surfaces(),
-            Axis::U,
-        )
-        .unwrap();
+        let pseudo_marginal_ray =
+            ParaxialSubView::calc_pseudo_marginal_ray(seq_sub_model, sequential_model.surfaces())
+                .unwrap();
 
         let expected = [
             (1.0000, 0.0),
@@ -1181,14 +1234,11 @@ mod test {
         let sequential_model = convexplano_lens::sequential_model(air, nbk7, &wavelengths);
         let seq_sub_model = sequential_model
             .submodels()
-            .get(&SubModelID(0usize, Axis::U))
+            .get(&0usize)
             .expect("Submodel not found.");
-        let reverse_parallel_ray = ParaxialSubView::calc_reverse_parallel_ray(
-            seq_sub_model,
-            sequential_model.surfaces(),
-            Axis::U,
-        )
-        .unwrap();
+        let reverse_parallel_ray =
+            ParaxialSubView::calc_reverse_parallel_ray(seq_sub_model, sequential_model.surfaces())
+                .unwrap();
 
         let expected = [(1.0000, 0.0), (1.0000, 0.0), (1.0000, 0.0200)];
 

--- a/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
@@ -8,16 +8,17 @@ use serde::Serialize;
 use tracing::trace;
 
 use crate::{
-    Axis, Pupil,
+    Pupil,
     core::{
         Float, PI,
         math::vec3::Vec3,
-        sequential_model::{SequentialModel, SequentialSubModel, SubModelID, Surface},
+        sequential_model::{SequentialModel, SequentialSubModel, Surface},
     },
     specs::{
         aperture::ApertureSpec,
         fields::{FieldSpec, PupilSampling},
     },
+    views::paraxial::SubModelID,
 };
 
 use trace::trace;
@@ -60,14 +61,12 @@ pub struct TraceResultsCollection {
 /// The results of a 3D ray trace.
 ///
 /// This represents the results of a 3D ray trace for a single set of values of
-/// 1. wavelength ID,
-/// 2. field ID, and
-/// 3. axis.
+/// 1. wavelength ID and
+/// 2. field ID.
 #[derive(Debug, Serialize)]
 pub struct TraceResults {
     wavelength_id: usize,
     field_id: usize,
-    axis: Axis,
 
     /// A single chief ray through the pupil center.
     chief_ray: RayBundle,
@@ -118,14 +117,15 @@ pub fn ray_trace_3d_view(
                 wavelength_id,
             );
 
-            let submodel_id = SubModelID(wavelength_id, Axis::U);
             let sequential_submodel = sequential_model
                 .submodels()
-                .get(&submodel_id)
+                .get(&wavelength_id)
                 .ok_or_else(|| anyhow!("Submodel not found"))?;
+            let v_index = paraxial_view.v_index_for_phi(field_specs[field_id].tangential_fan_phi());
+            let paraxial_submodel_id = SubModelID(wavelength_id, v_index);
             let paraxial_subview = paraxial_view
                 .subviews()
-                .get(&submodel_id)
+                .get(&paraxial_submodel_id)
                 .ok_or_else(|| anyhow!("Submodel not found"))?;
 
             let field_spec = &field_specs[field_id];
@@ -181,7 +181,6 @@ pub fn ray_trace_3d_view(
             Ok(TraceResults {
                 wavelength_id,
                 field_id,
-                axis: Axis::U,
                 chief_ray,
                 full_pupil,
                 tangential_fan,
@@ -243,11 +242,6 @@ impl TraceResultsCollection {
 }
 
 impl TraceResults {
-    // Returns the axis of the ray bundle.
-    pub fn axis(&self) -> Axis {
-        self.axis
-    }
-
     // Returns the field ID of the ray bundle.
     pub fn field_id(&self) -> usize {
         self.field_id
@@ -805,7 +799,7 @@ mod tests {
         let rays = rays(
             s.sequential_model.surfaces(),
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, Axis::U)],
+            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
             &s.field_specs[0],
             PupilSampling::TangentialRayFan { n: 3 },
         )
@@ -834,7 +828,7 @@ mod tests {
         let fan_rays = rays(
             seq_model.surfaces(),
             &aperture_spec,
-            &paraxial_view.subviews()[&SubModelID(0, Axis::U)],
+            &paraxial_view.subviews()[&SubModelID(0, 0)],
             &field_specs[0],
             PupilSampling::SagittalRayFan { n: 3 },
         )
@@ -860,7 +854,7 @@ mod tests {
         let result = rays(
             s.sequential_model.surfaces(),
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, Axis::U)],
+            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
             &field_spec,
             PupilSampling::TangentialRayFan { n: 3 },
         );
@@ -879,7 +873,7 @@ mod tests {
         let rays = chief_ray_from_angle(
             s.sequential_model.surfaces(),
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, Axis::U)],
+            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
             0.0,
             0.0,
         )
@@ -901,7 +895,7 @@ mod tests {
         let rays = chief_ray_from_angle(
             s.sequential_model.surfaces(),
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, Axis::U)],
+            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
             PI / 2.0,
             0.08727, // 5 degrees
         )
@@ -922,7 +916,7 @@ mod tests {
 
         let rays = chief_ray_from_pos(
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, Axis::U)],
+            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
             &Vec3::new(0.0, 0.0, -1.0),
         )
         .unwrap();
@@ -942,7 +936,7 @@ mod tests {
 
         let rays = chief_ray_from_pos(
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, Axis::U)],
+            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
             &Vec3::new(0.0, -0.08749, -1.0),
         )
         .unwrap();
@@ -963,7 +957,7 @@ mod tests {
         let rays = parallel_ray_bundle_on_sq_grid(
             s.sequential_model.surfaces(),
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, Axis::U)],
+            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
             1.0,
             0.0,
         );
@@ -975,7 +969,7 @@ mod tests {
         let rays = parallel_ray_bundle_on_sq_grid(
             s.sequential_model.surfaces(),
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, Axis::U)],
+            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
             0.5,
             0.0,
         );
@@ -987,7 +981,7 @@ mod tests {
     #[test]
     fn test_point_source_ray_fan() {
         let s = setup();
-        let enp_radius = &s.paraxial_view.subviews()[&SubModelID(0, Axis::U)]
+        let enp_radius = &s.paraxial_view.subviews()[&SubModelID(0, 0)]
             .entrance_pupil()
             .semi_diameter;
         let expected_z_dir_cosines: [Float; 3] = [
@@ -998,7 +992,7 @@ mod tests {
 
         let rays = point_source_ray_fan(
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, Axis::U)],
+            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
             3,
             PI / 2.0,
             &Vec3::new(0.0, 0.0, -1.0), // Point source located at z = -1.0
@@ -1020,7 +1014,7 @@ mod tests {
 
         let rays = point_source_ray_bundle_on_sq_grid(
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, Axis::U)],
+            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
             1.0,
             &Vec3::new(0.0, 0.0, -1.0), // Point source located at z = -1.0
         );
@@ -1031,7 +1025,7 @@ mod tests {
 
         let rays = point_source_ray_bundle_on_sq_grid(
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, Axis::U)],
+            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
             0.5,
             &Vec3::new(0.0, 0.0, -1.0), // Point source located at z = -1.0
         );
@@ -1119,10 +1113,7 @@ mod tests {
         let generated = rays(
             s.sequential_model.surfaces(),
             &s.aperture_spec,
-            s.paraxial_view
-                .subviews()
-                .get(&SubModelID(0, Axis::U))
-                .unwrap(),
+            s.paraxial_view.subviews().get(&SubModelID(0, 0)).unwrap(),
             &field_spec,
             PupilSampling::TangentialRayFan { n: 3 },
         )

--- a/crates/cherry-rs/tests/biconvex_lens_finite_object.rs
+++ b/crates/cherry-rs/tests/biconvex_lens_finite_object.rs
@@ -66,12 +66,10 @@ fn assert_ray_results_approx_eq(actual: &ParaxialRayBundle, expected: &[(f64, f6
 #[test]
 fn test_paraxial_view_aperture_stop() {
     let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
-    let submodels = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for submodel_id in submodels.keys() {
-        let sub_view = view.subviews().get(submodel_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.aperture_stop();
 
         assert_eq!(APERTURE_STOP, *result)
@@ -81,12 +79,10 @@ fn test_paraxial_view_aperture_stop() {
 #[test]
 fn test_paraxial_view_back_focal_distance() {
     let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
-    let submodels = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for submodel_id in submodels.keys() {
-        let sub_view = view.subviews().get(submodel_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.back_focal_distance();
 
         assert_abs_diff_eq!(BACK_FOCAL_DISTANCE, *result, epsilon = 1e-4)
@@ -96,12 +92,10 @@ fn test_paraxial_view_back_focal_distance() {
 #[test]
 fn test_paraxial_view_back_principal_plane() {
     let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
-    let submodels = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for submodel_id in submodels.keys() {
-        let sub_view = view.subviews().get(submodel_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.back_principal_plane();
 
         assert_abs_diff_eq!(BACK_PRINCIPAL_PLANE, *result, epsilon = 1e-4)
@@ -111,12 +105,10 @@ fn test_paraxial_view_back_principal_plane() {
 #[test]
 fn test_paraxial_view_entrance_pupil() {
     let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
-    let submodels = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for submodel_id in submodels.keys() {
-        let sub_view = view.subviews().get(submodel_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.entrance_pupil();
 
         assert_eq!(ENTRANCE_PUPIL, *result)
@@ -126,12 +118,10 @@ fn test_paraxial_view_entrance_pupil() {
 #[test]
 fn test_paraxial_view_exit_pupil() {
     let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
-    let submodels = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for submodel_id in submodels.keys() {
-        let sub_view = view.subviews().get(submodel_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.exit_pupil();
 
         assert_abs_diff_eq!(EXIT_PUPIL.location, result.location, epsilon = 1e-4);
@@ -146,12 +136,10 @@ fn test_paraxial_view_exit_pupil() {
 #[test]
 fn test_paraxial_view_effective_focal_length() {
     let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
-    let submodels = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for submodel_id in submodels.keys() {
-        let sub_view = view.subviews().get(submodel_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.effective_focal_length();
 
         assert_abs_diff_eq!(EFFECTIVE_FOCAL_LENGTH, *result, epsilon = 1e-4)
@@ -161,12 +149,10 @@ fn test_paraxial_view_effective_focal_length() {
 #[test]
 fn test_paraxial_view_front_focal_distance() {
     let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
-    let submodels = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for submodel_id in submodels.keys() {
-        let sub_view = view.subviews().get(submodel_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.front_focal_distance();
 
         assert_abs_diff_eq!(FRONT_FOCAL_DISTANCE, *result, epsilon = 1e-4)
@@ -176,12 +162,10 @@ fn test_paraxial_view_front_focal_distance() {
 #[test]
 fn test_paraxial_view_front_principal_plane() {
     let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for submodel_id in sub_models.keys() {
-        let sub_view = view.subviews().get(submodel_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.front_principal_plane();
 
         assert_abs_diff_eq!(FRONT_PRINCIPAL_PLANE, *result, epsilon = 1e-4)
@@ -191,12 +175,10 @@ fn test_paraxial_view_front_principal_plane() {
 #[test]
 fn test_paraxial_view_image_plane() {
     let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for submodel_id in sub_models.keys() {
-        let sub_view = view.subviews().get(submodel_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.paraxial_image_plane();
 
         assert_abs_diff_eq!(
@@ -215,12 +197,10 @@ fn test_paraxial_view_image_plane() {
 #[test]
 fn test_paraxial_view_marginal_ray() {
     let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for submodel_id in sub_models.keys() {
-        let sub_view = view.subviews().get(submodel_id).unwrap();
+    for sub_view in view.subviews().values() {
         assert_ray_results_approx_eq(sub_view.marginal_ray(), &marginal_ray_expected(), 1e-4);
     }
 }
@@ -228,12 +208,10 @@ fn test_paraxial_view_marginal_ray() {
 #[test]
 fn test_paraxial_view_chief_ray() {
     let model = sequential_model(n!(1.0), n!(1.517), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for submodel_id in sub_models.keys() {
-        let sub_view = view.subviews().get(submodel_id).unwrap();
+    for sub_view in view.subviews().values() {
         assert_ray_results_approx_eq(sub_view.chief_ray(), &chief_ray_expected(), 1e-4);
     }
 }

--- a/crates/cherry-rs/tests/concave_mirror.rs
+++ b/crates/cherry-rs/tests/concave_mirror.rs
@@ -62,12 +62,10 @@ fn assert_ray_results_approx_eq(actual: &ParaxialRayBundle, expected: &[(f64, f6
 #[test]
 fn concave_mirror_paraxial_chief_ray() {
     let model = sequential_model(n!(1.0), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         assert_ray_results_approx_eq(sub_view.chief_ray(), &chief_ray_expected(), 1e-4);
     }
 }
@@ -75,12 +73,10 @@ fn concave_mirror_paraxial_chief_ray() {
 #[test]
 fn concave_mirror_paraxial_aperture_stop() {
     let model = sequential_model(n!(1.0), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.aperture_stop();
 
         assert_eq!(APERTURE_STOP, *result)
@@ -90,12 +86,10 @@ fn concave_mirror_paraxial_aperture_stop() {
 #[test]
 fn concave_mirror_paraxial_back_focal_distance() {
     let model = sequential_model(n!(1.0), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.back_focal_distance();
 
         assert_abs_diff_eq!(BACK_FOCAL_DISTANCE, *result, epsilon = 1e-4)
@@ -105,12 +99,10 @@ fn concave_mirror_paraxial_back_focal_distance() {
 #[test]
 fn concave_mirror_paraxial_back_principal_plane() {
     let model = sequential_model(n!(1.0), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.back_principal_plane();
 
         assert_abs_diff_eq!(BACK_PRINCIPAL_PLANE, *result, epsilon = 1e-4)
@@ -120,12 +112,10 @@ fn concave_mirror_paraxial_back_principal_plane() {
 #[test]
 fn concave_mirror_paraxial_entrance_pupil() {
     let model = sequential_model(n!(1.0), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.entrance_pupil();
 
         assert_eq!(ENTRANCE_PUPIL, *result)
@@ -135,12 +125,10 @@ fn concave_mirror_paraxial_entrance_pupil() {
 #[test]
 fn concave_mirror_paraxial_exit_pupil() {
     let model = sequential_model(n!(1.0), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.exit_pupil();
 
         assert_abs_diff_eq!(EXIT_PUPIL.location, result.location, epsilon = 1e-4);
@@ -155,12 +143,10 @@ fn concave_mirror_paraxial_exit_pupil() {
 #[test]
 fn concave_mirror_paraxial_effective_focal_length() {
     let model = sequential_model(n!(1.0), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.effective_focal_length();
 
         assert_abs_diff_eq!(EFFECTIVE_FOCAL_LENGTH, *result, epsilon = 1e-4)
@@ -170,12 +156,10 @@ fn concave_mirror_paraxial_effective_focal_length() {
 #[test]
 fn concave_mirror_paraxial_front_focal_distance() {
     let model = sequential_model(n!(1.0), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.front_focal_distance();
 
         assert_abs_diff_eq!(FRONT_FOCAL_DISTANCE, *result, epsilon = 1e-4)
@@ -185,12 +169,10 @@ fn concave_mirror_paraxial_front_focal_distance() {
 #[test]
 fn concave_mirror_paraxial_front_principal_plane() {
     let model = sequential_model(n!(1.0), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.front_principal_plane();
 
         assert_abs_diff_eq!(FRONT_PRINCIPAL_PLANE, *result, epsilon = 1e-4)
@@ -200,12 +182,10 @@ fn concave_mirror_paraxial_front_principal_plane() {
 #[test]
 fn concave_mirror_paraxial_image_plane() {
     let model = sequential_model(n!(1.0), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.paraxial_image_plane();
 
         assert_abs_diff_eq!(
@@ -224,12 +204,10 @@ fn concave_mirror_paraxial_image_plane() {
 #[test]
 fn concave_mirror_paraxial_marginal_ray() {
     let model = sequential_model(n!(1.0), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         assert_ray_results_approx_eq(sub_view.marginal_ray(), &marginal_ray_expected(), 1e-4);
     }
 }

--- a/crates/cherry-rs/tests/convexplano_lens_materials.rs
+++ b/crates/cherry-rs/tests/convexplano_lens_materials.rs
@@ -11,7 +11,7 @@ mod test_ri_info {
     use lib_ria::Store;
 
     use cherry_rs::examples::convexplano_lens::sequential_model;
-    use cherry_rs::{Axis, FieldSpec, ParaxialView};
+    use cherry_rs::{FieldSpec, ParaxialView};
 
     pub fn load_store() -> Result<Store> {
         let filename = std::path::PathBuf::from("data/rii.db");
@@ -37,9 +37,11 @@ mod test_ri_info {
     ];
 
     // Paraxial property values
-    fn primary_axial_color() -> HashMap<Axis, f64> {
+    // primary_axial_color is keyed by v_index; for a single phi=90° field,
+    // v_index=0.
+    fn primary_axial_color() -> HashMap<usize, f64> {
         let mut primary_axial_color = HashMap::new();
-        primary_axial_color.insert(Axis::U, 0.7743);
+        primary_axial_color.insert(0usize, 0.7743);
         primary_axial_color
     }
 

--- a/crates/cherry-rs/tests/convexplano_lens_ri.rs
+++ b/crates/cherry-rs/tests/convexplano_lens_ri.rs
@@ -72,12 +72,10 @@ fn assert_ray_results_approx_eq(actual: &ParaxialRayBundle, expected: &[(f64, f6
 #[test]
 fn convexplano_lens_ri_paraxial_chief_ray() {
     let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         assert_ray_results_approx_eq(sub_view.chief_ray(), &chief_ray_expected(), 1e-4);
     }
 }
@@ -85,12 +83,10 @@ fn convexplano_lens_ri_paraxial_chief_ray() {
 #[test]
 fn convexplano_lens_ri_paraxial_aperture_stop() {
     let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.aperture_stop();
 
         assert_eq!(APERTURE_STOP, *result)
@@ -100,12 +96,10 @@ fn convexplano_lens_ri_paraxial_aperture_stop() {
 #[test]
 fn convexplano_lens_ri_paraxial_back_focal_distance() {
     let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.back_focal_distance();
 
         assert_abs_diff_eq!(BACK_FOCAL_DISTANCE, *result, epsilon = 1e-4)
@@ -115,12 +109,10 @@ fn convexplano_lens_ri_paraxial_back_focal_distance() {
 #[test]
 fn convexplano_lens_ri_paraxial_back_principal_plane() {
     let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.back_principal_plane();
 
         assert_abs_diff_eq!(BACK_PRINCIPAL_PLANE, *result, epsilon = 1e-4)
@@ -130,12 +122,10 @@ fn convexplano_lens_ri_paraxial_back_principal_plane() {
 #[test]
 fn convexplano_lens_ri_paraxial_entrance_pupil() {
     let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.entrance_pupil();
 
         assert_eq!(ENTRANCE_PUPIL, *result)
@@ -145,12 +135,10 @@ fn convexplano_lens_ri_paraxial_entrance_pupil() {
 #[test]
 fn convexplano_lens_ri_paraxial_exit_pupil() {
     let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.exit_pupil();
 
         assert_abs_diff_eq!(EXIT_PUPIL.location, result.location, epsilon = 1e-4);
@@ -165,12 +153,10 @@ fn convexplano_lens_ri_paraxial_exit_pupil() {
 #[test]
 fn convexplano_lens_ri_paraxial_effective_focal_length() {
     let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.effective_focal_length();
 
         assert_abs_diff_eq!(EFFECTIVE_FOCAL_LENGTH, *result, epsilon = 1e-4)
@@ -180,12 +166,10 @@ fn convexplano_lens_ri_paraxial_effective_focal_length() {
 #[test]
 fn convexplano_lens_ri_paraxial_front_focal_distance() {
     let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.front_focal_distance();
 
         assert_abs_diff_eq!(FRONT_FOCAL_DISTANCE, *result, epsilon = 1e-4)
@@ -195,12 +179,10 @@ fn convexplano_lens_ri_paraxial_front_focal_distance() {
 #[test]
 fn convexplano_lens_ri_paraxial_front_principal_plane() {
     let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.front_principal_plane();
 
         assert_abs_diff_eq!(FRONT_PRINCIPAL_PLANE, *result, epsilon = 1e-4)
@@ -210,12 +192,10 @@ fn convexplano_lens_ri_paraxial_front_principal_plane() {
 #[test]
 fn convexplano_lens_ri_paraxial_image_plane() {
     let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.paraxial_image_plane();
 
         assert_abs_diff_eq!(
@@ -234,12 +214,10 @@ fn convexplano_lens_ri_paraxial_image_plane() {
 #[test]
 fn convexplano_lens_ri_paraxial_marginal_ray() {
     let model = sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let sub_models = model.submodels();
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         assert_ray_results_approx_eq(sub_view.marginal_ray(), &marginal_ray_expected(), 1e-4);
     }
 }

--- a/crates/cherry-rs/tests/mirrors_figure_z.rs
+++ b/crates/cherry-rs/tests/mirrors_figure_z.rs
@@ -1,5 +1,7 @@
+use std::f64::consts::FRAC_PI_2;
+
 use approx::assert_abs_diff_eq;
-use cherry_rs::{Axis, FieldSpec, ParaxialView, examples::mirrors_figure_z, n};
+use cherry_rs::{FieldSpec, ParaxialView, SubModelID, examples::mirrors_figure_z, n};
 
 const WAVELENGTHS: [f64; 1] = [0.5876];
 const FIELD_SPECS: [FieldSpec; 1] = [FieldSpec::Angle {
@@ -11,9 +13,8 @@ const FIELD_SPECS: [FieldSpec; 1] = [FieldSpec::Angle {
 const APERTURE_STOP: usize = 1;
 
 // Entrance pupil coincides with the aperture stop (Mirror 1, theta = 30°).
-// U axis: projected SD = r · cos(30°) (theta tilt foreshortens in U).
-// R axis: projected SD = r (theta tilt does not affect R).
-const ENTRANCE_PUPIL_LOCATION: f64 = 0.0;
+// phi=90° (v=Y): projected SD = r · cos(30°) (theta tilt foreshortens in Y).
+// phi=0° (v=X): projected SD = r (theta tilt does not affect X).
 const ENTRANCE_PUPIL_SD_U: f64 = 12.7 * 0.8660254037844387; // 12.7 · cos(30°)
 const ENTRANCE_PUPIL_SD_R: f64 = 12.7;
 
@@ -45,25 +46,8 @@ fn track_equals_z_for_straight_system() {
 fn mirrors_figure_z_paraxial_aperture_stop() {
     let model = mirrors_figure_z::sequential_model(n!(1.0), &WAVELENGTHS);
     let view = ParaxialView::new(&model, &FIELD_SPECS, false).expect("paraxial view");
-    for sub_view in model.submodels().keys().map(|id| &view.subviews()[id]) {
+    for sub_view in view.subviews().values() {
         assert_eq!(*sub_view.aperture_stop(), APERTURE_STOP);
-    }
-}
-
-#[test]
-fn mirrors_figure_z_paraxial_entrance_pupil() {
-    let model = mirrors_figure_z::sequential_model(n!(1.0), &WAVELENGTHS);
-    let view = ParaxialView::new(&model, &FIELD_SPECS, false).expect("paraxial view");
-    for id in model.submodels().keys() {
-        let sub_view = &view.subviews()[id];
-        let ep = sub_view.entrance_pupil();
-        let expected_sd = if id.1 == Axis::U {
-            ENTRANCE_PUPIL_SD_U
-        } else {
-            ENTRANCE_PUPIL_SD_R
-        };
-        assert_abs_diff_eq!(ep.location, ENTRANCE_PUPIL_LOCATION, epsilon = 1e-10);
-        assert_abs_diff_eq!(ep.semi_diameter, expected_sd, epsilon = 1e-10);
     }
 }
 
@@ -71,7 +55,7 @@ fn mirrors_figure_z_paraxial_entrance_pupil() {
 fn mirrors_figure_z_paraxial_exit_pupil() {
     let model = mirrors_figure_z::sequential_model(n!(1.0), &WAVELENGTHS);
     let view = ParaxialView::new(&model, &FIELD_SPECS, false).expect("paraxial view");
-    for sub_view in model.submodels().keys().map(|id| &view.subviews()[id]) {
+    for sub_view in view.subviews().values() {
         assert_abs_diff_eq!(
             sub_view.exit_pupil().location,
             EXIT_PUPIL_LOCATION,
@@ -91,21 +75,68 @@ fn mirrors_figure_z_marginal_ray_uses_projected_sd() {
     let view = ParaxialView::new(&model, &FIELD_SPECS, false).expect("paraxial view");
     let r = 12.7_f64;
     let projected_u = r * (30.0_f64.to_radians()).cos();
-    let projected_r = r;
 
-    for id in model.submodels().keys() {
-        let sub_view = &view.subviews()[id];
-        let expected = if id.1 == Axis::U {
-            projected_u
-        } else {
-            projected_r
-        };
-        // The aperture stop is Mirror 1 (surface index 1).
-        assert_eq!(*sub_view.aperture_stop(), 1usize);
-        // The marginal ray height at the aperture stop should equal the projected SD.
-        let marginal_height_at_stop = sub_view.marginal_ray().rays_at_surface(1)[0].height;
-        assert_abs_diff_eq!(marginal_height_at_stop, expected, epsilon = 1e-10);
-    }
+    // FIELD_SPECS has phi=90° → only one submodel with v=Y (foreshortened).
+    let sub_view = view
+        .subviews()
+        .values()
+        .next()
+        .expect("at least one subview");
+    assert_eq!(*sub_view.aperture_stop(), 1usize);
+    let marginal_height_at_stop = sub_view.marginal_ray().rays_at_surface(1)[0].height;
+    assert_abs_diff_eq!(marginal_height_at_stop, projected_u, epsilon = 1e-10);
+}
+
+/// A phi=90° field (v=Y) is foreshortened by the 30°-about-X mirror tilt.
+/// The entrance pupil semi-diameter must equal 12.7·cos(30°) ≈ 10.9985.
+#[test]
+fn entrance_pupil_sd_phi_90_foreshortened() {
+    let field_specs = [FieldSpec::Angle {
+        chi: 0.0,
+        phi: 90.0,
+    }];
+    let model = mirrors_figure_z::sequential_model(n!(1.0), &WAVELENGTHS);
+    let view = ParaxialView::new(&model, &field_specs, false).expect("paraxial view");
+    let id = SubModelID(0, view.v_index_for_phi(FRAC_PI_2));
+    let ep = view.subviews()[&id].entrance_pupil();
+    assert_abs_diff_eq!(ep.semi_diameter, ENTRANCE_PUPIL_SD_U, epsilon = 1e-4);
+}
+
+/// A phi=0° field (v=X) is not foreshortened by the 30°-about-X mirror tilt.
+/// The entrance pupil semi-diameter must equal the raw 12.7.
+#[test]
+fn entrance_pupil_sd_phi_0_not_foreshortened() {
+    let field_specs = [FieldSpec::Angle { chi: 0.0, phi: 0.0 }];
+    let model = mirrors_figure_z::sequential_model(n!(1.0), &WAVELENGTHS);
+    let view = ParaxialView::new(&model, &field_specs, false).expect("paraxial view");
+    let id = SubModelID(0, view.v_index_for_phi(0.0));
+    let ep = view.subviews()[&id].entrance_pupil();
+    assert_abs_diff_eq!(ep.semi_diameter, ENTRANCE_PUPIL_SD_R, epsilon = 1e-4);
+}
+
+/// Each submodel uses only the field specs that match its phi angle for the
+/// chief ray. The phi=90° submodel uses the 5° field; the phi=0° submodel uses
+/// the 3° field.
+#[test]
+fn chief_ray_uses_matching_field_phi() {
+    let field_specs = [
+        FieldSpec::Angle {
+            chi: 5.0,
+            phi: 90.0,
+        },
+        FieldSpec::Angle { chi: 3.0, phi: 0.0 },
+    ];
+    let model = mirrors_figure_z::sequential_model(n!(1.0), &WAVELENGTHS);
+    let view = ParaxialView::new(&model, &field_specs, false).expect("paraxial view");
+
+    let id_phi90 = SubModelID(0, view.v_index_for_phi(FRAC_PI_2));
+    let id_phi0 = SubModelID(0, view.v_index_for_phi(0.0));
+
+    let angle_phi90 = view.subviews()[&id_phi90].chief_ray().rays_at_surface(0)[0].angle;
+    let angle_phi0 = view.subviews()[&id_phi0].chief_ray().rays_at_surface(0)[0].angle;
+
+    assert_abs_diff_eq!(angle_phi90, 5.0_f64.to_radians().tan(), epsilon = 1e-6);
+    assert_abs_diff_eq!(angle_phi0, 3.0_f64.to_radians().tan(), epsilon = 1e-6);
 }
 
 /// Track accumulates path length regardless of fold direction.

--- a/crates/cherry-rs/tests/petzval_lens.rs
+++ b/crates/cherry-rs/tests/petzval_lens.rs
@@ -14,12 +14,9 @@ fn test_describe_paraxial_view() {
 
 #[test]
 fn test_paraxial_view_aperture_stop() {
-    let model = sequential_model();
-    let sub_models = model.submodels();
     let view = paraxial_view();
 
-    for sub_model_id in sub_models.keys() {
-        let sub_view = view.subviews().get(sub_model_id).unwrap();
+    for sub_view in view.subviews().values() {
         let result = sub_view.aperture_stop();
 
         assert_eq!(APERTURE_STOP, *result)


### PR DESCRIPTION
The Axis enum is a holdover from an early design decision about how to calculate paraxial quantities in non-rotationally symmetric systems. Recent changes, like folding mirrors and defining tangential planes according to field points introduced some design tension with this concept.

Here I remove the Axis specification entirely. FieldSpecs now define all tangential planes, and paraxial quantities are computed within these tangential planes. The U and R planes from the system's RUF coordinate system no longer have special preference.

The paraxial summary window now shows quantities grouped by the aziumuthal angle of the field points' tangential planes, rather than R and U planes.