### PR TITLE
refactor: Remove cross-section ray fan from public API

### DIFF
--- a/crates/cherry-rs/benches/convexplano_lens.rs
+++ b/crates/cherry-rs/benches/convexplano_lens.rs
@@ -39,7 +39,6 @@ fn benchmark(c: &mut Criterion) {
                 black_box(&paraxial_view),
                 black_box(SamplingConfig {
                     n_fan_rays: 9,
-                    cross_section_n_fan_rays: 3,
                     full_pupil_spacing: 0.1,
                 }),
             )

--- a/crates/cherry-rs/benches/f_theta_scan_lens.rs
+++ b/crates/cherry-rs/benches/f_theta_scan_lens.rs
@@ -27,7 +27,6 @@ fn benchmark(c: &mut Criterion) {
                 black_box(&paraxial_view),
                 black_box(SamplingConfig {
                     n_fan_rays: 9,
-                    cross_section_n_fan_rays: 3,
                     full_pupil_spacing: 0.1,
                 }),
             )

--- a/crates/cherry-rs/src/gui/compute.rs
+++ b/crates/cherry-rs/src/gui/compute.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, rc::Rc};
 
 use crate::{
     ParaxialView, SequentialModel, components_view, cross_section_view, ray_trace_3d_view,
-    views::ray_trace_3d::SamplingConfig,
+    specs::fields::PupilSampling, trace_ray_bundle, views::ray_trace_3d::SamplingConfig,
 };
 
 use super::{
@@ -154,7 +154,6 @@ fn run_compute(
         .unwrap_or(0.1);
     let config = SamplingConfig {
         n_fan_rays: req.specs.n_fan_rays as usize,
-        cross_section_n_fan_rays: req.specs.cross_section_n_rays as usize,
         full_pupil_spacing,
     };
     let trace = match ray_trace_3d_view(&parsed.aperture, &parsed.fields, &seq, &pv, config) {
@@ -165,8 +164,23 @@ fn run_compute(
         }
     };
 
+    let cross_section_rays = trace_ray_bundle(
+        &parsed.aperture,
+        &parsed.fields,
+        &seq,
+        &pv,
+        PupilSampling::TangentialRayFan {
+            n: req.specs.cross_section_n_rays as usize,
+        },
+    )
+    .ok();
+
     let components = components_view(&seq, parsed.background.clone()).unwrap_or_default();
-    let cross_section = Some(cross_section_view(&seq, trace.as_ref(), &components));
+    let cross_section = Some(cross_section_view(
+        &seq,
+        cross_section_rays.as_deref(),
+        &components,
+    ));
 
     ResultPackage {
         id: req.id,

--- a/crates/cherry-rs/src/gui/windows/ray_fan.rs
+++ b/crates/cherry-rs/src/gui/windows/ray_fan.rs
@@ -514,7 +514,6 @@ mod tests {
         let pv = ParaxialView::new(&seq, &parsed.fields, false).expect("paraxial");
         let config = SamplingConfig {
             n_fan_rays: 11,
-            cross_section_n_fan_rays: 3,
             full_pupil_spacing: 0.1,
         };
         let trace = ray_trace_3d_view(&parsed.aperture, &parsed.fields, &seq, &pv, config).ok();

--- a/crates/cherry-rs/src/gui/windows/spot_diagram.rs
+++ b/crates/cherry-rs/src/gui/windows/spot_diagram.rs
@@ -443,7 +443,6 @@ mod tests {
             &pv,
             crate::views::ray_trace_3d::SamplingConfig {
                 n_fan_rays: 3,
-                cross_section_n_fan_rays: 3,
                 full_pupil_spacing: 0.1,
             },
         )

--- a/crates/cherry-rs/src/lib.rs
+++ b/crates/cherry-rs/src/lib.rs
@@ -37,7 +37,7 @@
 //! # Quick Start
 //! ```rust
 //! use cherry_rs::{
-//!     n, ray_trace_3d_view, ApertureSpec, FieldSpec, GapSpec, ImagePlane,
+//!     n, ray_trace_3d_view, trace_ray_bundle, ApertureSpec, FieldSpec, GapSpec, ImagePlane,
 //!     ParaxialView, Pupil, SamplingConfig, RefractiveIndexSpec, Rotation3D,
 //!     SequentialModel, SurfaceSpec, SurfaceType,
 //! };
@@ -116,7 +116,7 @@
 //!     &aperture_spec, &field_specs,
 //!     &sequential_model,
 //!     &paraxial_view,
-//!     SamplingConfig { n_fan_rays: 9, cross_section_n_fan_rays: 3, full_pupil_spacing: 0.1 },
+//!     SamplingConfig { n_fan_rays: 9, full_pupil_spacing: 0.1 },
 //! ).unwrap();
 //!
 //! // Get all results for the second (5 degree) field point.
@@ -157,6 +157,7 @@ pub use views::{
     },
     ray_trace_3d::{
         Ray, RayBundle, SamplingConfig, TraceResults, TraceResultsCollection, ray_trace_3d_view,
+        trace_ray_bundle,
     },
 };
 

--- a/crates/cherry-rs/src/views/cross_section.rs
+++ b/crates/cherry-rs/src/views/cross_section.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use crate::{
     SequentialModel,
     core::{Float, math::vec3::Vec3, sequential_model::Surface},
-    views::{components::Component, ray_trace_3d::TraceResultsCollection},
+    views::{components::Component, ray_trace_3d::RayBundle},
 };
 
 /// Identifies a global transverse coordinate axis for cross-section projection.
@@ -81,11 +81,13 @@ pub enum FlatPlaneKind {
 ///
 /// # Arguments
 /// * `model` - The sequential model.
-/// * `trace` - Optional ray trace results to overlay on the view.
+/// * `cross_section_rays` - Optional ray bundles to overlay on the view. Each
+///   tuple is `(field_id, wavelength_id, bundle)` as returned by
+///   [`trace_ray_bundle`](crate::trace_ray_bundle).
 /// * `components` - Pre-computed optical components (from `components_view`).
 pub fn cross_section_view(
     model: &SequentialModel,
-    trace: Option<&TraceResultsCollection>,
+    cross_section_rays: Option<&[(usize, usize, RayBundle)]>,
     components: &HashSet<Component>,
 ) -> CrossSectionView {
     let wavelengths = model.wavelengths().to_vec();
@@ -95,8 +97,8 @@ pub fn cross_section_view(
     let yz_valid = axis_dirs.iter().all(|d| d.x().abs() < EPS);
     let xz_valid = axis_dirs.iter().all(|d| d.y().abs() < EPS);
 
-    let yz = build_plane_geometry(model, trace, GlobalAxis::Y, components);
-    let xz = build_plane_geometry(model, trace, GlobalAxis::X, components);
+    let yz = build_plane_geometry(model, cross_section_rays, GlobalAxis::Y, components);
+    let xz = build_plane_geometry(model, cross_section_rays, GlobalAxis::X, components);
 
     CrossSectionView {
         wavelengths,
@@ -110,7 +112,7 @@ pub fn cross_section_view(
 /// Build the geometry for one cutting plane.
 fn build_plane_geometry(
     model: &SequentialModel,
-    trace: Option<&TraceResultsCollection>,
+    cross_section_rays: Option<&[(usize, usize, RayBundle)]>,
     axis: GlobalAxis,
     components: &HashSet<Component>,
 ) -> PlaneGeometry {
@@ -215,13 +217,12 @@ fn build_plane_geometry(
     let n_wavelengths = model.wavelengths().len();
     let mut ray_paths: Vec<Vec<Vec<[f64; 2]>>> = vec![Vec::new(); n_wavelengths];
 
-    if let Some(tc) = trace {
-        for result in tc.iter() {
-            let wl_id = result.wavelength_id();
+    if let Some(rays) = cross_section_rays {
+        for (_field_id, wl_id, bundle) in rays {
+            let wl_id = *wl_id;
             if wl_id >= n_wavelengths {
                 continue;
             }
-            let bundle = result.cross_section_fan();
             let n_surf = bundle.num_surfaces();
             let total = bundle.rays().len();
             let n_rays = if n_surf > 0 { total / n_surf } else { 0 };
@@ -407,18 +408,16 @@ mod tests {
 
     #[test]
     fn xz_rays_come_from_u_axis_results() {
-        // After removing axis-based filtering, a TangentialRayFan trace (which
-        // produces Axis::U results) should contribute ray paths to the XZ plane
-        // cross-section via projection, not just the YZ plane.
+        // A TangentialRayFan trace (phi=90°, YZ plane) should contribute ray
+        // paths to the XZ plane cross-section via projection.
         use crate::{
-            ApertureSpec, FieldSpec, ParaxialView,
-            views::ray_trace_3d::{SamplingConfig, ray_trace_3d_view},
+            ApertureSpec, FieldSpec, ParaxialView, specs::fields::PupilSampling,
+            views::ray_trace_3d::trace_ray_bundle,
         };
         let air = n!(1.0);
         let nbk7 = n!(1.515);
         let wavelengths: [Float; 1] = [0.5876];
         let model = convexplano_lens::sequential_model(air.clone(), nbk7, &wavelengths);
-        // phi=90° places the tangential fan in the YZ plane (Axis::U results).
         let fields = vec![FieldSpec::Angle {
             chi: 0.0,
             phi: 90.0,
@@ -427,25 +426,63 @@ mod tests {
             semi_diameter: 12.5,
         };
         let pv = ParaxialView::new(&model, &fields, false).unwrap();
-        let trace = ray_trace_3d_view(
+        let rays = trace_ray_bundle(
             &aperture,
             &fields,
             &model,
             &pv,
-            SamplingConfig {
-                n_fan_rays: 5,
-                cross_section_n_fan_rays: 5,
-                full_pupil_spacing: 0.1,
-            },
+            PupilSampling::TangentialRayFan { n: 5 },
         )
         .unwrap();
         let components = components_view(&model, air).unwrap();
-        let cs = cross_section_view(&model, Some(&trace), &components);
-        // XZ plane should have ray paths from the U-axis trace projected onto X.
+        let cs = cross_section_view(&model, Some(&rays), &components);
+        // XZ plane should have ray paths from the trace projected onto X.
         assert!(
             !cs.xz.ray_paths.iter().all(|w| w.is_empty()),
             "XZ plane should have ray paths from trace projection"
         );
+    }
+
+    #[test]
+    fn ray_paths_populated_per_wavelength() {
+        // Regression: tuples from trace_ray_bundle are (field_id, wavelength_id,
+        // bundle). If the destructuring order is swapped, all paths land in
+        // ray_paths[field_id] instead of ray_paths[wavelength_id], so only the
+        // first wavelength slot ever gets populated.
+        use crate::{
+            ApertureSpec, FieldSpec, ParaxialView, specs::fields::PupilSampling,
+            views::ray_trace_3d::trace_ray_bundle,
+        };
+        let air = n!(1.0);
+        let nbk7 = n!(1.515);
+        let wavelengths: [Float; 3] = [0.4861, 0.5876, 0.6563];
+        let model = convexplano_lens::sequential_model(air.clone(), nbk7, &wavelengths);
+        let fields = vec![FieldSpec::Angle {
+            chi: 0.0,
+            phi: 90.0,
+        }];
+        let aperture = ApertureSpec::EntrancePupil {
+            semi_diameter: 12.5,
+        };
+        let pv = ParaxialView::new(&model, &fields, false).unwrap();
+        let rays = trace_ray_bundle(
+            &aperture,
+            &fields,
+            &model,
+            &pv,
+            PupilSampling::TangentialRayFan { n: 3 },
+        )
+        .unwrap();
+        let components = components_view(&model, air).unwrap();
+        let cs = cross_section_view(&model, Some(&rays), &components);
+
+        // Every wavelength slot must have paths — not just the first one.
+        for (wl_idx, paths) in cs.yz.ray_paths.iter().enumerate() {
+            assert!(
+                !paths.is_empty(),
+                "wavelength {wl_idx} should have ray paths in the YZ plane"
+            );
+        }
     }
 
     #[test]

--- a/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
@@ -32,10 +32,6 @@ use super::paraxial::{ParaxialSubView, ParaxialView};
 pub struct SamplingConfig {
     /// Number of rays in the tangential and sagittal ray fans.
     pub n_fan_rays: usize,
-    /// Number of rays in the tangential fan used for the cross-section view.
-    /// May be 0 (no rays) or any positive integer up to
-    /// MAX_CROSS_SECTION_N_RAYS.
-    pub cross_section_n_fan_rays: usize,
     /// Grid spacing for the full-pupil square-grid sampling, in normalised
     /// pupil coordinates [0, 1].
     pub full_pupil_spacing: Float,
@@ -82,9 +78,67 @@ pub struct TraceResults {
 
     /// A sagittal ray fan perpendicular to the meridional plane.
     sagittal_fan: RayBundle,
+}
 
-    /// A tangential ray fan used exclusively for the cross-section view.
-    cross_section_fan: RayBundle,
+/// Trace a single ray bundle type across all (field, wavelength) pairs.
+///
+/// This is the lower-level counterpart to [`ray_trace_3d_view`]. Use it when
+/// you need a specific sampling that is not one of the four canonical bundles,
+/// for example a tangential fan at a different density for a cross-section
+/// display.
+///
+/// # Arguments
+/// * `aperture_spec` - The aperture specification.
+/// * `field_specs` - The field specifications.
+/// * `sequential_model` - The sequential model.
+/// * `paraxial_view` - A paraxial view. Required for locating the entrance
+///   pupil.
+/// * `sampling` - Which pupil sampling to use for every (field, wavelength)
+///   pair.
+///
+/// # Returns
+/// A `Vec` of `(field_id, wavelength_id, RayBundle)` tuples, one per
+/// (field, wavelength) pair, in unspecified order.
+pub fn trace_ray_bundle(
+    aperture_spec: &ApertureSpec,
+    field_specs: &[FieldSpec],
+    sequential_model: &SequentialModel,
+    paraxial_view: &ParaxialView,
+    sampling: PupilSampling,
+) -> Result<Vec<(usize, usize, RayBundle)>> {
+    validate_field_specs(sequential_model, field_specs)?;
+
+    let n_wavelengths = sequential_model.wavelengths().len();
+    let pairs: Vec<(usize, usize)> = (0..field_specs.len())
+        .flat_map(|f| (0..n_wavelengths).map(move |w| (f, w)))
+        .collect();
+
+    pairs
+        .into_par_iter()
+        .map(
+            |(field_id, wavelength_id)| -> Result<(usize, usize, RayBundle)> {
+                let sequential_submodel = sequential_model
+                    .submodel(wavelength_id)
+                    .ok_or_else(|| anyhow!("Submodel not found"))?;
+                let tangential_vec_id = paraxial_view
+                    .tangential_vec_id_for_phi(field_specs[field_id].tangential_fan_phi());
+                let paraxial_subview = paraxial_view
+                    .get(wavelength_id, tangential_vec_id)
+                    .ok_or_else(|| anyhow!("Submodel not found"))?;
+
+                let bundle = ray_trace_submodel(
+                    sequential_submodel,
+                    sequential_model.surfaces(),
+                    aperture_spec,
+                    &field_specs[field_id],
+                    paraxial_subview,
+                    sampling,
+                )?;
+
+                Ok((field_id, wavelength_id, bundle))
+            },
+        )
+        .collect::<Result<Vec<_>>>()
 }
 
 /// Perform a 3D ray trace on a sequential model.
@@ -173,16 +227,6 @@ pub fn ray_trace_3d_view(
                     n: config.n_fan_rays,
                 },
             )?;
-            let cross_section_fan = ray_trace_submodel(
-                sequential_submodel,
-                surfaces,
-                aperture_spec,
-                field_spec,
-                paraxial_subview,
-                PupilSampling::TangentialRayFan {
-                    n: config.cross_section_n_fan_rays,
-                },
-            )?;
 
             trace!(
                 field_id,
@@ -199,7 +243,6 @@ pub fn ray_trace_3d_view(
                 full_pupil,
                 tangential_fan,
                 sagittal_fan,
-                cross_section_fan,
             })
         })
         .collect::<Result<Vec<_>>>()?;
@@ -280,11 +323,6 @@ impl TraceResults {
     // Returns the sagittal ray fan bundle.
     pub fn sagittal_fan(&self) -> &RayBundle {
         &self.sagittal_fan
-    }
-
-    // Returns the tangential ray fan bundle used for the cross-section view.
-    pub fn cross_section_fan(&self) -> &RayBundle {
-        &self.cross_section_fan
     }
 
     // Returns the wavelength ID of the ray bundle.
@@ -795,12 +833,37 @@ mod tests {
     }
 
     #[test]
+    fn test_trace_ray_bundle() {
+        let s = setup();
+
+        let bundles = trace_ray_bundle(
+            &s.aperture_spec,
+            &s.field_specs,
+            &s.sequential_model,
+            &s.paraxial_view,
+            PupilSampling::TangentialRayFan { n: 7 },
+        )
+        .unwrap();
+
+        // One tuple per (field, wavelength) pair: 2 fields × 1 wavelength = 2.
+        assert_eq!(bundles.len(), 2);
+        for (field_id, wavelength_id, bundle) in &bundles {
+            assert!(*field_id < s.field_specs.len());
+            assert_eq!(*wavelength_id, 0);
+            assert_eq!(
+                bundle.rays().len() / bundle.num_surfaces(),
+                7,
+                "field {field_id} bundle should have 7 rays"
+            );
+        }
+    }
+
+    #[test]
     fn test_ray_trace_3d_view() {
         let s = setup();
 
         let config = SamplingConfig {
             n_fan_rays: 3,
-            cross_section_n_fan_rays: 3,
             full_pupil_spacing: 0.1,
         };
         let results = ray_trace_3d_view(
@@ -820,7 +883,6 @@ mod tests {
         let s = setup();
         let config = SamplingConfig {
             n_fan_rays: 5,
-            cross_section_n_fan_rays: 5,
             full_pupil_spacing: 0.1,
         };
 
@@ -1200,7 +1262,6 @@ mod tests {
         let paraxial_view = ParaxialView::new(&sequential_model, &field_specs, false).unwrap();
         let config = SamplingConfig {
             n_fan_rays: 3,
-            cross_section_n_fan_rays: 3,
             full_pupil_spacing: 0.1,
         };
 
@@ -1259,7 +1320,6 @@ mod tests {
         let s = setup();
         let config = SamplingConfig {
             n_fan_rays: 3,
-            cross_section_n_fan_rays: 3,
             full_pupil_spacing: 0.1,
         };
         let results = ray_trace_3d_view(

--- a/crates/cherry-rs/tests/f_theta_scan_lens.rs
+++ b/crates/cherry-rs/tests/f_theta_scan_lens.rs
@@ -37,7 +37,7 @@ fn test_ray_trace_3d_on_axis() {
         &paraxial_view,
         SamplingConfig {
             n_fan_rays: 9,
-            cross_section_n_fan_rays: 3,
+
             full_pupil_spacing: 0.1,
         },
     )
@@ -73,7 +73,7 @@ fn test_ray_trace_3d_off_axis() {
         &paraxial_view,
         SamplingConfig {
             n_fan_rays: 9,
-            cross_section_n_fan_rays: 3,
+
             full_pupil_spacing: 0.1,
         },
     )
@@ -99,7 +99,7 @@ fn test_ray_trace_3d_square_grid() {
         &paraxial_view,
         SamplingConfig {
             n_fan_rays: 9,
-            cross_section_n_fan_rays: 3,
+
             full_pupil_spacing: 0.5,
         },
     )


### PR DESCRIPTION
This introduces a new public function to the ray_trace_3d_view module called `trace_ray_bundle` that allows for more modular tracing of bundles. `ray_trace_3d_view` is used to trace the canonical set of bundles for each wavelength and field point, i.e. chief ray, full pupil, tangential fan, and sagittal fan.