### PR TITLE
refactor: Use Vec instead of HashMap for submodels

### DIFF
--- a/crates/cherry-rs/src/core/sequential_model.rs
+++ b/crates/cherry-rs/src/core/sequential_model.rs
@@ -1,5 +1,4 @@
 /// Data types for modeling sequential ray tracing systems.
-use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::ops::Range;
 
@@ -34,7 +33,7 @@ pub struct Gap {
 #[derive(Debug)]
 pub struct SequentialModel {
     surfaces: Vec<Surface>,
-    submodels: HashMap<usize, SequentialSubModelBase>,
+    submodels: Vec<SequentialSubModelBase>,
     wavelengths: Vec<Float>,
     axis_directions: Vec<Vec3>,
 }
@@ -347,10 +346,10 @@ impl SequentialModel {
 
         let (surfaces, axis_directions) = Self::surf_specs_to_surfs(surface_specs, gap_specs);
 
-        let mut models: HashMap<usize, SequentialSubModelBase> = HashMap::new();
-        for (wav_idx, &wavelength) in wavelengths.iter().enumerate() {
+        let mut models: Vec<SequentialSubModelBase> = Vec::new();
+        for &wavelength in wavelengths.iter() {
             let gaps = Self::gap_specs_to_gaps(gap_specs, wavelength)?;
-            models.insert(wav_idx, SequentialSubModelBase::new(gaps));
+            models.push(SequentialSubModelBase::new(gaps));
         }
 
         Ok(Self {
@@ -382,13 +381,22 @@ impl SequentialModel {
         &self.surfaces
     }
 
-    /// Returns the wavelength-indexed submodels of the system.
+    /// Returns the submodel for a given wavelength index, or `None` if the
+    /// index is out of range.
     ///
-    /// Each entry is keyed by the wavelength index (0-based, matching the order
-    /// passed to `new`). Tangential-direction splitting is handled by
+    /// Wavelength indices are 0-based and match the order of the wavelengths
+    /// slice passed to [`SequentialModel::new`].
+    pub fn submodel(&self, wavelength_id: usize) -> Option<&(impl SequentialSubModel + use<'_>)> {
+        self.submodels.get(wavelength_id)
+    }
+
+    /// Returns all wavelength submodels as a slice.
+    ///
+    /// The position in the slice is the wavelength index (0-based, matching the
+    /// order passed to `new`). Tangential-direction splitting is handled by
     /// `ParaxialView`, which builds one paraxial subview per wavelength ×
     /// tangential-vector combination.
-    pub fn submodels(&self) -> &HashMap<usize, impl SequentialSubModel + use<>> {
+    pub fn submodels(&self) -> &[impl SequentialSubModel + use<'_>] {
         &self.submodels
     }
 

--- a/crates/cherry-rs/src/gui/windows/paraxial.rs
+++ b/crates/cherry-rs/src/gui/windows/paraxial.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-use crate::{SubModelID, gui::result_package::ResultPackage, views::paraxial::ParaxialSubView};
+use crate::{gui::result_package::ResultPackage, views::paraxial::ParaxialSubView};
 
 /// Floating paraxial summary output window.
 pub struct ParaxialWindow;
@@ -29,10 +27,9 @@ impl ParaxialWindow {
 
 fn render_paraxial_content(ui: &mut egui::Ui, r: &ResultPackage) {
     let pv = r.paraxial.as_ref().unwrap();
-    let subviews = pv.subviews();
 
     // Collect unique v_indices, sorted ascending (ascending phi).
-    let mut v_indices: Vec<usize> = subviews.keys().map(|id| id.1).collect();
+    let mut v_indices: Vec<usize> = pv.iter().map(|sv| sv.tangential_vec_id()).collect();
     v_indices.sort_unstable();
     v_indices.dedup();
     let n_v = v_indices.len();
@@ -46,15 +43,15 @@ fn render_paraxial_content(ui: &mut egui::Ui, r: &ResultPackage) {
             ui.heading(format!("\u{03c6} = {phi_deg:.0}\u{00b0}"));
         }
 
-        // Subview IDs for this v_index, sorted by wavelength_id.
-        let mut ids: Vec<SubModelID> = subviews
-            .keys()
-            .filter(|id| id.1 == v_idx)
-            .copied()
+        // Subviews for this tangential_vec_id, sorted by wavelength_id.
+        let mut ids: Vec<(usize, usize)> = pv
+            .iter()
+            .filter(|sv| sv.tangential_vec_id() == v_idx)
+            .map(|sv| (sv.wavelength_id(), sv.tangential_vec_id()))
             .collect();
-        ids.sort_by_key(|id| id.0);
+        ids.sort_by_key(|&(wl_id, _)| wl_id);
 
-        render_v_table(ui, r, v_idx, &ids, subviews);
+        render_v_table(ui, r, v_idx, &ids, pv);
         ui.add_space(8.0);
     }
 
@@ -62,7 +59,7 @@ fn render_paraxial_content(ui: &mut egui::Ui, r: &ResultPackage) {
     if r.wavelengths.len() > 1 {
         let pac = pv.primary_axial_color();
         for &v_idx in &v_indices {
-            if let Some(&color) = pac.get(&v_idx) {
+            if let Some(&color) = pac.get(v_idx) {
                 let phi_suffix = if n_v > 1 {
                     let phi_deg = pv.phi_deg(v_idx);
                     format!(" (\u{03c6} = {phi_deg:.0}\u{00b0})")
@@ -84,8 +81,8 @@ fn render_v_table(
     ui: &mut egui::Ui,
     r: &ResultPackage,
     v_idx: usize,
-    ids: &[SubModelID],
-    subviews: &HashMap<SubModelID, ParaxialSubView>,
+    ids: &[(usize, usize)],
+    pv: &crate::views::paraxial::ParaxialView,
 ) {
     let n_wl = ids.len();
     let n_cols = 1 + n_wl;
@@ -97,12 +94,12 @@ fn render_v_table(
             // Wavelength header row — only when there are multiple wavelengths.
             if n_wl > 1 {
                 ui.label(""); // empty label cell
-                for id in ids {
+                for &(wl_id, _) in ids {
                     let wl_label = r
                         .wavelengths
-                        .get(id.0)
+                        .get(wl_id)
                         .map(|wl| format!("{wl:.4} \u{00b5}m"))
-                        .unwrap_or_else(|| format!("WL {}", id.0));
+                        .unwrap_or_else(|| format!("WL {wl_id}"));
                     ui.label(wl_label);
                 }
                 ui.end_row();
@@ -113,9 +110,9 @@ fn render_v_table(
                 ui.end_row();
             }
 
-            multi_row(ui, "EFL", ids, subviews, |sv| *sv.effective_focal_length());
-            multi_row(ui, "BFD", ids, subviews, |sv| *sv.back_focal_distance());
-            multi_row(ui, "FFD", ids, subviews, |sv| *sv.front_focal_distance());
+            multi_row(ui, "EFL", ids, pv, |sv| *sv.effective_focal_length());
+            multi_row(ui, "BFD", ids, pv, |sv| *sv.back_focal_distance());
+            multi_row(ui, "FFD", ids, pv, |sv| *sv.front_focal_distance());
 
             sep_row(ui, n_cols);
 
@@ -123,20 +120,16 @@ fn render_v_table(
                 ui,
                 "Entrance pupil dist. from first surface",
                 ids,
-                subviews,
+                pv,
                 |sv| sv.entrance_pupil().location,
             );
-            multi_row(ui, "Entrance pupil semi-diameter", ids, subviews, |sv| {
+            multi_row(ui, "Entrance pupil semi-diameter", ids, pv, |sv| {
                 sv.entrance_pupil().semi_diameter
             });
-            multi_row(
-                ui,
-                "Exit pupil dist. from last surface",
-                ids,
-                subviews,
-                |sv| sv.exit_pupil().location,
-            );
-            multi_row(ui, "Exit pupil semi-diameter", ids, subviews, |sv| {
+            multi_row(ui, "Exit pupil dist. from last surface", ids, pv, |sv| {
+                sv.exit_pupil().location
+            });
+            multi_row(ui, "Exit pupil semi-diameter", ids, pv, |sv| {
                 sv.exit_pupil().semi_diameter
             });
 
@@ -146,14 +139,14 @@ fn render_v_table(
                 ui,
                 "Front principal plane dist. from first surface",
                 ids,
-                subviews,
+                pv,
                 |sv| *sv.front_principal_plane(),
             );
             multi_row(
                 ui,
                 "Back principal plane dist. from last surface",
                 ids,
-                subviews,
+                pv,
                 |sv| *sv.back_principal_plane(),
             );
 
@@ -161,8 +154,8 @@ fn render_v_table(
 
             // Aperture stop is an integer index; format it without decimals.
             ui.label("Aperture stop (surface)");
-            for id in ids {
-                if let Some(sv) = subviews.get(id) {
+            for &(wl_id, tangential_vec_id) in ids {
+                if let Some(sv) = pv.get(wl_id, tangential_vec_id) {
                     ui.label(sv.aperture_stop().to_string());
                 } else {
                     ui.label("\u{2014}");
@@ -182,15 +175,15 @@ fn sep_row(ui: &mut egui::Ui, n_cols: usize) {
 fn multi_row<F>(
     ui: &mut egui::Ui,
     label: &str,
-    ids: &[SubModelID],
-    subviews: &HashMap<SubModelID, ParaxialSubView>,
+    ids: &[(usize, usize)],
+    pv: &crate::views::paraxial::ParaxialView,
     get_val: F,
 ) where
     F: Fn(&ParaxialSubView) -> f64,
 {
     ui.label(label);
-    for id in ids {
-        if let Some(sv) = subviews.get(id) {
+    for &(wl_id, tangential_vec_id) in ids {
+        if let Some(sv) = pv.get(wl_id, tangential_vec_id) {
             ui.label(format_value(get_val(sv)));
         } else {
             ui.label("\u{2014}");

--- a/crates/cherry-rs/src/gui/windows/ray_fan.rs
+++ b/crates/cherry-rs/src/gui/windows/ray_fan.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::{
-    FieldSpec, SubModelID, TraceResults,
+    FieldSpec, TraceResults,
     core::math::vec3::Vec3,
     gui::{
         colors::wavelength_to_color,
@@ -332,9 +332,8 @@ fn chief_ray_image_pos(
         let Some(pv) = &r.paraxial else {
             return (None, false);
         };
-        let v_index = pv.v_index_for_phi(phi);
-        let sub_id = SubModelID(wl_id, v_index);
-        let Some(sv) = pv.subviews().get(&sub_id) else {
+        let tangential_vec_id = pv.tangential_vec_id_for_phi(phi);
+        let Some(sv) = pv.get(wl_id, tangential_vec_id) else {
             return (None, false);
         };
 
@@ -351,7 +350,7 @@ fn chief_ray_image_pos(
         let y_fallback = ratio * y_max;
 
         // Lift scalar paraxial height to a 3D position along the tangential direction.
-        let tv = pv.tangential_vec(v_index);
+        let tv = pv.tangential_vec(tangential_vec_id);
         let rot_t = image_surf.rot_mat.transpose();
         let tan_global = rot_t * tv;
         let pos = image_surf.pos + tan_global * y_fallback;

--- a/crates/cherry-rs/src/lib.rs
+++ b/crates/cherry-rs/src/lib.rs
@@ -101,10 +101,13 @@
 //! let paraxial_view = ParaxialView::new(&sequential_model, &field_specs, false).unwrap();
 //!
 //! // Compute the effective focal length of the lens for each submodel.
-//! for (sub_model_id, sub_view) in paraxial_view.subviews() {
+//! for sub_view in paraxial_view.iter() {
 //!     let result = sub_view.effective_focal_length();
 //!
-//!     println!("Submodel ID: {:?}, Effective focal length: {}", sub_model_id, result);
+//!     println!(
+//!         "wavelength_id={} tangential_vec_id={} EFL={}",
+//!         sub_view.wavelength_id(), sub_view.tangential_vec_id(), result
+//!     );
 //! }
 //!
 //! // Compute a 3D ray trace of the system, sampling the pupil with a square
@@ -150,7 +153,7 @@ pub use views::{
     },
     paraxial::{
         ImagePlane, ParaxialRay, ParaxialRayBundle, ParaxialSubView, ParaxialSubViewDescription,
-        ParaxialView, ParaxialViewDescription, Pupil, SubModelID,
+        ParaxialView, ParaxialViewDescription, Pupil,
     },
     ray_trace_3d::{
         Ray, RayBundle, SamplingConfig, TraceResults, TraceResultsCollection, ray_trace_3d_view,

--- a/crates/cherry-rs/src/views/components/mod.rs
+++ b/crates/cherry-rs/src/views/components/mod.rs
@@ -63,8 +63,7 @@ pub fn components_view(
         RefractiveIndex::try_from_spec(background.as_ref(), wavelength)?;
 
     let sequential_sub_model = sequential_model
-        .submodels()
-        .get(&0usize)
+        .submodel(0)
         .ok_or(anyhow!("No submodel found for wavelength index 0."))?;
     let gaps = sequential_sub_model.gaps();
 

--- a/crates/cherry-rs/src/views/paraxial.rs
+++ b/crates/cherry-rs/src/views/paraxial.rs
@@ -7,10 +7,10 @@
 /// paraxial view is used to compute the paraxial parameters of an optical
 /// system, such as the entrance and exit pupils, the back and front focal
 /// distances, and the effective focal length.
-use std::{borrow::Borrow, collections::HashMap};
+use std::borrow::Borrow;
 
 use anyhow::{Result, anyhow};
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     FieldSpec,
@@ -24,25 +24,6 @@ use crate::{
     },
     specs::{fields::unique_tangential_vecs, surfaces::SurfaceType},
 };
-
-/// A unique identifier for a paraxial submodel.
-///
-/// The first element is the index of the wavelength in the system's list of
-/// wavelengths. The second element is the index into `ParaxialView`'s
-/// tangential-vector table, which is built from the field specs at view
-/// construction time.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct SubModelID(pub usize, pub usize);
-
-impl Serialize for SubModelID {
-    // Serialize as a string like "0:0" because tuple keys are awkward in JSON.
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(&format!("{}:{}", self.0, self.1))
-    }
-}
 
 const DEFAULT_THICKNESS: Float = 0.0;
 
@@ -111,12 +92,13 @@ type RayTransferMatrix = Mat2x2;
 /// properties of an optical system, such as the entrance and exit pupils, the
 /// back and front focal distances, and the effective focal length.
 ///
-/// Subviews are indexed by `SubModelID(wavelength_idx, v_index)` where
-/// `v_index` refers to an entry in `tangential_vecs`.
+/// Subviews are stored in a flat `Vec`, ordered by wavelength index first, then
+/// by `tangential_vec_id`. Each subview carries its own `wavelength_id` and
+/// `tangential_vec_id`.
 #[derive(Debug)]
 pub struct ParaxialView {
     tangential_vecs: Vec<TangentialVector>,
-    subviews: HashMap<SubModelID, ParaxialSubView>,
+    subviews: Vec<ParaxialSubView>,
     wavelengths: Vec<Float>,
 }
 
@@ -125,18 +107,20 @@ pub struct ParaxialView {
 /// This is used primarily for serialization of data for export.
 #[derive(Debug, Serialize)]
 pub struct ParaxialViewDescription {
-    subviews: HashMap<SubModelID, ParaxialSubViewDescription>,
-    /// Keyed by v_index (index into the tangential-vector table).
-    primary_axial_color: HashMap<usize, Float>,
+    subviews: Vec<ParaxialSubViewDescription>,
+    /// Indexed by tangential_vec_id (index into the tangential-vector table).
+    primary_axial_color: Vec<Float>,
 }
 
 /// A paraxial subview of an optical system.
 ///
-/// A paraxial subview is identified by a single submodel ID that corresponds to
-/// a submodel of a sequential model. It is not created by the user, but rather
-/// by instantiating a new ParaxialView struct.
+/// A paraxial subview is identified by a wavelength index and a tangential
+/// direction index. It is not created by the user, but rather by instantiating
+/// a new ParaxialView struct.
 #[derive(Debug)]
 pub struct ParaxialSubView {
+    wavelength_id: usize,
+    tangential_vec_id: usize,
     is_obj_space_telecentric: bool,
 
     aperture_stop: usize,
@@ -157,6 +141,8 @@ pub struct ParaxialSubView {
 /// This is used primarily for serialization of data for export.
 #[derive(Debug, Serialize)]
 pub struct ParaxialSubViewDescription {
+    wavelength_id: usize,
+    tangential_vec_id: usize,
     aperture_stop: usize,
     back_focal_distance: Float,
     back_principal_plane: Float,
@@ -286,18 +272,19 @@ impl ParaxialView {
                 unique_tangential_vecs(field_specs)
             };
 
-        let mut subviews = HashMap::new();
-        for (&wav_idx, submodel) in sequential_model.submodels() {
+        let mut subviews = Vec::new();
+        for (wav_idx, submodel) in sequential_model.submodels().iter().enumerate() {
             for (v_idx, &v) in tangential_vecs.iter().enumerate() {
-                let id = SubModelID(wav_idx, v_idx);
                 let subview = ParaxialSubView::new(
+                    wav_idx,
+                    v_idx,
                     submodel,
                     surfaces,
                     v,
                     field_specs,
                     is_obj_space_telecentric,
                 )?;
-                subviews.insert(id, subview);
+                subviews.push(subview);
             }
         }
 
@@ -313,38 +300,63 @@ impl ParaxialView {
     /// This is used primarily for serialization of data for export.
     pub fn describe(&self) -> ParaxialViewDescription {
         ParaxialViewDescription {
-            subviews: self
-                .subviews
-                .iter()
-                .map(|(id, subview)| (*id, subview.describe()))
-                .collect(),
+            subviews: self.subviews.iter().map(|sv| sv.describe()).collect(),
             primary_axial_color: self.primary_axial_color(),
         }
     }
 
-    /// Returns the subviews of the paraxial view.
-    pub fn subviews(&self) -> &HashMap<SubModelID, ParaxialSubView> {
-        &self.subviews
+    /// Returns the subview for the given wavelength and tangential-direction
+    /// indices, or `None` if no such subview exists.
+    pub fn get(&self, wavelength_id: usize, tangential_vec_id: usize) -> Option<&ParaxialSubView> {
+        self.subviews.iter().find(|sv| {
+            sv.wavelength_id == wavelength_id && sv.tangential_vec_id == tangential_vec_id
+        })
     }
 
-    /// Returns the tangential direction vector for a given v_index.
-    pub fn tangential_vec(&self, v_index: usize) -> TangentialVector {
-        self.tangential_vecs[v_index]
+    /// Returns an iterator over all subviews.
+    pub fn iter(&self) -> impl Iterator<Item = &ParaxialSubView> {
+        self.subviews.iter()
     }
 
-    /// Returns the azimuthal angle in degrees for a given v_index.
-    pub fn phi_deg(&self, v_index: usize) -> Float {
-        let v = self.tangential_vecs[v_index];
+    /// Returns an iterator over all subviews for a given wavelength index.
+    pub fn get_by_wavelength_id(
+        &self,
+        wavelength_id: usize,
+    ) -> impl Iterator<Item = &ParaxialSubView> {
+        self.subviews
+            .iter()
+            .filter(move |sv| sv.wavelength_id == wavelength_id)
+    }
+
+    /// Returns an iterator over all subviews for a given tangential-direction
+    /// index.
+    pub fn get_by_tangential_vec_id(
+        &self,
+        tangential_vec_id: usize,
+    ) -> impl Iterator<Item = &ParaxialSubView> {
+        self.subviews
+            .iter()
+            .filter(move |sv| sv.tangential_vec_id == tangential_vec_id)
+    }
+
+    /// Returns the tangential direction vector for a given tangential_vec_id.
+    pub fn tangential_vec(&self, tangential_vec_id: usize) -> TangentialVector {
+        self.tangential_vecs[tangential_vec_id]
+    }
+
+    /// Returns the azimuthal angle in degrees for a given tangential_vec_id.
+    pub fn phi_deg(&self, tangential_vec_id: usize) -> Float {
+        let v = self.tangential_vecs[tangential_vec_id];
         v.y().atan2(v.x()).to_degrees()
     }
 
-    /// Returns the v_index whose tangential vector is closest (by dot product)
-    /// to the given azimuthal angle in radians.
+    /// Returns the tangential_vec_id whose tangential vector is closest (by dot
+    /// product) to the given azimuthal angle in radians.
     ///
     /// For the common case where `phi_rad` exactly matches a stored phi key
     /// (bit-identical `tangential_fan_phi()` value), this finds the exact
     /// entry. Falls back to index 0 if the table is empty.
-    pub fn v_index_for_phi(&self, phi_rad: Float) -> usize {
+    pub fn tangential_vec_id_for_phi(&self, phi_rad: Float) -> usize {
         let target: TangentialVector = Vec3::new(phi_rad.cos(), phi_rad.sin(), 0.0);
         self.tangential_vecs
             .iter()
@@ -362,15 +374,15 @@ impl ParaxialView {
     ///
     /// Primary axial color is the absolute difference in EFL between the
     /// maximum and minimum wavelengths, reported per tangential-vector index.
-    pub fn primary_axial_color(&self) -> HashMap<usize, Float> {
-        let min_wav_index = self
+    pub fn primary_axial_color(&self) -> Vec<Float> {
+        let min_watangential_vec_id = self
             .wavelengths
             .iter()
             .enumerate()
             .min_by(|(_, a), (_, b)| a.total_cmp(b))
             .map(|(index, _)| index)
             .unwrap_or_default();
-        let max_wav_index = self
+        let max_watangential_vec_id = self
             .wavelengths
             .iter()
             .enumerate()
@@ -378,24 +390,12 @@ impl ParaxialView {
             .map(|(index, _)| index)
             .unwrap_or_default();
 
-        let mut efls_min_wav: HashMap<SubModelID, Float> = HashMap::new();
-        let mut efls_max_wav: HashMap<SubModelID, Float> = HashMap::new();
-
-        for (id, subview) in &self.subviews {
-            if id.0 == min_wav_index {
-                efls_min_wav.insert(*id, *subview.effective_focal_length());
-            } else if id.0 == max_wav_index {
-                efls_max_wav.insert(*id, *subview.effective_focal_length());
-            }
-        }
-
-        // Pair entries that share the same v_index.
-        let mut primary_axial_color: HashMap<usize, Float> = HashMap::new();
-        for (id_min, efl_min) in &efls_min_wav {
-            for (id_max, efl_max) in &efls_max_wav {
-                if id_min.1 == id_max.1 {
-                    primary_axial_color.insert(id_min.1, (efl_max - efl_min).abs());
-                }
+        let mut primary_axial_color = vec![0.0; self.tangential_vecs.len()];
+        for sv_min in self.get_by_wavelength_id(min_watangential_vec_id) {
+            if let Some(sv_max) = self.get(max_watangential_vec_id, sv_min.tangential_vec_id) {
+                let diff =
+                    (sv_max.effective_focal_length() - sv_min.effective_focal_length()).abs();
+                primary_axial_color[sv_min.tangential_vec_id] = diff;
             }
         }
 
@@ -410,6 +410,8 @@ impl ParaxialSubView {
     /// plane (e.g. `(0,1,0)` for phi=90°). It is propagated through mirror
     /// surfaces internally to compute per-surface foreshortening.
     fn new(
+        wavelength_id: usize,
+        tangential_vec_id: usize,
         sequential_sub_model: &impl SequentialSubModel,
         surfaces: &[Surface],
         v: TangentialVector,
@@ -461,6 +463,8 @@ impl ParaxialSubView {
             Self::calc_paraxial_image_plane(surfaces, &marginal_ray, &chief_ray)?;
 
         Ok(Self {
+            wavelength_id,
+            tangential_vec_id,
             is_obj_space_telecentric,
 
             aperture_stop,
@@ -479,6 +483,8 @@ impl ParaxialSubView {
 
     fn describe(&self) -> ParaxialSubViewDescription {
         ParaxialSubViewDescription {
+            wavelength_id: self.wavelength_id,
+            tangential_vec_id: self.tangential_vec_id,
             aperture_stop: self.aperture_stop,
             back_focal_distance: self.back_focal_distance,
             back_principal_plane: self.back_principal_plane,
@@ -491,6 +497,14 @@ impl ParaxialSubView {
             marginal_ray: self.marginal_ray.clone(),
             paraxial_image_plane: self.paraxial_image_plane.clone(),
         }
+    }
+
+    pub fn wavelength_id(&self) -> usize {
+        self.wavelength_id
+    }
+
+    pub fn tangential_vec_id(&self) -> usize {
+        self.tangential_vec_id
     }
 
     pub fn aperture_stop(&self) -> &usize {
@@ -1121,10 +1135,7 @@ mod test {
         let nbk7 = n!(1.515);
         let wavelengths: [Float; 1] = [0.5876];
         let sequential_model = convexplano_lens::sequential_model(air, nbk7, &wavelengths);
-        let seq_sub_model = sequential_model
-            .submodels()
-            .get(&0usize)
-            .expect("Submodel not found.");
+        let seq_sub_model = sequential_model.submodel(0).expect("Submodel not found.");
         let field_specs = vec![
             FieldSpec::Angle {
                 chi: 0.0,
@@ -1138,6 +1149,8 @@ mod test {
 
         (
             ParaxialSubView::new(
+                0,
+                0,
                 seq_sub_model,
                 sequential_model.surfaces(),
                 Vec3::new(0.0, 1.0, 0.0), // v = Y (phi=90°)
@@ -1202,10 +1215,7 @@ mod test {
         let nbk7 = n!(1.515);
         let wavelengths: [Float; 1] = [0.5876];
         let sequential_model = convexplano_lens::sequential_model(air, nbk7, &wavelengths);
-        let seq_sub_model = sequential_model
-            .submodels()
-            .get(&0usize)
-            .expect("Submodel not found.");
+        let seq_sub_model = sequential_model.submodel(0).expect("Submodel not found.");
         let pseudo_marginal_ray =
             ParaxialSubView::calc_pseudo_marginal_ray(seq_sub_model, sequential_model.surfaces())
                 .unwrap();
@@ -1232,10 +1242,7 @@ mod test {
         let nbk7 = n!(1.515);
         let wavelengths: [Float; 1] = [0.5876];
         let sequential_model = convexplano_lens::sequential_model(air, nbk7, &wavelengths);
-        let seq_sub_model = sequential_model
-            .submodels()
-            .get(&0usize)
-            .expect("Submodel not found.");
+        let seq_sub_model = sequential_model.submodel(0).expect("Submodel not found.");
         let reverse_parallel_ray =
             ParaxialSubView::calc_reverse_parallel_ray(seq_sub_model, sequential_model.surfaces())
                 .unwrap();

--- a/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
@@ -18,7 +18,6 @@ use crate::{
         aperture::ApertureSpec,
         fields::{FieldSpec, PupilSampling},
     },
-    views::paraxial::SubModelID,
 };
 
 use trace::trace;
@@ -125,14 +124,12 @@ pub fn ray_trace_3d_view(
             );
 
             let sequential_submodel = sequential_model
-                .submodels()
-                .get(&wavelength_id)
+                .submodel(wavelength_id)
                 .ok_or_else(|| anyhow!("Submodel not found"))?;
-            let v_index = paraxial_view.v_index_for_phi(field_specs[field_id].tangential_fan_phi());
-            let paraxial_submodel_id = SubModelID(wavelength_id, v_index);
+            let tangential_vec_id =
+                paraxial_view.tangential_vec_id_for_phi(field_specs[field_id].tangential_fan_phi());
             let paraxial_subview = paraxial_view
-                .subviews()
-                .get(&paraxial_submodel_id)
+                .get(wavelength_id, tangential_vec_id)
                 .ok_or_else(|| anyhow!("Submodel not found"))?;
 
             let field_spec = &field_specs[field_id];
@@ -663,7 +660,7 @@ fn validate_field_specs(
                 }
             }
             FieldSpec::PointSource { .. } => {
-                for submodel in sequential_model.submodels().values() {
+                for submodel in sequential_model.submodels() {
                     if submodel.is_obj_at_inf() {
                         return Err(anyhow!(
                             "Cannot have a point source field with an infinite object distance"
@@ -858,7 +855,7 @@ mod tests {
         let rays = rays(
             s.sequential_model.surfaces(),
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
+            s.paraxial_view.get(0, 0).unwrap(),
             &s.field_specs[0],
             PupilSampling::TangentialRayFan { n: 3 },
         )
@@ -887,7 +884,7 @@ mod tests {
         let fan_rays = rays(
             seq_model.surfaces(),
             &aperture_spec,
-            &paraxial_view.subviews()[&SubModelID(0, 0)],
+            paraxial_view.get(0, 0).unwrap(),
             &field_specs[0],
             PupilSampling::SagittalRayFan { n: 3 },
         )
@@ -933,7 +930,7 @@ mod tests {
         let chief = rays(
             seq_model.surfaces(),
             &aperture_spec,
-            &paraxial_view.subviews()[&SubModelID(0, 0)],
+            paraxial_view.get(0, 0).unwrap(),
             &field_spec,
             PupilSampling::ChiefRay,
         )
@@ -941,7 +938,7 @@ mod tests {
         let sag_fan = rays(
             seq_model.surfaces(),
             &aperture_spec,
-            &paraxial_view.subviews()[&SubModelID(0, 0)],
+            paraxial_view.get(0, 0).unwrap(),
             &field_spec,
             PupilSampling::SagittalRayFan { n: 3 },
         )
@@ -970,7 +967,7 @@ mod tests {
         let result = rays(
             s.sequential_model.surfaces(),
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
+            s.paraxial_view.get(0, 0).unwrap(),
             &field_spec,
             PupilSampling::TangentialRayFan { n: 3 },
         );
@@ -989,7 +986,7 @@ mod tests {
         let rays = chief_ray_from_angle(
             s.sequential_model.surfaces(),
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
+            s.paraxial_view.get(0, 0).unwrap(),
             0.0,
             0.0,
         )
@@ -1011,7 +1008,7 @@ mod tests {
         let rays = chief_ray_from_angle(
             s.sequential_model.surfaces(),
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
+            s.paraxial_view.get(0, 0).unwrap(),
             PI / 2.0,
             0.08727, // 5 degrees
         )
@@ -1032,7 +1029,7 @@ mod tests {
 
         let rays = chief_ray_from_pos(
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
+            s.paraxial_view.get(0, 0).unwrap(),
             &Vec3::new(0.0, 0.0, -1.0),
         )
         .unwrap();
@@ -1052,7 +1049,7 @@ mod tests {
 
         let rays = chief_ray_from_pos(
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
+            s.paraxial_view.get(0, 0).unwrap(),
             &Vec3::new(0.0, -0.08749, -1.0),
         )
         .unwrap();
@@ -1073,7 +1070,7 @@ mod tests {
         let rays = parallel_ray_bundle_on_sq_grid(
             s.sequential_model.surfaces(),
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
+            s.paraxial_view.get(0, 0).unwrap(),
             1.0,
             0.0,
         );
@@ -1085,7 +1082,7 @@ mod tests {
         let rays = parallel_ray_bundle_on_sq_grid(
             s.sequential_model.surfaces(),
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
+            s.paraxial_view.get(0, 0).unwrap(),
             0.5,
             0.0,
         );
@@ -1097,7 +1094,10 @@ mod tests {
     #[test]
     fn test_point_source_ray_fan() {
         let s = setup();
-        let enp_radius = &s.paraxial_view.subviews()[&SubModelID(0, 0)]
+        let enp_radius = s
+            .paraxial_view
+            .get(0, 0)
+            .unwrap()
             .entrance_pupil()
             .semi_diameter;
         let expected_z_dir_cosines: [Float; 3] = [
@@ -1108,7 +1108,7 @@ mod tests {
 
         let rays = point_source_ray_fan(
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
+            s.paraxial_view.get(0, 0).unwrap(),
             3,
             PI / 2.0,
             &Vec3::new(0.0, 0.0, -1.0), // Point source located at z = -1.0
@@ -1130,7 +1130,7 @@ mod tests {
 
         let rays = point_source_ray_bundle_on_sq_grid(
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
+            s.paraxial_view.get(0, 0).unwrap(),
             1.0,
             &Vec3::new(0.0, 0.0, -1.0), // Point source located at z = -1.0
         );
@@ -1141,7 +1141,7 @@ mod tests {
 
         let rays = point_source_ray_bundle_on_sq_grid(
             &s.aperture_spec,
-            &s.paraxial_view.subviews()[&SubModelID(0, 0)],
+            s.paraxial_view.get(0, 0).unwrap(),
             0.5,
             &Vec3::new(0.0, 0.0, -1.0), // Point source located at z = -1.0
         );
@@ -1230,7 +1230,7 @@ mod tests {
         let generated = rays(
             s.sequential_model.surfaces(),
             &s.aperture_spec,
-            s.paraxial_view.subviews().get(&SubModelID(0, 0)).unwrap(),
+            s.paraxial_view.get(0, 0).unwrap(),
             &field_spec,
             PupilSampling::TangentialRayFan { n: 3 },
         )

--- a/crates/cherry-rs/tests/biconvex_lens_finite_object.rs
+++ b/crates/cherry-rs/tests/biconvex_lens_finite_object.rs
@@ -69,7 +69,7 @@ fn test_paraxial_view_aperture_stop() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.aperture_stop();
 
         assert_eq!(APERTURE_STOP, *result)
@@ -82,7 +82,7 @@ fn test_paraxial_view_back_focal_distance() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.back_focal_distance();
 
         assert_abs_diff_eq!(BACK_FOCAL_DISTANCE, *result, epsilon = 1e-4)
@@ -95,7 +95,7 @@ fn test_paraxial_view_back_principal_plane() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.back_principal_plane();
 
         assert_abs_diff_eq!(BACK_PRINCIPAL_PLANE, *result, epsilon = 1e-4)
@@ -108,7 +108,7 @@ fn test_paraxial_view_entrance_pupil() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.entrance_pupil();
 
         assert_eq!(ENTRANCE_PUPIL, *result)
@@ -121,7 +121,7 @@ fn test_paraxial_view_exit_pupil() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.exit_pupil();
 
         assert_abs_diff_eq!(EXIT_PUPIL.location, result.location, epsilon = 1e-4);
@@ -139,7 +139,7 @@ fn test_paraxial_view_effective_focal_length() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.effective_focal_length();
 
         assert_abs_diff_eq!(EFFECTIVE_FOCAL_LENGTH, *result, epsilon = 1e-4)
@@ -152,7 +152,7 @@ fn test_paraxial_view_front_focal_distance() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.front_focal_distance();
 
         assert_abs_diff_eq!(FRONT_FOCAL_DISTANCE, *result, epsilon = 1e-4)
@@ -165,7 +165,7 @@ fn test_paraxial_view_front_principal_plane() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.front_principal_plane();
 
         assert_abs_diff_eq!(FRONT_PRINCIPAL_PLANE, *result, epsilon = 1e-4)
@@ -178,7 +178,7 @@ fn test_paraxial_view_image_plane() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.paraxial_image_plane();
 
         assert_abs_diff_eq!(
@@ -200,7 +200,7 @@ fn test_paraxial_view_marginal_ray() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         assert_ray_results_approx_eq(sub_view.marginal_ray(), &marginal_ray_expected(), 1e-4);
     }
 }
@@ -211,7 +211,7 @@ fn test_paraxial_view_chief_ray() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         assert_ray_results_approx_eq(sub_view.chief_ray(), &chief_ray_expected(), 1e-4);
     }
 }

--- a/crates/cherry-rs/tests/concave_mirror.rs
+++ b/crates/cherry-rs/tests/concave_mirror.rs
@@ -65,7 +65,7 @@ fn concave_mirror_paraxial_chief_ray() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         assert_ray_results_approx_eq(sub_view.chief_ray(), &chief_ray_expected(), 1e-4);
     }
 }
@@ -76,7 +76,7 @@ fn concave_mirror_paraxial_aperture_stop() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.aperture_stop();
 
         assert_eq!(APERTURE_STOP, *result)
@@ -89,7 +89,7 @@ fn concave_mirror_paraxial_back_focal_distance() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.back_focal_distance();
 
         assert_abs_diff_eq!(BACK_FOCAL_DISTANCE, *result, epsilon = 1e-4)
@@ -102,7 +102,7 @@ fn concave_mirror_paraxial_back_principal_plane() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.back_principal_plane();
 
         assert_abs_diff_eq!(BACK_PRINCIPAL_PLANE, *result, epsilon = 1e-4)
@@ -115,7 +115,7 @@ fn concave_mirror_paraxial_entrance_pupil() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.entrance_pupil();
 
         assert_eq!(ENTRANCE_PUPIL, *result)
@@ -128,7 +128,7 @@ fn concave_mirror_paraxial_exit_pupil() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.exit_pupil();
 
         assert_abs_diff_eq!(EXIT_PUPIL.location, result.location, epsilon = 1e-4);
@@ -146,7 +146,7 @@ fn concave_mirror_paraxial_effective_focal_length() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.effective_focal_length();
 
         assert_abs_diff_eq!(EFFECTIVE_FOCAL_LENGTH, *result, epsilon = 1e-4)
@@ -159,7 +159,7 @@ fn concave_mirror_paraxial_front_focal_distance() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.front_focal_distance();
 
         assert_abs_diff_eq!(FRONT_FOCAL_DISTANCE, *result, epsilon = 1e-4)
@@ -172,7 +172,7 @@ fn concave_mirror_paraxial_front_principal_plane() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.front_principal_plane();
 
         assert_abs_diff_eq!(FRONT_PRINCIPAL_PLANE, *result, epsilon = 1e-4)
@@ -185,7 +185,7 @@ fn concave_mirror_paraxial_image_plane() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.paraxial_image_plane();
 
         assert_abs_diff_eq!(
@@ -207,7 +207,7 @@ fn concave_mirror_paraxial_marginal_ray() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         assert_ray_results_approx_eq(sub_view.marginal_ray(), &marginal_ray_expected(), 1e-4);
     }
 }

--- a/crates/cherry-rs/tests/convexplano_lens_materials.rs
+++ b/crates/cherry-rs/tests/convexplano_lens_materials.rs
@@ -1,10 +1,10 @@
 #[cfg(feature = "ri-info")]
 mod test_ri_info {
     use core::panic;
-    use std::rc::Rc;
     /// Tests the lens with material data from the refractiveindex.info
     /// database.
-    use std::{collections::HashMap, io::Read};
+    use std::io::Read;
+    use std::rc::Rc;
 
     use anyhow::Result;
     use approx::assert_abs_diff_eq;
@@ -36,15 +36,6 @@ mod test_ri_info {
         },
     ];
 
-    // Paraxial property values
-    // primary_axial_color is keyed by v_index; for a single phi=90° field,
-    // v_index=0.
-    fn primary_axial_color() -> HashMap<usize, f64> {
-        let mut primary_axial_color = HashMap::new();
-        primary_axial_color.insert(0usize, 0.7743);
-        primary_axial_color
-    }
-
     #[test]
     fn test_feature_enabled() {
         println!("Feature ri-info is enabled!");
@@ -63,13 +54,10 @@ mod test_ri_info {
         let view =
             ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-        let expected = primary_axial_color();
+        // For a single phi=90° field there is one tangential direction
+        // (tangential_vec_id=0).
         let results = view.primary_axial_color();
-
-        assert_eq!(expected.len(), results.len());
-        for (axis, expected_value) in expected.iter() {
-            let result = results.get(axis).unwrap();
-            assert_abs_diff_eq!(expected_value, result, epsilon = 1e-4);
-        }
+        assert_eq!(results.len(), 1);
+        assert_abs_diff_eq!(results[0], 0.7743, epsilon = 1e-4);
     }
 }

--- a/crates/cherry-rs/tests/convexplano_lens_ri.rs
+++ b/crates/cherry-rs/tests/convexplano_lens_ri.rs
@@ -75,7 +75,7 @@ fn convexplano_lens_ri_paraxial_chief_ray() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         assert_ray_results_approx_eq(sub_view.chief_ray(), &chief_ray_expected(), 1e-4);
     }
 }
@@ -86,7 +86,7 @@ fn convexplano_lens_ri_paraxial_aperture_stop() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.aperture_stop();
 
         assert_eq!(APERTURE_STOP, *result)
@@ -99,7 +99,7 @@ fn convexplano_lens_ri_paraxial_back_focal_distance() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.back_focal_distance();
 
         assert_abs_diff_eq!(BACK_FOCAL_DISTANCE, *result, epsilon = 1e-4)
@@ -112,7 +112,7 @@ fn convexplano_lens_ri_paraxial_back_principal_plane() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.back_principal_plane();
 
         assert_abs_diff_eq!(BACK_PRINCIPAL_PLANE, *result, epsilon = 1e-4)
@@ -125,7 +125,7 @@ fn convexplano_lens_ri_paraxial_entrance_pupil() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.entrance_pupil();
 
         assert_eq!(ENTRANCE_PUPIL, *result)
@@ -138,7 +138,7 @@ fn convexplano_lens_ri_paraxial_exit_pupil() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.exit_pupil();
 
         assert_abs_diff_eq!(EXIT_PUPIL.location, result.location, epsilon = 1e-4);
@@ -156,7 +156,7 @@ fn convexplano_lens_ri_paraxial_effective_focal_length() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.effective_focal_length();
 
         assert_abs_diff_eq!(EFFECTIVE_FOCAL_LENGTH, *result, epsilon = 1e-4)
@@ -169,7 +169,7 @@ fn convexplano_lens_ri_paraxial_front_focal_distance() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.front_focal_distance();
 
         assert_abs_diff_eq!(FRONT_FOCAL_DISTANCE, *result, epsilon = 1e-4)
@@ -182,7 +182,7 @@ fn convexplano_lens_ri_paraxial_front_principal_plane() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.front_principal_plane();
 
         assert_abs_diff_eq!(FRONT_PRINCIPAL_PLANE, *result, epsilon = 1e-4)
@@ -195,7 +195,7 @@ fn convexplano_lens_ri_paraxial_image_plane() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.paraxial_image_plane();
 
         assert_abs_diff_eq!(
@@ -217,7 +217,7 @@ fn convexplano_lens_ri_paraxial_marginal_ray() {
     let view =
         ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         assert_ray_results_approx_eq(sub_view.marginal_ray(), &marginal_ray_expected(), 1e-4);
     }
 }

--- a/crates/cherry-rs/tests/mirrors_figure_z.rs
+++ b/crates/cherry-rs/tests/mirrors_figure_z.rs
@@ -1,7 +1,7 @@
 use std::f64::consts::FRAC_PI_2;
 
 use approx::assert_abs_diff_eq;
-use cherry_rs::{FieldSpec, ParaxialView, SubModelID, examples::mirrors_figure_z, n};
+use cherry_rs::{FieldSpec, ParaxialView, examples::mirrors_figure_z, n};
 
 const WAVELENGTHS: [f64; 1] = [0.5876];
 const FIELD_SPECS: [FieldSpec; 1] = [FieldSpec::Angle {
@@ -46,7 +46,7 @@ fn track_equals_z_for_straight_system() {
 fn mirrors_figure_z_paraxial_aperture_stop() {
     let model = mirrors_figure_z::sequential_model(n!(1.0), &WAVELENGTHS);
     let view = ParaxialView::new(&model, &FIELD_SPECS, false).expect("paraxial view");
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         assert_eq!(*sub_view.aperture_stop(), APERTURE_STOP);
     }
 }
@@ -55,7 +55,7 @@ fn mirrors_figure_z_paraxial_aperture_stop() {
 fn mirrors_figure_z_paraxial_exit_pupil() {
     let model = mirrors_figure_z::sequential_model(n!(1.0), &WAVELENGTHS);
     let view = ParaxialView::new(&model, &FIELD_SPECS, false).expect("paraxial view");
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         assert_abs_diff_eq!(
             sub_view.exit_pupil().location,
             EXIT_PUPIL_LOCATION,
@@ -77,11 +77,7 @@ fn mirrors_figure_z_marginal_ray_uses_projected_sd() {
     let projected_u = r * (30.0_f64.to_radians()).cos();
 
     // FIELD_SPECS has phi=90° → only one submodel with v=Y (foreshortened).
-    let sub_view = view
-        .subviews()
-        .values()
-        .next()
-        .expect("at least one subview");
+    let sub_view = view.iter().next().expect("at least one subview");
     assert_eq!(*sub_view.aperture_stop(), 1usize);
     let marginal_height_at_stop = sub_view.marginal_ray().rays_at_surface(1)[0].height;
     assert_abs_diff_eq!(marginal_height_at_stop, projected_u, epsilon = 1e-10);
@@ -97,8 +93,8 @@ fn entrance_pupil_sd_phi_90_foreshortened() {
     }];
     let model = mirrors_figure_z::sequential_model(n!(1.0), &WAVELENGTHS);
     let view = ParaxialView::new(&model, &field_specs, false).expect("paraxial view");
-    let id = SubModelID(0, view.v_index_for_phi(FRAC_PI_2));
-    let ep = view.subviews()[&id].entrance_pupil();
+    let tangential_vec_id = view.tangential_vec_id_for_phi(FRAC_PI_2);
+    let ep = view.get(0, tangential_vec_id).unwrap().entrance_pupil();
     assert_abs_diff_eq!(ep.semi_diameter, ENTRANCE_PUPIL_SD_U, epsilon = 1e-4);
 }
 
@@ -109,8 +105,8 @@ fn entrance_pupil_sd_phi_0_not_foreshortened() {
     let field_specs = [FieldSpec::Angle { chi: 0.0, phi: 0.0 }];
     let model = mirrors_figure_z::sequential_model(n!(1.0), &WAVELENGTHS);
     let view = ParaxialView::new(&model, &field_specs, false).expect("paraxial view");
-    let id = SubModelID(0, view.v_index_for_phi(0.0));
-    let ep = view.subviews()[&id].entrance_pupil();
+    let tangential_vec_id = view.tangential_vec_id_for_phi(0.0);
+    let ep = view.get(0, tangential_vec_id).unwrap().entrance_pupil();
     assert_abs_diff_eq!(ep.semi_diameter, ENTRANCE_PUPIL_SD_R, epsilon = 1e-4);
 }
 
@@ -129,11 +125,11 @@ fn chief_ray_uses_matching_field_phi() {
     let model = mirrors_figure_z::sequential_model(n!(1.0), &WAVELENGTHS);
     let view = ParaxialView::new(&model, &field_specs, false).expect("paraxial view");
 
-    let id_phi90 = SubModelID(0, view.v_index_for_phi(FRAC_PI_2));
-    let id_phi0 = SubModelID(0, view.v_index_for_phi(0.0));
+    let v_phi90 = view.tangential_vec_id_for_phi(FRAC_PI_2);
+    let v_phi0 = view.tangential_vec_id_for_phi(0.0);
 
-    let angle_phi90 = view.subviews()[&id_phi90].chief_ray().rays_at_surface(0)[0].angle;
-    let angle_phi0 = view.subviews()[&id_phi0].chief_ray().rays_at_surface(0)[0].angle;
+    let angle_phi90 = view.get(0, v_phi90).unwrap().chief_ray().rays_at_surface(0)[0].angle;
+    let angle_phi0 = view.get(0, v_phi0).unwrap().chief_ray().rays_at_surface(0)[0].angle;
 
     assert_abs_diff_eq!(angle_phi90, 5.0_f64.to_radians().tan(), epsilon = 1e-6);
     assert_abs_diff_eq!(angle_phi0, 3.0_f64.to_radians().tan(), epsilon = 1e-6);

--- a/crates/cherry-rs/tests/petzval_lens.rs
+++ b/crates/cherry-rs/tests/petzval_lens.rs
@@ -16,7 +16,7 @@ fn test_describe_paraxial_view() {
 fn test_paraxial_view_aperture_stop() {
     let view = paraxial_view();
 
-    for sub_view in view.subviews().values() {
+    for sub_view in view.iter() {
         let result = sub_view.aperture_stop();
 
         assert_eq!(APERTURE_STOP, *result)


### PR DESCRIPTION
This is an internal change to switch to Vec instead of HashMap to store SequentialSubmodels and ParaxialSubviews. This change makes access over different combinations of Specs more uniform across the library.

In addition, it is slightly faster; at most we will have about ten or twenty submodels and subviews. This amount does not justify the overhead of a HashMap. The convexplano lens benchmark was 5% faster; the f theta scan lens 2%.