### PR TITLE
feat: Transverse ray aberration plots

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -754,6 +754,7 @@ dependencies = [
  "egui-winit",
  "egui_extras",
  "egui_kittest",
+ "egui_plot",
  "env_logger",
  "gloo-net",
  "js-sys",
@@ -1236,6 +1237,17 @@ checksum = "5bb00f16e00af09092c117515246732adba4ca4649463bdbc2ab6114a2944765"
 dependencies = [
  "egui",
  "kittest",
+]
+
+[[package]]
+name = "egui_plot"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524318041a8ea90c81c738e8985f8ad9e3f9bed636b03c2ff37b218113ed5121"
+dependencies = [
+ "ahash",
+ "egui",
+ "emath",
 ]
 
 [[package]]

--- a/crates/cherry-rs/Cargo.toml
+++ b/crates/cherry-rs/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/bin/gen_rii_index.rs"
 required-features = [ "ri-info" ]
 
 [features]
-gui = [ "dep:eframe", "dep:egui", "dep:egui_extras", "dep:env_logger", "dep:log", "dep:rfd", "dep:serde_json" ]
+gui = [ "dep:eframe", "dep:egui", "dep:egui_extras", "dep:egui_plot", "dep:env_logger", "dep:log", "dep:rfd", "dep:serde_json" ]
 ri-info = [ "dep:ria", "dep:bitcode", "dep:serde_json" ]
 
 [dependencies]
@@ -38,6 +38,7 @@ eframe = { version = "0.32", default-features = false, optional = true, features
 ] }
 egui = { version = "0.32", optional = true }
 egui_extras = { version = "0.32", default-features = false, optional = true }
+egui_plot = { version = "0.33", optional = true }
 log = { version = "0.4.28", optional = true }
 rfd = { version = "0.15", optional = true }
 serde_json = { version = "1", optional = true }

--- a/crates/cherry-rs/benches/convexplano_lens.rs
+++ b/crates/cherry-rs/benches/convexplano_lens.rs
@@ -39,6 +39,7 @@ fn benchmark(c: &mut Criterion) {
                 black_box(&paraxial_view),
                 black_box(SamplingConfig {
                     n_fan_rays: 9,
+                    cross_section_n_fan_rays: 3,
                     full_pupil_spacing: 0.1,
                 }),
             )

--- a/crates/cherry-rs/benches/f_theta_scan_lens.rs
+++ b/crates/cherry-rs/benches/f_theta_scan_lens.rs
@@ -27,6 +27,7 @@ fn benchmark(c: &mut Criterion) {
                 black_box(&paraxial_view),
                 black_box(SamplingConfig {
                     n_fan_rays: 9,
+                    cross_section_n_fan_rays: 3,
                     full_pupil_spacing: 0.1,
                 }),
             )

--- a/crates/cherry-rs/src/gui/app.rs
+++ b/crates/cherry-rs/src/gui/app.rs
@@ -9,8 +9,8 @@ use crate::gui::{
     model::SystemSpecs,
     result_package::ResultPackage,
     windows::{
-        CrossSectionWindow, ParaxialWindow, SpecsWindow, SpotDiagramWindow, SystemWindow,
-        WindowVisibility,
+        CrossSectionWindow, ParaxialWindow, RayFanWindow, SpecsWindow, SpotDiagramWindow,
+        SystemWindow, WindowVisibility,
     },
 };
 
@@ -46,6 +46,7 @@ pub struct CherryApp {
     specs_window: SpecsWindow,
     spot_diagram_window: SpotDiagramWindow,
     cross_section_window: CrossSectionWindow,
+    ray_fan_window: RayFanWindow,
 
     // ri-info: material browser data loaded on main thread for UI
     #[cfg(feature = "ri-info")]
@@ -188,6 +189,7 @@ impl CherryApp {
             specs_window: SpecsWindow::default(),
             spot_diagram_window: SpotDiagramWindow::default(),
             cross_section_window: CrossSectionWindow::default(),
+            ray_fan_window: RayFanWindow::default(),
             #[cfg(feature = "ri-info")]
             material_index,
             #[cfg(feature = "ri-info")]
@@ -361,6 +363,7 @@ impl CherryApp {
         ui.toggle_value(&mut self.windows.paraxial_summary, "Paraxial Summary");
         ui.toggle_value(&mut self.windows.spot_diagram, "Spot Diagram");
         ui.toggle_value(&mut self.windows.cross_section, "Cross Section");
+        ui.toggle_value(&mut self.windows.ray_fan, "Ray Fan Plot");
     }
 }
 
@@ -375,6 +378,7 @@ impl eframe::App for CherryApp {
                 paraxial_summary: self.windows.paraxial_summary,
                 spot_diagram: self.windows.spot_diagram,
                 cross_section: self.windows.cross_section,
+                ray_fan: self.windows.ray_fan,
                 system: self.windows.system,
             },
         };
@@ -583,6 +587,11 @@ impl eframe::App for CherryApp {
             if changed {
                 self.bump_input_id();
             }
+        }
+
+        if self.windows.ray_fan {
+            self.ray_fan_window
+                .show(ctx, &mut self.windows.ray_fan, self.latest_result.as_ref());
         }
 
         // Keep repainting while a compute is in flight.

--- a/crates/cherry-rs/src/gui/compute.rs
+++ b/crates/cherry-rs/src/gui/compute.rs
@@ -137,6 +137,7 @@ fn run_compute(
                 wavelengths,
                 surfaces,
                 fields,
+                field_specs: parsed.fields.clone(),
                 paraxial: None,
                 ray_trace: None,
                 cross_section: None,
@@ -152,7 +153,8 @@ fn run_compute(
         .parse::<f64>()
         .unwrap_or(0.1);
     let config = SamplingConfig {
-        n_fan_rays: req.specs.cross_section_n_rays as usize,
+        n_fan_rays: req.specs.n_fan_rays as usize,
+        cross_section_n_fan_rays: req.specs.cross_section_n_rays as usize,
         full_pupil_spacing,
     };
     let trace = match ray_trace_3d_view(&parsed.aperture, &parsed.fields, &seq, &pv, config) {
@@ -171,6 +173,7 @@ fn run_compute(
         wavelengths,
         surfaces,
         fields,
+        field_specs: parsed.fields.clone(),
         paraxial: Some(pv),
         ray_trace: trace,
         cross_section,

--- a/crates/cherry-rs/src/gui/examples.rs
+++ b/crates/cherry-rs/src/gui/examples.rs
@@ -44,6 +44,7 @@ pub fn mirrors_figure_z() -> SystemSpecs {
         selected_materials: Vec::new(),
         cross_section_n_rays: 11,
         full_pupil_spacing: "0.1".into(),
+        n_fan_rays: 65,
         background_n: "1.0".into(),
         background_material_key: None,
     }
@@ -84,6 +85,7 @@ pub fn petzval_lens() -> SystemSpecs {
         selected_materials: Vec::new(),
         cross_section_n_rays: 11,
         full_pupil_spacing: "0.1".into(),
+        n_fan_rays: 65,
         background_n: "1.0".into(),
         background_material_key: None,
     }
@@ -118,6 +120,7 @@ pub fn biconvex_lens() -> SystemSpecs {
         selected_materials: Vec::new(),
         cross_section_n_rays: 11,
         full_pupil_spacing: "0.1".into(),
+        n_fan_rays: 65,
         background_n: "1.0".into(),
         background_material_key: None,
     }
@@ -185,6 +188,7 @@ pub fn convexplano_lens_with_materials() -> SystemSpecs {
         selected_materials: vec!["other:air:Ciddor".into(), "popular_glass:BK7:SCHOTT".into()],
         cross_section_n_rays: 11,
         full_pupil_spacing: "0.1".into(),
+        n_fan_rays: 65,
         background_n: "1.0".into(),
         background_material_key: Some("other:air:Ciddor".into()),
     }
@@ -310,6 +314,7 @@ pub fn f_theta_scan_lens() -> SystemSpecs {
         ],
         cross_section_n_rays: 3,
         full_pupil_spacing: "0.1".into(),
+        n_fan_rays: 65,
         background_n: "1.0".into(),
         background_material_key: Some("other:air:Ciddor".into()),
     }
@@ -353,6 +358,7 @@ pub fn concave_mirror() -> SystemSpecs {
         selected_materials: Vec::new(),
         cross_section_n_rays: 11,
         full_pupil_spacing: "0.1".into(),
+        n_fan_rays: 65,
         background_n: "1.0".into(),
         background_material_key: None,
     }

--- a/crates/cherry-rs/src/gui/model.rs
+++ b/crates/cherry-rs/src/gui/model.rs
@@ -213,6 +213,10 @@ pub struct SystemSpecs {
     /// [0, 1].
     #[serde(default = "default_full_pupil_spacing")]
     pub full_pupil_spacing: String,
+    /// Number of rays in each tangential/sagittal fan bundle. Must be odd;
+    /// range 3–501. Controls TA curve resolution in the Ray Fan Plot window.
+    #[serde(default = "default_n_fan_rays")]
+    pub n_fan_rays: u32,
     /// Refractive index of the background medium (used in constant-n mode).
     #[serde(default = "default_background_n")]
     pub background_n: String,
@@ -222,7 +226,11 @@ pub struct SystemSpecs {
 }
 
 fn default_cross_section_n_rays() -> u32 {
-    11
+    3
+}
+
+fn default_n_fan_rays() -> u32 {
+    65
 }
 
 fn default_full_pupil_spacing() -> String {
@@ -253,8 +261,9 @@ impl Default for SystemSpecs {
             field_mode: FieldMode::Angle,
             use_materials: false,
             selected_materials: Vec::new(),
-            cross_section_n_rays: 11,
+            cross_section_n_rays: 3,
             full_pupil_spacing: "0.1".into(),
+            n_fan_rays: 65,
             background_n: "1.0".into(),
             background_material_key: None,
         }

--- a/crates/cherry-rs/src/gui/panels/system.rs
+++ b/crates/cherry-rs/src/gui/panels/system.rs
@@ -21,6 +21,28 @@ pub fn system_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
         changed = true;
     }
 
+    // Fan ray count (must be odd, range 3–501).
+    ui.horizontal(|ui| {
+        ui.label("Fan rays:");
+        let mut n = specs.n_fan_rays;
+        let response = ui.add(
+            egui::DragValue::new(&mut n)
+                .range(33u32..=501u32)
+                .speed(2.0),
+        );
+        if response.changed() || n.is_multiple_of(2) {
+            // Snap to nearest odd, staying in range.
+            if n.is_multiple_of(2) {
+                n = n.saturating_add(1).min(501);
+            }
+            n = n.clamp(33, 501);
+            if n != specs.n_fan_rays {
+                specs.n_fan_rays = n;
+                changed = true;
+            }
+        }
+    });
+
     ui.add_space(8.0);
     ui.label("Background");
     ui.separator();
@@ -58,4 +80,47 @@ pub fn system_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
     }
 
     changed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gui::model::SystemSpecs;
+    use egui_kittest::{Harness, kittest::Queryable};
+
+    #[test]
+    fn fan_rays_label_is_present() {
+        let mut specs = SystemSpecs::default();
+        let mut harness = Harness::new(|ctx| {
+            egui::Window::new("System").show(ctx, |ui| {
+                system_panel(ui, &mut specs);
+            });
+        });
+        harness.step();
+        harness.get_by_label_contains("Fan rays");
+    }
+
+    #[test]
+    fn fan_rays_snaps_to_odd() {
+        // Manually set an even value to test snapping.
+        let specs = SystemSpecs {
+            n_fan_rays: 64,
+            ..Default::default()
+        };
+        let mut harness = Harness::new_state(
+            |ctx, s: &mut SystemSpecs| {
+                egui::Window::new("System").show(ctx, |ui| {
+                    system_panel(ui, s);
+                });
+            },
+            specs,
+        );
+        harness.step();
+        // After one frame with an even value, it should have been snapped to odd
+        let snapped = harness.state().n_fan_rays;
+        assert!(
+            !snapped.is_multiple_of(2),
+            "n_fan_rays should be odd after snapping, got {snapped}"
+        );
+    }
 }

--- a/crates/cherry-rs/src/gui/result_package.rs
+++ b/crates/cherry-rs/src/gui/result_package.rs
@@ -1,5 +1,5 @@
 use crate::{
-    CrossSectionView, ParaxialView, TraceResultsCollection,
+    CrossSectionView, FieldSpec, ParaxialView, TraceResultsCollection,
     core::math::{linalg::mat3x3::Mat3x3, vec3::Vec3},
 };
 
@@ -25,6 +25,9 @@ pub struct ResultPackage {
     pub wavelengths: Vec<f64>,
     pub surfaces: Vec<SurfaceDesc>,
     pub fields: Vec<FieldDesc>,
+    /// Parsed field specs in the same order as `fields`. Used by the Ray Fan
+    /// Plot window for TA computation and the paraxial chief-ray fallback.
+    pub field_specs: Vec<FieldSpec>,
     pub paraxial: Option<ParaxialView>,
     pub ray_trace: Option<TraceResultsCollection>,
     pub cross_section: Option<CrossSectionView>,
@@ -39,6 +42,7 @@ impl ResultPackage {
             wavelengths: Vec::new(),
             surfaces: Vec::new(),
             fields: Vec::new(),
+            field_specs: Vec::new(),
             paraxial: None,
             ray_trace: None,
             cross_section: None,

--- a/crates/cherry-rs/src/gui/windows/cross_section.rs
+++ b/crates/cherry-rs/src/gui/windows/cross_section.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 
 const VIEWPORT_HEIGHT_RATIO: f32 = 0.5;
+const MAX_CROSS_SECTION_N_RAYS: u32 = 32;
 const MIN_VIEWPORT_HEIGHT: f32 = 200.0;
 const SCALEBAR_MARGIN: f32 = 8.0;
 const SCALEBAR_HEIGHT: f32 = 4.0;
@@ -49,16 +50,16 @@ impl CrossSectionWindow {
         result: Option<&ResultPackage>,
         n_rays: &mut u32,
     ) -> bool {
-        let old = *n_rays;
+        let mut changed = false;
         egui::Window::new("Cross Section")
             .open(open)
             .default_width(700.0)
             .min_width(300.0)
             .resizable(true)
             .show(ctx, |ui| {
-                self.show_content(ui, result, n_rays);
+                changed = self.show_content(ui, result, n_rays);
             });
-        *n_rays != old
+        changed
     }
 
     fn show_content(
@@ -66,16 +67,16 @@ impl CrossSectionWindow {
         ui: &mut egui::Ui,
         result: Option<&ResultPackage>,
         n_rays: &mut u32,
-    ) {
+    ) -> bool {
         let Some(result) = result else {
             self.show_empty_viewport(ui);
-            return;
+            return false;
         };
 
         let cs_data = result.cross_section.as_ref();
 
         // Controls.
-        self.show_controls(ui, cs_data, n_rays);
+        let changed = self.show_controls(ui, cs_data, n_rays);
         ui.separator();
 
         // Viewport.
@@ -90,6 +91,8 @@ impl CrossSectionWindow {
                 self.show_empty_viewport(ui);
             }
         }
+
+        changed
     }
 
     fn show_controls(
@@ -97,7 +100,7 @@ impl CrossSectionWindow {
         ui: &mut egui::Ui,
         cs_data: Option<&CrossSectionView>,
         n_rays: &mut u32,
-    ) {
+    ) -> bool {
         // Auto-select the valid plane.
         if let Some(cs) = cs_data {
             if self.cutting_plane == CuttingPlane::YZ && !cs.yz_valid && cs.xz_valid {
@@ -110,6 +113,7 @@ impl CrossSectionWindow {
         let yz_valid = cs_data.is_none_or(|cs| cs.yz_valid);
         let xz_valid = cs_data.is_none_or(|cs| cs.xz_valid);
 
+        let mut changed = false;
         ui.horizontal(|ui| {
             ui.label("Plane:");
             ui.add_enabled_ui(yz_valid, |ui| {
@@ -120,12 +124,16 @@ impl CrossSectionWindow {
             });
             ui.separator();
             ui.label("Rays:");
-            ui.add(
+            let resp = ui.add(
                 egui::DragValue::new(n_rays)
-                    .range(0_u32..=1000_u32)
+                    .range(0_u32..=MAX_CROSS_SECTION_N_RAYS)
                     .speed(1.0),
             );
+            if resp.changed() {
+                changed = true;
+            }
         });
+        changed
     }
 
     fn show_viewport(&self, ui: &mut egui::Ui, cs: &CrossSectionView, wavelengths: &[f64]) {
@@ -769,6 +777,35 @@ mod tests {
     }
 
     #[test]
+    fn n_rays_change_does_not_signal_recompute_without_result() {
+        // show() must return false when there is no result, even if n_rays
+        // changes, because there is nothing to recompute.
+        struct State {
+            window: CrossSectionWindow,
+            n_rays: u32,
+            changed: bool,
+        }
+        let state = State {
+            window: CrossSectionWindow::default(),
+            n_rays: 3,
+            changed: false,
+        };
+        let mut harness = Harness::new_state(
+            |ctx, s: &mut State| {
+                let mut open = true;
+                s.changed = s.window.show(ctx, &mut open, None, &mut s.n_rays);
+            },
+            state,
+        );
+        harness.step();
+        harness.step();
+        assert!(
+            !harness.state().changed,
+            "show() must not signal recompute when result is None"
+        );
+    }
+
+    #[test]
     fn neither_valid_shows_message() {
         let window = CrossSectionWindow::default();
         use crate::views::cross_section::{Bounds2D, CrossSectionView, PlaneGeometry};
@@ -798,6 +835,7 @@ mod tests {
             wavelengths: vec![0.5876],
             surfaces: Vec::new(),
             fields: Vec::new(),
+            field_specs: Vec::new(),
             paraxial: None,
             ray_trace: None,
             cross_section: Some(cs),

--- a/crates/cherry-rs/src/gui/windows/mod.rs
+++ b/crates/cherry-rs/src/gui/windows/mod.rs
@@ -2,6 +2,7 @@ mod cross_section;
 #[cfg(feature = "ri-info")]
 mod materials;
 mod paraxial;
+mod ray_fan;
 mod specs;
 mod spot_diagram;
 mod system;
@@ -10,6 +11,7 @@ pub use cross_section::{CrossSectionWindow, CuttingPlane};
 #[cfg(feature = "ri-info")]
 pub use materials::MaterialsWindow;
 pub use paraxial::ParaxialWindow;
+pub use ray_fan::RayFanWindow;
 pub use specs::SpecsWindow;
 pub use spot_diagram::SpotDiagramWindow;
 pub use system::SystemWindow;
@@ -23,6 +25,7 @@ pub struct WindowVisibility {
     pub paraxial_summary: bool,
     pub spot_diagram: bool,
     pub cross_section: bool,
+    pub ray_fan: bool,
     pub system: bool,
 }
 
@@ -34,6 +37,7 @@ impl Default for WindowVisibility {
             paraxial_summary: false,
             spot_diagram: false,
             cross_section: false,
+            ray_fan: false,
             system: false,
         }
     }

--- a/crates/cherry-rs/src/gui/windows/paraxial.rs
+++ b/crates/cherry-rs/src/gui/windows/paraxial.rs
@@ -242,6 +242,7 @@ mod tests {
             wavelengths: wls,
             surfaces: Vec::new(),
             fields: Vec::new(),
+            field_specs: parsed.fields.clone(),
             paraxial: Some(pv),
             ray_trace: None,
             cross_section: None,

--- a/crates/cherry-rs/src/gui/windows/ray_fan.rs
+++ b/crates/cherry-rs/src/gui/windows/ray_fan.rs
@@ -1,0 +1,648 @@
+use std::collections::HashMap;
+
+use crate::{
+    FieldSpec, SubModelID, TraceResults,
+    core::math::vec3::Vec3,
+    gui::{
+        colors::wavelength_to_color,
+        result_package::{ResultPackage, SurfaceDesc},
+    },
+    views::ray_trace_3d::RayBundle,
+};
+use egui_plot::{HLine, Line, Plot, PlotPoints};
+
+const PLOT_SIZE: f32 = 180.0;
+
+/// `[pupil_coord, ta]` pairs for one (field, wavelength, fan-type) combination.
+struct TaCurve {
+    points: Vec<[f64; 2]>,
+}
+
+/// Precomputed TA data for one field column.
+struct FieldTaData {
+    /// True when at least one wavelength uses the paraxial chief-ray fallback.
+    paraxial_fallback: bool,
+    /// Tangential TA curves, keyed by wavelength_id.
+    tangential: HashMap<usize, TaCurve>,
+    /// Sagittal TA curves, keyed by wavelength_id.
+    sagittal: HashMap<usize, TaCurve>,
+}
+
+/// Floating Ray Fan Plot window.
+#[derive(Default)]
+pub struct RayFanWindow {
+    wavelength_visible: Vec<bool>,
+    last_n_wavelengths: usize,
+}
+
+impl RayFanWindow {
+    /// Show the Ray Fan Plot window.
+    pub fn show(&mut self, ctx: &egui::Context, open: &mut bool, result: Option<&ResultPackage>) {
+        egui::Window::new("Ray Fan Plot")
+            .open(open)
+            .default_width(640.0)
+            .show(ctx, |ui| {
+                if let Some(r) = result
+                    && r.wavelengths.len() != self.last_n_wavelengths
+                {
+                    self.wavelength_visible = vec![true; r.wavelengths.len()];
+                    self.last_n_wavelengths = r.wavelengths.len();
+                }
+                match result {
+                    None => {
+                        ui.label("No data yet.");
+                    }
+                    Some(r) if r.ray_trace.is_none() => {
+                        let msg = r.error.as_deref().unwrap_or("unknown");
+                        ui.colored_label(
+                            egui::Color32::RED,
+                            format!("Ray trace unavailable: {msg}"),
+                        );
+                    }
+                    Some(r) => self.render_content(ui, r),
+                }
+            });
+    }
+
+    fn render_content(&mut self, ui: &mut egui::Ui, r: &ResultPackage) {
+        let n_fields = r.fields.len();
+        let n_wl = r.wavelengths.len();
+
+        if n_fields == 0 {
+            ui.label("No fields defined.");
+            return;
+        }
+
+        // Wavelength toggles — outside the scroll area, always visible.
+        if n_wl > 1 {
+            ui.horizontal(|ui| {
+                for (i, &wl) in r.wavelengths.iter().enumerate() {
+                    if let Some(v) = self.wavelength_visible.get_mut(i) {
+                        let color = wavelength_to_color(wl);
+                        ui.checkbox(
+                            v,
+                            egui::RichText::new(format!("{wl:.4} \u{00b5}m")).color(color),
+                        );
+                    }
+                }
+            });
+        }
+
+        // Compute TA curves for all fields.
+        let image_surf = r.surfaces.last();
+        let ta_data: Vec<FieldTaData> = (0..n_fields)
+            .map(|fid| compute_field_ta(r, fid, image_surf))
+            .collect();
+
+        // Shared Y scales: tangential and sagittal computed independently.
+        let (tan_min, tan_max) =
+            shared_y_scale(&ta_data, &self.wavelength_visible, |fd| &fd.tangential);
+        let (sag_min, sag_max) =
+            shared_y_scale(&ta_data, &self.wavelength_visible, |fd| &fd.sagittal);
+
+        // Plot grid: row headers on left (fixed), scrollable field columns on right.
+        ui.horizontal_top(|ui| {
+            // Row headers — not inside the scroll area so they don't scroll away.
+            ui.vertical(|ui| {
+                // Spacer to align with the column-header row (~24 px).
+                ui.add_space(24.0);
+                for label in &["Tangential", "Sagittal"] {
+                    let (rect, _) = ui.allocate_exact_size(
+                        egui::vec2(70.0, PLOT_SIZE),
+                        egui::Sense::hover(),
+                    );
+                    ui.painter_at(rect).text(
+                        rect.center(),
+                        egui::Align2::CENTER_CENTER,
+                        *label,
+                        egui::FontId::proportional(12.0),
+                        ui.visuals().text_color(),
+                    );
+                }
+            });
+
+            // Scrollable field columns.
+            egui::ScrollArea::horizontal()
+                .id_salt("ray_fan_scroll")
+                .show(ui, |ui| {
+                    ui.horizontal_top(|ui| {
+                        for (fid, field_data) in ta_data.iter().enumerate() {
+                            let field_label =
+                                r.fields.get(fid).map(|f| f.label.as_str()).unwrap_or("\u{2014}");
+                            ui.vertical(|ui| {
+                                // Column header.
+                                ui.horizontal(|ui| {
+                                    ui.label(field_label);
+                                    if field_data.paraxial_fallback {
+                                        ui.label("\u{26a0}").on_hover_text(
+                                            "Chief ray vignetted \u{2014} TA reference from paraxial model",
+                                        );
+                                    }
+                                });
+
+                                let plot_ctx = FanPlotCtx {
+                                    wavelengths: &r.wavelengths,
+                                    wavelength_visible: &self.wavelength_visible,
+                                };
+                                draw_fan_plot(
+                                    ui,
+                                    format!("rf_tan_{fid}"),
+                                    "Tangential TA (mm)",
+                                    &field_data.tangential,
+                                    &plot_ctx,
+                                    tan_min,
+                                    tan_max,
+                                );
+                                draw_fan_plot(
+                                    ui,
+                                    format!("rf_sag_{fid}"),
+                                    "Sagittal TA (mm)",
+                                    &field_data.sagittal,
+                                    &plot_ctx,
+                                    sag_min,
+                                    sag_max,
+                                );
+                            });
+                        }
+                    });
+                });
+        });
+    }
+}
+
+// ── Plot drawing
+// ──────────────────────────────────────────────────────────────
+
+struct FanPlotCtx<'a> {
+    wavelengths: &'a [f64],
+    wavelength_visible: &'a [bool],
+}
+
+fn draw_fan_plot(
+    ui: &mut egui::Ui,
+    id: String,
+    y_label: &str,
+    curves: &HashMap<usize, TaCurve>,
+    ctx: &FanPlotCtx<'_>,
+    y_min: f64,
+    y_max: f64,
+) {
+    let FanPlotCtx {
+        wavelengths,
+        wavelength_visible,
+    } = ctx;
+    Plot::new(id)
+        .width(PLOT_SIZE)
+        .height(PLOT_SIZE)
+        .x_axis_label("p")
+        .y_axis_label(y_label)
+        .include_x(-1.0)
+        .include_x(1.0)
+        .include_y(y_min)
+        .include_y(y_max)
+        .allow_zoom(false)
+        .allow_drag(false)
+        .allow_scroll(false)
+        .allow_boxed_zoom(false)
+        .allow_double_click_reset(false)
+        .show(ui, |plot_ui| {
+            // Zero reference line.
+            plot_ui.hline(
+                HLine::new("zero", 0.0)
+                    .color(egui::Color32::from_gray(140))
+                    .width(1.0),
+            );
+
+            for (wl_id, &visible) in wavelength_visible.iter().enumerate() {
+                if !visible {
+                    continue;
+                }
+                let Some(curve) = curves.get(&wl_id) else {
+                    continue;
+                };
+                if curve.points.is_empty() {
+                    continue;
+                }
+                let color = wavelengths
+                    .get(wl_id)
+                    .copied()
+                    .map(wavelength_to_color)
+                    .unwrap_or(egui::Color32::WHITE);
+                let name = wavelengths
+                    .get(wl_id)
+                    .map(|w| format!("{w:.4} \u{00b5}m"))
+                    .unwrap_or_default();
+                plot_ui.line(
+                    Line::new(name, PlotPoints::new(curve.points.clone()))
+                        .color(color)
+                        .width(1.5),
+                );
+            }
+        });
+}
+
+// ── TA computation
+// ────────────────────────────────────────────────────────────
+
+/// Compute TA data for one field column across all wavelengths.
+fn compute_field_ta(
+    r: &ResultPackage,
+    field_id: usize,
+    image_surf: Option<&SurfaceDesc>,
+) -> FieldTaData {
+    let empty = FieldTaData {
+        paraxial_fallback: false,
+        tangential: HashMap::new(),
+        sagittal: HashMap::new(),
+    };
+    let Some(ray_trace) = &r.ray_trace else {
+        return empty;
+    };
+    let Some(image_surf) = image_surf else {
+        return empty;
+    };
+
+    let phi = r
+        .field_specs
+        .get(field_id)
+        .map(|fs| fs.tangential_fan_phi())
+        .unwrap_or(0.0);
+
+    // Direction vectors in global frame: R_cursor_to_global = rot_mat^T.
+    let rot_t = image_surf.rot_mat.transpose();
+    let tan_dir = rot_t * Vec3::new(phi.cos(), phi.sin(), 0.0);
+    let sag_dir = rot_t * Vec3::new(-phi.sin(), phi.cos(), 0.0);
+
+    let mut tangential: HashMap<usize, TaCurve> = HashMap::new();
+    let mut sagittal: HashMap<usize, TaCurve> = HashMap::new();
+    let mut paraxial_fallback = false;
+
+    for wl_id in 0..r.wavelengths.len() {
+        let Some(tr) = ray_trace.get(field_id, wl_id) else {
+            continue;
+        };
+
+        let (chief_pos, used_fallback) =
+            chief_ray_image_pos(tr, r, field_id, wl_id, image_surf, phi);
+        let Some(chief_pos) = chief_pos else {
+            continue;
+        };
+        if used_fallback {
+            paraxial_fallback = true;
+        }
+
+        tangential.insert(
+            wl_id,
+            fan_ta_curve(tr.tangential_fan(), &chief_pos, &tan_dir),
+        );
+        sagittal.insert(wl_id, fan_ta_curve(tr.sagittal_fan(), &chief_pos, &sag_dir));
+    }
+
+    FieldTaData {
+        paraxial_fallback,
+        tangential,
+        sagittal,
+    }
+}
+
+/// Return the chief ray 3D position at the image surface and whether the
+/// paraxial fallback was used.
+fn chief_ray_image_pos(
+    tr: &TraceResults,
+    r: &ResultPackage,
+    field_id: usize,
+    wl_id: usize,
+    image_surf: &SurfaceDesc,
+    phi: f64,
+) -> (Option<Vec3>, bool) {
+    if tr.chief_ray_reached_image() {
+        let bundle = tr.chief_ray();
+        let n_surf = bundle.num_surfaces();
+        if n_surf == 0 {
+            return (None, false);
+        }
+        let rays = bundle.rays();
+        // Chief ray bundle has exactly 1 ray; rays are stored flat with 1 per surface.
+        let Some(ray) = rays.get(n_surf - 1) else {
+            return (None, false);
+        };
+        (Some(Vec3::new(ray.x(), ray.y(), ray.z())), false)
+    } else {
+        // Paraxial fallback.
+        let Some(pv) = &r.paraxial else {
+            return (None, false);
+        };
+        let v_index = pv.v_index_for_phi(phi);
+        let sub_id = SubModelID(wl_id, v_index);
+        let Some(sv) = pv.subviews().get(&sub_id) else {
+            return (None, false);
+        };
+
+        let Some(last) = sv.chief_ray().last_surface() else {
+            return (None, false);
+        };
+        let y_max = last.first().map(|pr| pr.height).unwrap_or(0.0);
+
+        let ratio = r
+            .field_specs
+            .get(field_id)
+            .map(|fs| field_height_ratio(fs, &r.field_specs, phi))
+            .unwrap_or(0.0);
+        let y_fallback = ratio * y_max;
+
+        // Lift scalar paraxial height to a 3D position along the tangential direction.
+        let tv = pv.tangential_vec(v_index);
+        let rot_t = image_surf.rot_mat.transpose();
+        let tan_global = rot_t * tv;
+        let pos = image_surf.pos + tan_global * y_fallback;
+        (Some(pos), true)
+    }
+}
+
+/// Ratio `height_i / height_max` for the paraxial chief-ray fallback scaling.
+fn field_height_ratio(fs: &FieldSpec, all_fields: &[FieldSpec], phi: f64) -> f64 {
+    const EPS: f64 = 1e-9;
+    match fs {
+        FieldSpec::Angle { chi, .. } => {
+            let chi_max = all_fields
+                .iter()
+                .filter(|f| (f.tangential_fan_phi() - phi).abs() < EPS)
+                .filter_map(|f| match f {
+                    FieldSpec::Angle { chi, .. } => Some(chi.abs()),
+                    _ => None,
+                })
+                .fold(0.0_f64, f64::max);
+            if chi_max.abs() < EPS {
+                return 0.0;
+            }
+            chi.to_radians().tan() / chi_max.to_radians().tan()
+        }
+        FieldSpec::PointSource { x, y } => {
+            let r_i = (x.powi(2) + y.powi(2)).sqrt();
+            let r_max = all_fields
+                .iter()
+                .filter_map(|f| match f {
+                    FieldSpec::PointSource { x, y } => Some((x.powi(2) + y.powi(2)).sqrt()),
+                    _ => None,
+                })
+                .fold(0.0_f64, f64::max);
+            if r_max < EPS {
+                return 0.0;
+            }
+            r_i / r_max
+        }
+    }
+}
+
+/// Extract TA values from a fan bundle at the image surface (last surface).
+fn fan_ta_curve(bundle: &RayBundle, chief_pos: &Vec3, dir: &Vec3) -> TaCurve {
+    let total = bundle.rays().len();
+    let n_surf = bundle.num_surfaces();
+    if n_surf == 0 {
+        return TaCurve { points: Vec::new() };
+    }
+    let n_rays = total / n_surf;
+    if n_rays == 0 {
+        return TaCurve { points: Vec::new() };
+    }
+    let image_surf_idx = n_surf - 1;
+    let start = image_surf_idx * n_rays;
+    let rays = bundle.rays();
+    let terminated = bundle.terminated();
+
+    let mut points = Vec::with_capacity(n_rays);
+    for i in 0..n_rays {
+        // Skip terminated rays.
+        if terminated.get(i).copied().unwrap_or(0) > 0 {
+            continue;
+        }
+        let Some(ray) = rays.get(start + i) else {
+            continue;
+        };
+        let p = if n_rays > 1 {
+            -1.0 + 2.0 * i as f64 / (n_rays - 1) as f64
+        } else {
+            0.0
+        };
+        let ray_pos = Vec3::new(ray.x(), ray.y(), ray.z());
+        let delta = ray_pos - *chief_pos;
+        let ta = delta.dot(dir);
+        points.push([p, ta]);
+    }
+    TaCurve { points }
+}
+
+/// Shared [min, max] Y range for all visible wavelengths across all field
+/// columns. Adds ~15% padding. Falls back to a tiny default range when no data.
+fn shared_y_scale<F>(ta_data: &[FieldTaData], wavelength_visible: &[bool], get_map: F) -> (f64, f64)
+where
+    F: Fn(&FieldTaData) -> &HashMap<usize, TaCurve>,
+{
+    let mut y_min = f64::MAX;
+    let mut y_max = f64::MIN;
+    for fd in ta_data {
+        for (wl_id, &visible) in wavelength_visible.iter().enumerate() {
+            if !visible {
+                continue;
+            }
+            if let Some(curve) = get_map(fd).get(&wl_id) {
+                for &[_, ta] in &curve.points {
+                    y_min = y_min.min(ta);
+                    y_max = y_max.max(ta);
+                }
+            }
+        }
+    }
+    if y_min > y_max {
+        return (-1e-6, 1e-6);
+    }
+    let span = (y_max - y_min).max(1e-9);
+    let pad = span * 0.15;
+    (y_min - pad, y_max + pad)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use egui_kittest::{Harness, kittest::Queryable};
+
+    use crate::gui::result_package::{FieldDesc, ResultPackage};
+
+    /// Build a minimal ResultPackage with the given wavelengths and a single
+    /// on-axis angle field. Surfaces and ray trace are omitted so the window
+    /// falls through to the "ray trace unavailable" branch — sufficient for
+    /// label / toggle tests.
+    fn make_minimal(wavelengths: &[f64]) -> ResultPackage {
+        ResultPackage {
+            id: 1,
+            wavelengths: wavelengths.to_vec(),
+            surfaces: Vec::new(),
+            fields: vec![FieldDesc {
+                label: "\u{03c7}=0.000\u{00b0}, \u{03c6}=90.000\u{00b0}".to_string(),
+            }],
+            field_specs: vec![crate::FieldSpec::Angle {
+                chi: 0.0,
+                phi: 90.0,
+            }],
+            paraxial: None,
+            ray_trace: None,
+            cross_section: None,
+            error: None,
+        }
+    }
+
+    /// Build a full ResultPackage (with ray trace) for the given wavelengths
+    /// using the default SystemSpecs (convexplano-like default lens).
+    fn make_result(wavelengths: &[&str]) -> ResultPackage {
+        use crate::gui::{convert, model::SystemSpecs};
+        use crate::{
+            ParaxialView, SequentialModel, ray_trace_3d_view, views::ray_trace_3d::SamplingConfig,
+        };
+
+        let specs = SystemSpecs {
+            wavelengths: wavelengths.iter().map(|s| s.to_string()).collect(),
+            n_fan_rays: 11,
+            ..Default::default()
+        };
+        #[cfg(not(feature = "ri-info"))]
+        let parsed = convert::convert_specs(&specs).expect("convert");
+        #[cfg(feature = "ri-info")]
+        let parsed = convert::convert_specs(&specs, &Default::default()).expect("convert");
+        let seq = SequentialModel::new(&parsed.gaps, &parsed.surfaces, &parsed.wavelengths)
+            .expect("model");
+        let pv = ParaxialView::new(&seq, &parsed.fields, false).expect("paraxial");
+        let config = SamplingConfig {
+            n_fan_rays: 11,
+            cross_section_n_fan_rays: 3,
+            full_pupil_spacing: 0.1,
+        };
+        let trace = ray_trace_3d_view(&parsed.aperture, &parsed.fields, &seq, &pv, config).ok();
+        let wls = seq.wavelengths().to_vec();
+
+        // Build surface descs manually (mirrors compute.rs logic).
+        use crate::{core::sequential_model::Surface, gui::result_package::SurfaceDesc};
+        let surfaces: Vec<SurfaceDesc> = seq
+            .surfaces()
+            .iter()
+            .enumerate()
+            .map(|(i, s)| {
+                let name = match s {
+                    Surface::Conic(_) => "Conic",
+                    Surface::Image(_) => "Image",
+                    Surface::Object(_) => "Object",
+                    Surface::Probe(_) => "Probe",
+                    Surface::Stop(_) => "Stop",
+                };
+                SurfaceDesc {
+                    index: i,
+                    label: format!("{name} [{i}]"),
+                    pos: s.pos(),
+                    rot_mat: s.rot_mat(),
+                }
+            })
+            .collect();
+
+        let fields: Vec<FieldDesc> = parsed
+            .fields
+            .iter()
+            .map(|f| {
+                let label = match f {
+                    crate::FieldSpec::Angle { chi, phi } => {
+                        format!("\u{03c7}={chi:.3}\u{00b0}, \u{03c6}={phi:.3}\u{00b0}")
+                    }
+                    crate::FieldSpec::PointSource { x, y } => format!("({x}, {y}) mm"),
+                };
+                FieldDesc { label }
+            })
+            .collect();
+
+        ResultPackage {
+            id: 1,
+            wavelengths: wls,
+            surfaces,
+            fields,
+            field_specs: parsed.fields.clone(),
+            paraxial: Some(pv),
+            ray_trace: trace,
+            cross_section: None,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn no_result_shows_placeholder() {
+        let mut window = RayFanWindow::default();
+        let mut harness = Harness::new(|ctx| {
+            let mut open = true;
+            window.show(ctx, &mut open, None);
+        });
+        harness.step();
+        harness.get_by_label("No data yet.");
+    }
+
+    #[test]
+    fn with_result_shows_field_label() {
+        let result = make_result(&["0.567"]);
+        let mut harness = Harness::new_state(
+            |ctx, (w, r): &mut (RayFanWindow, ResultPackage)| {
+                let mut open = true;
+                w.show(ctx, &mut open, Some(r));
+            },
+            (RayFanWindow::default(), result),
+        );
+        harness.step();
+        harness.get_by_label_contains("\u{03c7}=");
+    }
+
+    #[test]
+    fn single_wavelength_no_toggle_row() {
+        let result = make_minimal(&[0.567]);
+        let mut harness = Harness::new_state(
+            |ctx, (w, r): &mut (RayFanWindow, ResultPackage)| {
+                let mut open = true;
+                w.show(ctx, &mut open, Some(r));
+            },
+            (RayFanWindow::default(), result),
+        );
+        harness.step();
+        assert!(
+            harness.query_by_label_contains("\u{00b5}m").is_none(),
+            "wavelength toggle row must not appear for a single wavelength"
+        );
+    }
+
+    #[test]
+    fn multi_wavelength_shows_toggle_row() {
+        let result = make_result(&["0.486", "0.587", "0.656"]);
+        let mut harness = Harness::new_state(
+            |ctx, (w, r): &mut (RayFanWindow, ResultPackage)| {
+                let mut open = true;
+                w.show(ctx, &mut open, Some(r));
+            },
+            (RayFanWindow::default(), result),
+        );
+        harness.step();
+        // The toggle row contains wavelength labels; assert at least one per
+        // wavelength.
+        assert!(
+            harness
+                .query_all_by_label_contains("0.4860")
+                .next()
+                .is_some()
+        );
+        assert!(
+            harness
+                .query_all_by_label_contains("0.5870")
+                .next()
+                .is_some()
+        );
+        assert!(
+            harness
+                .query_all_by_label_contains("0.6560")
+                .next()
+                .is_some()
+        );
+    }
+}

--- a/crates/cherry-rs/src/gui/windows/spot_diagram.rs
+++ b/crates/cherry-rs/src/gui/windows/spot_diagram.rs
@@ -395,6 +395,7 @@ mod tests {
             wavelengths: seq.wavelengths().to_vec(),
             surfaces: Vec::new(),
             fields: Vec::new(),
+            field_specs: Vec::new(),
             paraxial: Some(pv),
             ray_trace: None,
             cross_section: None,
@@ -442,6 +443,7 @@ mod tests {
             &pv,
             crate::views::ray_trace_3d::SamplingConfig {
                 n_fan_rays: 3,
+                cross_section_n_fan_rays: 3,
                 full_pupil_spacing: 0.1,
             },
         )
@@ -469,6 +471,7 @@ mod tests {
                     label: "5.000\u{00b0}".into(),
                 },
             ],
+            field_specs: parsed.fields.clone(),
             paraxial: Some(pv),
             ray_trace: Some(trace),
             cross_section: None,

--- a/crates/cherry-rs/src/lib.rs
+++ b/crates/cherry-rs/src/lib.rs
@@ -113,7 +113,7 @@
 //!     &aperture_spec, &field_specs,
 //!     &sequential_model,
 //!     &paraxial_view,
-//!     SamplingConfig { n_fan_rays: 9, full_pupil_spacing: 0.1 },
+//!     SamplingConfig { n_fan_rays: 9, cross_section_n_fan_rays: 3, full_pupil_spacing: 0.1 },
 //! ).unwrap();
 //!
 //! // Get all results for the second (5 degree) field point.

--- a/crates/cherry-rs/src/views/cross_section.rs
+++ b/crates/cherry-rs/src/views/cross_section.rs
@@ -221,7 +221,7 @@ fn build_plane_geometry(
             if wl_id >= n_wavelengths {
                 continue;
             }
-            let bundle = result.tangential_fan();
+            let bundle = result.cross_section_fan();
             let n_surf = bundle.num_surfaces();
             let total = bundle.rays().len();
             let n_rays = if n_surf > 0 { total / n_surf } else { 0 };
@@ -434,6 +434,7 @@ mod tests {
             &pv,
             SamplingConfig {
                 n_fan_rays: 5,
+                cross_section_n_fan_rays: 5,
                 full_pupil_spacing: 0.1,
             },
         )

--- a/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
@@ -33,6 +33,10 @@ use super::paraxial::{ParaxialSubView, ParaxialView};
 pub struct SamplingConfig {
     /// Number of rays in the tangential and sagittal ray fans.
     pub n_fan_rays: usize,
+    /// Number of rays in the tangential fan used for the cross-section view.
+    /// May be 0 (no rays) or any positive integer up to
+    /// MAX_CROSS_SECTION_N_RAYS.
+    pub cross_section_n_fan_rays: usize,
     /// Grid spacing for the full-pupil square-grid sampling, in normalised
     /// pupil coordinates [0, 1].
     pub full_pupil_spacing: Float,
@@ -79,6 +83,9 @@ pub struct TraceResults {
 
     /// A sagittal ray fan perpendicular to the meridional plane.
     sagittal_fan: RayBundle,
+
+    /// A tangential ray fan used exclusively for the cross-section view.
+    cross_section_fan: RayBundle,
 }
 
 /// Perform a 3D ray trace on a sequential model.
@@ -169,6 +176,16 @@ pub fn ray_trace_3d_view(
                     n: config.n_fan_rays,
                 },
             )?;
+            let cross_section_fan = ray_trace_submodel(
+                sequential_submodel,
+                surfaces,
+                aperture_spec,
+                field_spec,
+                paraxial_subview,
+                PupilSampling::TangentialRayFan {
+                    n: config.cross_section_n_fan_rays,
+                },
+            )?;
 
             trace!(
                 field_id,
@@ -185,6 +202,7 @@ pub fn ray_trace_3d_view(
                 full_pupil,
                 tangential_fan,
                 sagittal_fan,
+                cross_section_fan,
             })
         })
         .collect::<Result<Vec<_>>>()?;
@@ -267,9 +285,20 @@ impl TraceResults {
         &self.sagittal_fan
     }
 
+    // Returns the tangential ray fan bundle used for the cross-section view.
+    pub fn cross_section_fan(&self) -> &RayBundle {
+        &self.cross_section_fan
+    }
+
     // Returns the wavelength ID of the ray bundle.
     pub fn wavelength_id(&self) -> usize {
         self.wavelength_id
+    }
+
+    /// Returns true if the chief ray reached the image surface without
+    /// terminating early (aperture miss, convergence failure, etc.).
+    pub fn chief_ray_reached_image(&self) -> bool {
+        self.chief_ray.terminated().first().copied().unwrap_or(0) == 0
     }
 }
 
@@ -331,24 +360,27 @@ fn rays(
                     chi_rad,
                 )?,
                 PupilSampling::TangentialRayFan { n } => {
-                    let fan_phi = field_spec.tangential_fan_phi();
+                    let tan_phi = field_spec.tangential_fan_phi();
                     parallel_ray_fan(
                         surfaces,
                         aperture_spec,
                         paraxial_subview,
                         n,
-                        fan_phi,
+                        tan_phi,
+                        tan_phi,
                         chi_rad,
                     )?
                 }
                 PupilSampling::SagittalRayFan { n } => {
-                    let fan_phi = field_spec.sagittal_fan_phi();
+                    let tan_phi = field_spec.tangential_fan_phi();
+                    let sag_phi = field_spec.sagittal_fan_phi();
                     parallel_ray_fan(
                         surfaces,
                         aperture_spec,
                         paraxial_subview,
                         n,
-                        fan_phi,
+                        tan_phi,
+                        sag_phi,
                         chi_rad,
                     )?
                 }
@@ -400,17 +432,17 @@ fn rays(
 /// * `surfaces` - The surfaces of the system.
 /// * `aperture_spec` - The aperture specification.
 /// * `paraxial_subview` - The paraxial subview.
-/// * `theta` - The polar angle of the ray in the x-y plane.
-/// * `phi` - The angle of the ray w.r.t. the z-axis.
+/// * `phi` - The azimuthal angle of the ray in the x-y plane, radians.
+/// * `chi` - The zenith angle of the ray w.r.t. the z-axis, radians.
 fn chief_ray_from_angle(
     surfaces: &[Surface],
     aperture_spec: &ApertureSpec,
     paraxial_subview: &ParaxialSubView,
-    theta: Float,
     phi: Float,
+    chi: Float,
 ) -> Result<Vec<Ray>> {
-    let origin = parallel_ray_bundle_origin(surfaces, aperture_spec, paraxial_subview, theta, phi)?;
-    let dir = Vec3::new(theta.cos() * phi.sin(), theta.sin() * phi.sin(), phi.cos()).normalize();
+    let origin = parallel_ray_bundle_origin(surfaces, aperture_spec, paraxial_subview, phi, chi)?;
+    let dir = Vec3::new(phi.cos() * chi.sin(), phi.sin() * chi.sin(), chi.cos()).normalize();
 
     Ok(vec![Ray::new(origin, dir)])
 }
@@ -443,29 +475,54 @@ fn chief_ray_from_pos(
 /// * `aperture_spec` - The aperture specification.
 /// * `paraxial_subview` - The paraxial subview.
 /// * `num_rays` - The number of rays in the fan.
-/// * `theta` - The polar angle of the ray fan in the x-y plane.
-/// * `phi` - The angle of the ray w.r.t. the z-axis.
+/// * `fan_origin_phi` - The azimuthal angle of the fan's origin point, radians.
+/// * `fan_spread_phi` - The azimuthal angle of the plane containing the ray
+///   fan, radians.
+/// * `chi` - The zenith angle of the ray w.r.t. the z-axis, radians.
 #[allow(clippy::too_many_arguments)]
 fn parallel_ray_fan(
     surfaces: &[Surface],
     aperture_spec: &ApertureSpec,
     paraxial_subview: &ParaxialSubView,
     num_rays: usize,
-    theta: Float,
-    phi: Float,
+    fan_origin_phi: Float,
+    fan_spread_phi: Float,
+    chi: Float,
 ) -> Result<Vec<Ray>> {
     let enp = entrance_pupil(aperture_spec, paraxial_subview)?;
-    let origin = parallel_ray_bundle_origin(surfaces, aperture_spec, paraxial_subview, theta, phi)?;
+    let origin = parallel_ray_bundle_origin(
+        surfaces,
+        aperture_spec,
+        paraxial_subview,
+        fan_origin_phi,
+        chi,
+    )?;
 
     let rays = Ray::parallel_ray_fan(
         num_rays,
         enp.semi_diameter,
         origin.z(),
-        theta,
-        phi,
+        fan_spread_phi,
+        fan_origin_phi,
+        chi,
         origin.x(),
         origin.y(),
     );
+
+    if let Some(center) = rays.get(num_rays / 2) {
+        trace!(
+            fan_origin_phi,
+            fan_spread_phi,
+            chi,
+            origin_x = origin.x(),
+            origin_y = origin.y(),
+            origin_z = origin.z(),
+            dir_x = center.k(),
+            dir_y = center.l(),
+            dir_z = center.m(),
+            "parallel_ray_fan: center ray (p=0) origin and direction"
+        );
+    }
 
     Ok(rays)
 }
@@ -483,24 +540,24 @@ fn parallel_ray_fan(
 ///   distances, i.e. [0, 1]. A spacing of 1.0 means that one ray will lie at
 ///   the pupil center (the chief ray) and the others will lie at the pupil edge
 ///   (marginal rays).
-/// * `phi` - The angle of the ray bundle w.r.t. the z-axis in radians.
+/// * `chi` - The zenith angle of the ray bundle w.r.t. the z-axis in radians.
 fn parallel_ray_bundle_on_sq_grid(
     surfaces: &[Surface],
     aperture_spec: &ApertureSpec,
     paraxial_subview: &ParaxialSubView,
     spacing: Float,
-    phi: Float,
+    chi: Float,
 ) -> Result<Vec<Ray>> {
     let enp = entrance_pupil(aperture_spec, paraxial_subview)?;
     let abs_spacing = enp.semi_diameter * spacing;
     let origin =
-        parallel_ray_bundle_origin(surfaces, aperture_spec, paraxial_subview, PI / 2.0, phi)?;
+        parallel_ray_bundle_origin(surfaces, aperture_spec, paraxial_subview, PI / 2.0, chi)?;
 
     let rays = Ray::parallel_ray_bundle_on_sq_grid(
         enp.semi_diameter,
         abs_spacing,
         origin.z(),
-        phi,
+        chi,
         origin.x(),
         origin.y(),
     );
@@ -666,14 +723,14 @@ fn axial_launch_point(obj_z: Float, sur_z: Float, enp_z: Float) -> Float {
 /// * `surfaces` - The surfaces of the system.
 /// * `aperture_spec` - The aperture specification.
 /// * `paraxial_subview` - The paraxial subview.
-/// * `theta` - The polar angle of the ray fan in the x-y plane.
-/// * `phi` - The angle of the ray w.r.t. the z-axis.
+/// * `phi` - The azimuthal angle of the ray fan in the x-y plane, radians.
+/// * `chi` - The zenith angle of the ray w.r.t. the z-axis, radians.
 fn parallel_ray_bundle_origin(
     surfaces: &[Surface],
     aperture_spec: &ApertureSpec,
     paraxial_subview: &ParaxialSubView,
-    theta: Float,
     phi: Float,
+    chi: Float,
 ) -> Result<Vec3> {
     let enp = entrance_pupil(aperture_spec, paraxial_subview)?;
     let obj_z = surfaces[0].pos().z();
@@ -682,13 +739,13 @@ fn parallel_ray_bundle_origin(
 
     let launch_point_z = axial_launch_point(obj_z, sur_z, enp_z);
 
-    // Determine the radial distance from the axis at the launch point for the
-    // center of the ray fan.
+    // Determine the perpendicular distance from the axis at the launch point for
+    // the center of the ray fan.
     let dz = enp_z - launch_point_z;
+    let r = -dz * chi.tan();
 
-    let r = -dz * phi.tan();
-    let x = r * theta.cos();
-    let y = r * theta.sin();
+    let x = r * phi.cos();
+    let y = r * phi.sin();
 
     Ok(Vec3::new(x, y, launch_point_z))
 }
@@ -746,6 +803,7 @@ mod tests {
 
         let config = SamplingConfig {
             n_fan_rays: 3,
+            cross_section_n_fan_rays: 3,
             full_pupil_spacing: 0.1,
         };
         let results = ray_trace_3d_view(
@@ -765,6 +823,7 @@ mod tests {
         let s = setup();
         let config = SamplingConfig {
             n_fan_rays: 5,
+            cross_section_n_fan_rays: 5,
             full_pupil_spacing: 0.1,
         };
 
@@ -836,13 +895,70 @@ mod tests {
 
         assert_eq!(fan_rays.len(), 3);
 
-        // Sagittal fan phi = tangential_fan_phi + π/2 = π/2 + π/2 = π.
-        // Vec3::fan with theta=π spreads positions along (-cos π, -sin π) = (+1, 0),
+        // fan_spread_phi = sagittal_fan_phi = tangential_fan_phi + π/2 = π/2 + π/2 = π.
+        // Vec3::fan with phi=π spreads positions along (cos π, sin π) = (-1, 0),
         // so the three ray origins differ in X and share the same Y coordinate.
         let xs: Vec<f64> = fan_rays.iter().map(|r| r.x()).collect();
         let ys: Vec<f64> = fan_rays.iter().map(|r| r.y()).collect();
         assert!(xs.iter().any(|x| (x - xs[0]).abs() > 1e-6));
         assert!(ys.windows(2).all(|w| (w[1] - w[0]).abs() < 1e-6));
+        // fan_origin_phi = tangential_fan_phi, so the center ray (index 1 of 3)
+        // is displaced in the tangential (Y) direction, not zero.
+        assert!(
+            ys[1].abs() > 1e-6,
+            "sagittal fan center should be offset in the tangential direction"
+        );
+    }
+
+    /// Regression test: The sagittal fan rays must travel in the field
+    /// direction, not in the sagittal-plane direction.  For phi=90°, chi=5°
+    /// the field direction is (0, sin 5°, cos 5°); the sagittal fan
+    /// incorrectly used fan_spread_phi for the ray direction, giving (-sin
+    /// 5°, 0, cos 5°).
+    #[test]
+    fn test_sagittal_fan_ray_direction_matches_field() {
+        let air = n!(1.0);
+        let nbk7 = n!(1.515);
+        let wavelengths: [Float; 1] = [0.5876];
+        let seq_model = sequential_model(air, nbk7, &wavelengths);
+        let aperture_spec = ApertureSpec::EntrancePupil {
+            semi_diameter: 12.5,
+        };
+        let field_spec = FieldSpec::Angle {
+            chi: 5.0,
+            phi: 90.0,
+        };
+        let paraxial_view = ParaxialView::new(&seq_model, &[field_spec], false).unwrap();
+
+        let chief = rays(
+            seq_model.surfaces(),
+            &aperture_spec,
+            &paraxial_view.subviews()[&SubModelID(0, 0)],
+            &field_spec,
+            PupilSampling::ChiefRay,
+        )
+        .unwrap();
+        let sag_fan = rays(
+            seq_model.surfaces(),
+            &aperture_spec,
+            &paraxial_view.subviews()[&SubModelID(0, 0)],
+            &field_spec,
+            PupilSampling::SagittalRayFan { n: 3 },
+        )
+        .unwrap();
+
+        let chief_dir = (chief[0].k(), chief[0].l(), chief[0].m());
+
+        // Every sagittal fan ray must travel in the same direction as the chief ray.
+        for (i, r) in sag_fan.iter().enumerate() {
+            let dir = (r.k(), r.l(), r.m());
+            assert!(
+                (dir.0 - chief_dir.0).abs() < 1e-10
+                    && (dir.1 - chief_dir.1).abs() < 1e-10
+                    && (dir.2 - chief_dir.2).abs() < 1e-10,
+                "sagittal fan ray {i} direction {dir:?} != chief ray direction {chief_dir:?}"
+            );
+        }
     }
 
     #[test]
@@ -1084,6 +1200,7 @@ mod tests {
         let paraxial_view = ParaxialView::new(&sequential_model, &field_specs, false).unwrap();
         let config = SamplingConfig {
             n_fan_rays: 3,
+            cross_section_n_fan_rays: 3,
             full_pupil_spacing: 0.1,
         };
 
@@ -1133,5 +1250,33 @@ mod tests {
 
         // For a 45° fan, dy/dx should equal tan(45°) = 1.0
         approx::assert_abs_diff_eq!(dy / dx, 1.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn chief_ray_reached_image_on_axis() {
+        // On-axis chief ray should always reach the image surface in a standard
+        // refractive system.
+        let s = setup();
+        let config = SamplingConfig {
+            n_fan_rays: 3,
+            cross_section_n_fan_rays: 3,
+            full_pupil_spacing: 0.1,
+        };
+        let results = ray_trace_3d_view(
+            &s.aperture_spec,
+            &s.field_specs,
+            &s.sequential_model,
+            &s.paraxial_view,
+            config,
+        )
+        .unwrap();
+
+        let on_axis = results
+            .get(0, 0)
+            .expect("field 0, wavelength 0 should exist");
+        assert!(
+            on_axis.chief_ray_reached_image(),
+            "On-axis chief ray should reach the image surface"
+        );
     }
 }

--- a/crates/cherry-rs/src/views/ray_trace_3d/rays.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/rays.rs
@@ -269,19 +269,22 @@ impl Ray {
         self.dir.n()
     }
 
-    /// Create a fan of uniformly spaced rays in a given z-plane at an angle phi
-    /// to the z-axis.
+    /// Create a fan of uniformly spaced rays in a given z-plane at a zenith
+    /// angle chi to the z-axis.
     ///
-    /// The vectors have endpoints at an angle theta with respect to the x-axis
-    /// and extend from distances -r to r from the point (0, 0, z). The rays
-    /// are at an angle phi from the z-axis.
+    /// The vectors have endpoints at an azimuthal angle spread_phi with respect
+    /// to the x-axis and extend from distances -r to r from the point (0, 0,
+    /// z). All rays share the same direction, given by field_phi and chi.
     ///
     /// # Arguments
     /// * `n`: Number of vectors to create
     /// * `r`: Radial span of vector endpoints from [-r, r]
     /// * `z`: z-coordinate of endpoints
-    /// * `theta` : The polar angle of the ray fan in the x-y plane.
-    /// * `phi``: Angle of vectors with respect to z, the optics axis, radians
+    /// * `spread_phi`: Azimuthal angle of the fan spread in the x-y plane,
+    ///   radians.
+    /// * `field_phi`: Azimuthal angle of the field direction, radians.
+    /// * `chi`: Zenith angle of vectors with respect to z, the optics axis,
+    ///   radians.
     /// * `radial_offset_x`: Offset the radial position of the vectors by this
     ///   amount in x
     /// * `radial_offset_y`: Offset the radial position of the vectors by this
@@ -291,18 +294,19 @@ impl Ray {
         n: usize,
         r: Float,
         z: Float,
-        theta: Float,
-        phi: Float,
+        spread_phi: Float,
+        field_phi: Float,
+        chi: Float,
         radial_offset_x: Float,
         radial_offset_y: Float,
     ) -> Vec<Ray> {
-        let pos = Vec3::fan(n, r, z, theta, radial_offset_x, radial_offset_y);
+        let pos = Vec3::fan(n, r, z, spread_phi, radial_offset_x, radial_offset_y);
         let dir: Vec<Vec3> = pos
             .iter()
             .map(|_| {
-                let l = phi.sin() * theta.cos();
-                let m = phi.sin() * theta.sin();
-                let n = phi.cos();
+                let l = chi.sin() * field_phi.cos();
+                let m = chi.sin() * field_phi.sin();
+                let n = chi.cos();
                 Vec3::new(l, m, n)
             })
             .collect();

--- a/crates/cherry-rs/tests/f_theta_scan_lens.rs
+++ b/crates/cherry-rs/tests/f_theta_scan_lens.rs
@@ -37,6 +37,7 @@ fn test_ray_trace_3d_on_axis() {
         &paraxial_view,
         SamplingConfig {
             n_fan_rays: 9,
+            cross_section_n_fan_rays: 3,
             full_pupil_spacing: 0.1,
         },
     )
@@ -72,6 +73,7 @@ fn test_ray_trace_3d_off_axis() {
         &paraxial_view,
         SamplingConfig {
             n_fan_rays: 9,
+            cross_section_n_fan_rays: 3,
             full_pupil_spacing: 0.1,
         },
     )
@@ -97,6 +99,7 @@ fn test_ray_trace_3d_square_grid() {
         &paraxial_view,
         SamplingConfig {
             n_fan_rays: 9,
+            cross_section_n_fan_rays: 3,
             full_pupil_spacing: 0.5,
         },
     )


### PR DESCRIPTION
Transverse ray aberration plots have now been added to the GUI.

Both sagittal and tangential plots for each field point are plotted.

<img width="476" height="467" alt="Screenshot From 2026-04-15 15-16-21" src="https://github.com/user-attachments/assets/9fc857eb-5d01-4fd1-b72d-30599c5899dc" />
