### PR TITLE
refactor: Change Surface to a Trait and separate out placement logic

### DIFF
--- a/crates/cherry-rs/src/core/math/linalg/mat2x2.rs
+++ b/crates/cherry-rs/src/core/math/linalg/mat2x2.rs
@@ -12,10 +12,6 @@ impl Mat2x2 {
             e: [[e00, e01], [e10, e11]],
         }
     }
-
-    pub fn identity() -> Self {
-        Self::new(1.0, 0.0, 0.0, 1.0)
-    }
 }
 
 impl std::ops::Mul<Mat2x2> for Mat2x2 {
@@ -44,15 +40,10 @@ mod test {
     }
 
     #[test]
-    fn mat2_identity() {
-        let mat = Mat2x2::identity();
-        assert_eq!(mat, Mat2x2::new(1.0, 0.0, 0.0, 1.0));
-    }
-
-    #[test]
     fn mat2_identity_mul() {
+        let identity = Mat2x2::new(1.0, 0.0, 0.0, 1.0);
         let mat = Mat2x2::new(1.0, 2.0, 3.0, 4.0);
-        assert_eq!(mat * Mat2x2::identity(), mat);
-        assert_eq!(Mat2x2::identity() * mat, mat);
+        assert_eq!(mat * identity, mat);
+        assert_eq!(identity * mat, mat);
     }
 }

--- a/crates/cherry-rs/src/core/mod.rs
+++ b/crates/cherry-rs/src/core/mod.rs
@@ -1,7 +1,9 @@
 /// Data types for modeling ray tracing systems.
 pub(super) mod math;
+pub(crate) mod placement;
 pub(crate) mod refractive_index;
 pub(crate) mod sequential_model;
+pub(crate) mod surfaces;
 
 pub(crate) type Float = f64;
 

--- a/crates/cherry-rs/src/core/placement.rs
+++ b/crates/cherry-rs/src/core/placement.rs
@@ -1,0 +1,153 @@
+/// Placement of a surface in a sequential optical system.
+///
+/// A [`Placement`] describes *where* a surface sits in 3D space and how the
+/// optical axis (cursor) is oriented when it arrives at that surface. It is
+/// intentionally separate from surface geometry ([`Surface`]) so that
+/// coordinate-system operations and intrinsic-geometry operations do not mix.
+///
+/// [`Surface`]: crate::core::surfaces::Surface
+use crate::core::{
+    Float,
+    math::{linalg::mat3x3::Mat3x3, vec3::Vec3},
+};
+
+use crate::core::math::geometry::reference_frames::Cursor;
+use crate::specs::surfaces::SurfaceSpec;
+
+/// Position and orientation of a surface in the global coordinate system.
+#[derive(Debug, Clone)]
+pub struct Placement {
+    /// Vertex position in the global coordinate system.
+    pub position: Vec3,
+
+    /// Cumulative path length along the axis to this surface.
+    pub track: Float,
+
+    /// Rotation from the global frame into the surface's local frame.
+    ///
+    /// Equals `surface_tilt_rotation × cursor_rotation` (global-to-local).
+    pub rotation_matrix: Mat3x3,
+
+    /// Inverse of `rotation_matrix` (local-to-global).
+    ///
+    /// Because the matrix is orthogonal this equals
+    /// `rotation_matrix.transpose()`.
+    pub inv_rotation_matrix: Mat3x3,
+
+    /// Rotation from the global frame into the optical-axis (cursor) frame
+    /// only, without any surface tilt applied.
+    ///
+    /// Needed for aperture-projection calculations (`projected_semi_diameter`)
+    /// and for `is_rotationally_symmetric`.
+    pub cursor_rotation_matrix: Mat3x3,
+}
+
+impl Placement {
+    /// Build a [`Placement`] from a surface spec and the current cursor state.
+    ///
+    /// The cursor holds the current position and optical-axis orientation.
+    /// The spec may carry an additional surface-tilt rotation that is composed
+    /// on top of the cursor orientation.
+    pub(crate) fn from_spec(spec: &SurfaceSpec, cursor: &Cursor) -> Self {
+        let cursor_rotation_matrix = cursor.rotation_matrix();
+        let rotation_matrix = match spec {
+            SurfaceSpec::Conic { rotation, .. }
+            | SurfaceSpec::Image { rotation }
+            | SurfaceSpec::Probe { rotation }
+            | SurfaceSpec::Stop { rotation, .. } => {
+                rotation.rotation_matrix() * cursor_rotation_matrix
+            }
+            SurfaceSpec::Object => cursor_rotation_matrix,
+        };
+        Self::new(
+            cursor.pos(),
+            cursor.track(),
+            rotation_matrix,
+            cursor_rotation_matrix,
+        )
+    }
+
+    /// Create a new [`Placement`] from its constituent parts.
+    pub fn new(
+        position: Vec3,
+        track: Float,
+        rotation_matrix: Mat3x3,
+        cursor_rotation_matrix: Mat3x3,
+    ) -> Self {
+        let inv_rotation_matrix = rotation_matrix.transpose();
+        Self {
+            position,
+            track,
+            rotation_matrix,
+            inv_rotation_matrix,
+            cursor_rotation_matrix,
+        }
+    }
+
+    /// Returns the axial (z) position of the surface vertex.
+    pub fn z(&self) -> Float {
+        self.position.z()
+    }
+
+    /// Returns `true` if any coordinate of the vertex position is infinite.
+    ///
+    /// This is the case for the object surface of a system with an object at
+    /// infinity.
+    pub fn is_infinite(&self) -> bool {
+        self.position.x().is_infinite()
+            || self.position.y().is_infinite()
+            || self.position.z().is_infinite()
+    }
+
+    /// Returns the unit vector pointing along the optical axis (cursor forward
+    /// direction) at this surface, expressed in the global frame.
+    pub fn axis_direction(&self) -> Vec3 {
+        // The third row of cursor_rotation_matrix is the forward direction in
+        // global coords when the matrix is global-to-cursor.
+        // Transposing maps it back to global, giving the forward vector.
+        self.cursor_rotation_matrix.transpose() * Vec3::new(0.0, 0.0, 1.0)
+    }
+
+    /// Returns the semi-diameter as seen by a paraxial ray travelling along
+    /// the cursor axis in the tangential plane defined by `v`.
+    ///
+    /// `r` is the surface's clear-aperture semi-diameter (from
+    /// [`Surface::semi_diameter`]). `v` is a unit vector in the global
+    /// frame that lies in the transverse plane and defines the meridional
+    /// plane of interest.
+    ///
+    /// For a tilted surface the effective limit on cursor height is
+    /// `r · |n_F| / sqrt(n_φ² + n_F²)` where `(n_R, n_U, n_F)` are the
+    /// surface-normal components in the cursor frame and
+    /// `n_φ = n_R · v_x + n_U · v_y` is the component along `v`.
+    ///
+    /// Returns [`Float::INFINITY`] when `r` is infinite (non-aperture
+    /// surfaces).
+    ///
+    /// [`Surface::semi_diameter`]: crate::core::surfaces::Surface::semi_diameter
+    pub fn projected_semi_diameter(&self, r: Float, v: Vec3) -> Float {
+        if r.is_infinite() {
+            return Float::INFINITY;
+        }
+
+        // R_surf = cursor_to_local = global_to_local · cursor_to_global
+        //        = rotation_matrix · cursor_rotation_matrix.transpose()
+        let r_surf = self.rotation_matrix * self.cursor_rotation_matrix.transpose();
+
+        // Third row of R_surf is the surface normal expressed in cursor frame:
+        // (n_R, n_U, n_F)
+        let n_r = r_surf.e[2][0];
+        let n_u = r_surf.e[2][1];
+        let n_f = r_surf.e[2][2];
+
+        // Component of the surface normal along the tangential direction v.
+        let n_phi = n_r * v.x() + n_u * v.y();
+        let denom = (n_phi * n_phi + n_f * n_f).sqrt();
+
+        if denom < 1e-12 {
+            return 0.0;
+        }
+
+        r * n_f.abs() / denom
+    }
+}

--- a/crates/cherry-rs/src/core/sequential_model.rs
+++ b/crates/cherry-rs/src/core/sequential_model.rs
@@ -1,18 +1,18 @@
 /// Data types for modeling sequential ray tracing systems.
-use std::fmt::{Display, Formatter};
 use std::ops::Range;
 
 use anyhow::{Result, anyhow};
-use tracing::trace;
 
 use crate::core::{
     Float,
     math::{geometry::reference_frames::Cursor, linalg::mat3x3::Mat3x3, vec3::Vec3},
+    placement::Placement,
     refractive_index::RefractiveIndex,
+    surfaces::{Conic, Image, Object, Probe, Stop, Surface},
 };
 use crate::specs::{
     gaps::GapSpec,
-    surfaces::{SurfaceSpec, SurfaceType},
+    surfaces::{BoundaryType, SurfaceSpec},
 };
 
 /// A gap between two surfaces in a sequential system.
@@ -32,9 +32,12 @@ pub struct Gap {
 /// [SequentialSubModel](trait@SequentialSubModel) for more information.
 #[derive(Debug)]
 pub struct SequentialModel {
-    surfaces: Vec<Surface>,
+    surfaces: Vec<Box<dyn Surface>>,
+    placements: Vec<Placement>,
     submodels: Vec<SequentialSubModelBase>,
     wavelengths: Vec<Float>,
+
+    // The cursor forward direction at each surface vertex.
     axis_directions: Vec<Vec3>,
 }
 
@@ -115,7 +118,11 @@ pub trait SequentialSubModel {
     fn len(&self) -> usize {
         self.gaps().len()
     }
-    fn try_iter<'a>(&'a self, surfaces: &'a [Surface]) -> Result<SequentialSubModelIter<'a>>;
+    fn try_iter<'a>(
+        &'a self,
+        surfaces: &'a [Box<dyn Surface>],
+        placements: &'a [Placement],
+    ) -> Result<SequentialSubModelIter<'a>>;
 
     fn slice(&self, idx: Range<usize>) -> SequentialSubModelSlice<'_> {
         SequentialSubModelSlice {
@@ -141,14 +148,16 @@ pub struct SequentialSubModelSlice<'a> {
 ///
 /// Most operations in sequential modeling involve use of this iterator.
 pub struct SequentialSubModelIter<'a> {
-    surfaces: &'a [Surface],
+    surfaces: &'a [Box<dyn Surface>],
+    placements: &'a [Placement],
     gaps: &'a [Gap],
     index: usize,
 }
 
 /// A reverse iterator over the surfaces and gaps in a submodel.
 pub struct SequentialSubModelReverseIter<'a> {
-    surfaces: &'a [Surface],
+    surfaces: &'a [Box<dyn Surface>],
+    placements: &'a [Placement],
     gaps: &'a [Gap],
     index: usize,
 }
@@ -157,75 +166,12 @@ pub struct SequentialSubModelReverseIter<'a> {
 ///
 /// See the documentation for
 /// [SequentialSubModel](trait@SequentialSubModel) for more information.
-pub type Step<'a> = (&'a Gap, &'a Surface, Option<&'a Gap>);
-
-#[derive(Debug)]
-pub enum Surface {
-    Conic(Conic),
-    Image(Image),
-    Object(Object),
-    Probe(Probe),
-    Stop(Stop),
-    //Toric(Toric),
+pub struct Step<'a> {
+    pub gap_before: &'a Gap,
+    pub surface: &'a dyn Surface,
+    pub gap_after: Option<&'a Gap>,
+    pub placement: &'a Placement,
 }
-
-#[derive(Debug)]
-pub struct Conic {
-    pos: Vec3,
-    track: Float,
-    rotation_matrix: Mat3x3,
-    inv_rotation_matrix: Mat3x3,
-    rotation_matrix_global_to_cursor: Mat3x3,
-    semi_diameter: Float,
-    radius_of_curvature: Float,
-    conic_constant: Float,
-    surface_type: SurfaceType,
-}
-
-#[derive(Debug)]
-pub struct Image {
-    pos: Vec3,
-    track: Float,
-    rotation_matrix: Mat3x3,
-    inv_rotation_matrix: Mat3x3,
-}
-
-#[derive(Debug)]
-pub struct Object {
-    pos: Vec3,
-    track: Float,
-}
-
-/// A surface without any effect on rays that is used to measure intersections.
-#[derive(Debug)]
-pub struct Probe {
-    pos: Vec3,
-    track: Float,
-    rotation_matrix: Mat3x3,
-    inv_rotation_matrix: Mat3x3,
-}
-
-#[derive(Debug)]
-pub struct Stop {
-    pos: Vec3,
-    track: Float,
-    rotation_matrix: Mat3x3,
-    inv_rotation_matrix: Mat3x3,
-    rotation_matrix_global_to_cursor: Mat3x3,
-    semi_diameter: Float,
-}
-
-// TODO: Implement Toric surfaces
-//#[derive(Debug)]
-//pub struct Toric {
-//    pos: Vec3,
-//    rotation_matrix: Mat3,
-//    semi_diameter: Float,
-//    radius_of_curvature_y: Float,
-//    radius_of_curvature_x: Float,
-//    conic_constant: Float,
-//    surface_type: SurfaceType,
-//}
 
 /// Propagates a tangential direction unit vector through the mirror surfaces of
 /// a system using the vector law of reflection.
@@ -235,17 +181,22 @@ pub struct Stop {
 /// reflecting surface the returned vector is the direction arriving at the
 /// surface; subsequent surfaces receive the post-reflection direction as their
 /// incident vector. The vector is expressed in global coordinates throughout.
-pub(crate) fn propagate_tangential_vec(v_init: Vec3, surfaces: &[Surface]) -> Vec<Vec3> {
-    use crate::specs::surfaces::SurfaceType;
+pub(crate) fn propagate_tangential_vec(
+    v_init: Vec3,
+    surfaces: &[Box<dyn Surface>],
+    placements: &[Placement],
+) -> Vec<Vec3> {
+    use crate::specs::surfaces::BoundaryType;
     let mut v = v_init;
     surfaces
         .iter()
-        .map(|surf| {
+        .zip(placements.iter())
+        .map(|(surf, placement)| {
             let v_incident = v;
-            if let SurfaceType::Reflecting = surf.surface_type() {
+            if let BoundaryType::Reflecting = surf.boundary_type() {
                 // Normal in global frame: third column of inv_rotation_matrix
                 // (maps local Z to global).
-                let n = surf.inv_rot_mat() * Vec3::new(0.0, 0.0, 1.0);
+                let n = placement.inv_rotation_matrix * Vec3::new(0.0, 0.0, 1.0);
                 let dot = v.x() * n.x() + v.y() * n.y() + v.z() * n.z();
                 v = Vec3::new(
                     v.x() - 2.0 * dot * n.x(),
@@ -259,60 +210,29 @@ pub(crate) fn propagate_tangential_vec(v_init: Vec3, surfaces: &[Surface]) -> Ve
 }
 
 /// Returns the index of the first physical surface in the system.
-/// This is the first surface that is not an object, image, or probe surface.
-/// If no such surface exists, then the function returns None.
-pub(crate) fn first_physical_surface(surfaces: &[Surface]) -> Option<usize> {
+///
+/// A physical surface is one that has a finite semi-diameter,
+/// i.e., a Conic or Stop. Object, Image, and Probe surfaces are excluded.
+pub(crate) fn first_physical_surface(surfaces: &[Box<dyn Surface>]) -> Option<usize> {
     surfaces
         .iter()
-        .position(|surf| matches!(surf, Surface::Conic(_) | Surface::Stop(_)))
+        .position(|surf| surf.semi_diameter().is_finite())
 }
 
 /// Returns the index of the last physical surface in the system.
-/// This is the last surface that is not an object, image, or probe surface.
-/// If no such surface exists, then the function returns None.
-pub fn last_physical_surface(surfaces: &[Surface]) -> Option<usize> {
+///
+/// A physical surface is one that limits the has a finite semi-diameter,
+/// i.e., a Conic or Stop. Object, Image, and Probe surfaces are excluded.
+pub fn last_physical_surface(surfaces: &[Box<dyn Surface>]) -> Option<usize> {
     surfaces
         .iter()
-        .rposition(|surf| matches!(surf, Surface::Conic(_) | Surface::Stop(_)))
+        .rposition(|surf| surf.semi_diameter().is_finite())
 }
 
 /// Returns the id of a surface in a reversed system.
-pub fn reversed_surface_id(surfaces: &[Surface], surf_id: usize) -> usize {
+pub fn reversed_surface_id(num_surfaces: usize, surf_id: usize) -> usize {
     // Reversed IDs are ray starts, then image plane, then surfaces
-    surfaces.len() - surf_id - 1
-}
-
-impl Conic {
-    pub fn sag_norm(&self, pos: Vec3) -> (Float, Vec3) {
-        if self.radius_of_curvature.is_infinite() {
-            return (0.0, Vec3::new(0.0, 0.0, 1.0));
-        }
-
-        // Convert to polar coordinates in x, y plane
-        let r = (pos.x().powi(2) + pos.y().powi(2)).sqrt();
-        let theta = pos.y().atan2(pos.x());
-
-        // Compute surface sag
-        let a = r.powi(2) / self.radius_of_curvature;
-        let sag =
-            a / (1.0 + (1.0 - (1.0 + self.conic_constant) * a / self.radius_of_curvature).sqrt());
-
-        // Compute surface normal
-        let denom = (self.radius_of_curvature.powi(4)
-            - (1.0 + self.conic_constant) * (r * self.radius_of_curvature).powi(2))
-        .sqrt();
-        let dfdx = -r * self.radius_of_curvature * theta.cos() / denom;
-        let dfdy = -r * self.radius_of_curvature * theta.sin() / denom;
-        let dfdz = 1.0 as Float;
-
-        // Do not normalize the normal vector!
-        // Its magnitude is important for Newton-Raphson ray tracing calculations.
-        let norm = Vec3::new(dfdx, dfdy, dfdz);
-
-        trace!(sag, dfdx, dfdy, dfdz, "conic sag_norm");
-
-        (sag, norm)
-    }
+    num_surfaces - surf_id - 1
 }
 
 impl Gap {
@@ -344,7 +264,8 @@ impl SequentialModel {
     ) -> Result<Self> {
         Self::validate_specs(gap_specs, wavelengths)?;
 
-        let (surfaces, axis_directions) = Self::surf_specs_to_surfs(surface_specs, gap_specs);
+        let (surfaces, placements, axis_directions) =
+            Self::surf_specs_to_surfs(surface_specs, gap_specs);
 
         let mut models: Vec<SequentialSubModelBase> = Vec::new();
         for &wavelength in wavelengths.iter() {
@@ -354,6 +275,7 @@ impl SequentialModel {
 
         Ok(Self {
             surfaces,
+            placements,
             submodels: models,
             wavelengths: wavelengths.to_vec(),
             axis_directions,
@@ -367,18 +289,27 @@ impl SequentialModel {
     pub fn largest_semi_diameter(&self) -> Float {
         self.surfaces
             .iter()
-            .filter_map(|surf| match surf {
-                Surface::Conic(conic) => Some(conic.semi_diameter),
-                //Surface::Toric(toric) => Some(toric.semi_diameter),
-                Surface::Stop(stop) => Some(stop.semi_diameter),
-                _ => None,
+            .filter_map(|surf| {
+                let sd = surf.semi_diameter();
+                if sd.is_finite() { Some(sd) } else { None }
             })
             .fold(0.0, |acc, x| acc.max(x))
     }
 
     /// Returns the surfaces in the system.
-    pub fn surfaces(&self) -> &[Surface] {
+    ///
+    /// The i-th surface corresponds to the i-th placement returned by
+    /// [`placements()`](Self::placements).
+    pub fn surfaces(&self) -> &[Box<dyn Surface>] {
         &self.surfaces
+    }
+
+    /// Returns the placements of all surfaces in the system.
+    ///
+    /// The i-th placement corresponds to the i-th surface returned by
+    /// [`surfaces()`](Self::surfaces).
+    pub fn placements(&self) -> &[Placement] {
+        &self.placements
     }
 
     /// Returns the submodel for a given wavelength index, or `None` if the
@@ -421,17 +352,14 @@ impl SequentialModel {
 
     /// Returns true if the system is rotationally symmetric about the optical
     /// axis.
-    pub fn is_rotationally_symmetric(surfaces: &[Surface]) -> bool {
-        !surfaces.iter().any(|surf| {
-            let r_surf = match surf {
-                Surface::Conic(c) => {
-                    c.rotation_matrix * c.rotation_matrix_global_to_cursor.transpose()
-                }
-                Surface::Stop(s) => {
-                    s.rotation_matrix * s.rotation_matrix_global_to_cursor.transpose()
-                }
-                _ => return false,
-            };
+    ///
+    /// A system is rotationally symmetric if no physical surface has a tilt
+    /// relative to the optical axis, i.e., the surface-tilt rotation equals
+    /// the cursor rotation at every physical surface.
+    pub fn is_rotationally_symmetric(placements: &[Placement]) -> bool {
+        !placements.iter().any(|p| {
+            // R_surf = surface_tilt × cursor = global_to_local · cursor_to_global
+            let r_surf = p.rotation_matrix * p.cursor_rotation_matrix.transpose();
             !r_surf.approx_eq(&Mat3x3::identity(), 1e-10)
         })
     }
@@ -439,8 +367,9 @@ impl SequentialModel {
     fn surf_specs_to_surfs(
         surf_specs: &[SurfaceSpec],
         gap_specs: &[GapSpec],
-    ) -> (Vec<Surface>, Vec<Vec3>) {
-        let mut surfaces = Vec::new();
+    ) -> (Vec<Box<dyn Surface>>, Vec<Placement>, Vec<Vec3>) {
+        let mut surfaces: Vec<Box<dyn Surface>> = Vec::new();
+        let mut placements = Vec::new();
         let mut axis_directions = Vec::new();
 
         // The first surface is an object surface.
@@ -450,29 +379,30 @@ impl SequentialModel {
         // Create surfaces 0 to n-1
         for (surf_spec, gap_spec) in surf_specs.iter().zip(gap_specs.iter()) {
             axis_directions.push(cursor.forward());
-            let surf = Surface::from_spec(surf_spec, &cursor);
+            let placement = Placement::from_spec(surf_spec, &cursor);
+            let surf = surface_from_spec(surf_spec);
 
-            // Flip the cursor upon reflection
-            if let SurfaceType::Reflecting = surf.surface_type() {
-                let (_, mut norm) = surf.sag_norm(cursor.pos());
-                norm = (surf.inv_rot_mat() * norm).normalize(); // Transform normal to global coordinates
+            // Flip the cursor upon reflection. Evaluate the normal at the
+            // vertex (local origin = (0,0,0)) and transform to global frame.
+            if let BoundaryType::Reflecting = surf.boundary_type() {
+                let (_, mut norm) = surf.sag_norm(Vec3::new(0.0, 0.0, 0.0));
+                norm = (placement.inv_rotation_matrix * norm).normalize();
                 cursor.reflect(&norm);
             }
 
-            // Add the surface to the list and advance the cursor
+            placements.push(placement);
             surfaces.push(surf);
             cursor.advance(gap_spec.thickness);
         }
 
         // Add the last surface
         axis_directions.push(cursor.forward());
-        surfaces.push(Surface::from_spec(
-            surf_specs
-                .last()
-                .expect("There should always be one last surface."),
-            &cursor,
-        ));
-        (surfaces, axis_directions)
+        let last_spec = surf_specs
+            .last()
+            .expect("There should always be one last surface.");
+        placements.push(Placement::from_spec(last_spec, &cursor));
+        surfaces.push(surface_from_spec(last_spec));
+        (surfaces, placements, axis_directions)
     }
 
     fn validate_gaps(gaps: &[GapSpec]) -> Result<()> {
@@ -516,8 +446,12 @@ impl SequentialSubModel for SequentialSubModelBase {
             .is_infinite()
     }
 
-    fn try_iter<'a>(&'a self, surfaces: &'a [Surface]) -> Result<SequentialSubModelIter<'a>> {
-        SequentialSubModelIter::new(surfaces, &self.gaps)
+    fn try_iter<'a>(
+        &'a self,
+        surfaces: &'a [Box<dyn Surface>],
+        placements: &'a [Placement],
+    ) -> Result<SequentialSubModelIter<'a>> {
+        SequentialSubModelIter::new(surfaces, placements, &self.gaps)
     }
 }
 
@@ -534,13 +468,21 @@ impl SequentialSubModel for SequentialSubModelSlice<'_> {
             .is_infinite()
     }
 
-    fn try_iter<'b>(&'b self, surfaces: &'b [Surface]) -> Result<SequentialSubModelIter<'b>> {
-        SequentialSubModelIter::new(surfaces, self.gaps)
+    fn try_iter<'b>(
+        &'b self,
+        surfaces: &'b [Box<dyn Surface>],
+        placements: &'b [Placement],
+    ) -> Result<SequentialSubModelIter<'b>> {
+        SequentialSubModelIter::new(surfaces, placements, self.gaps)
     }
 }
 
 impl<'a> SequentialSubModelIter<'a> {
-    fn new(surfaces: &'a [Surface], gaps: &'a [Gap]) -> Result<Self> {
+    fn new(
+        surfaces: &'a [Box<dyn Surface>],
+        placements: &'a [Placement],
+        gaps: &'a [Gap],
+    ) -> Result<Self> {
         if surfaces.len() != gaps.len() + 1 {
             return Err(anyhow!(
                 "The number of surfaces must be one more than the number of gaps in a forward sequential submodel."
@@ -549,13 +491,14 @@ impl<'a> SequentialSubModelIter<'a> {
 
         Ok(Self {
             surfaces,
+            placements,
             gaps,
             index: 0,
         })
     }
 
     pub fn try_reverse(self) -> Result<SequentialSubModelReverseIter<'a>> {
-        SequentialSubModelReverseIter::new(self.surfaces, self.gaps)
+        SequentialSubModelReverseIter::new(self.surfaces, self.placements, self.gaps)
     }
 }
 
@@ -563,17 +506,24 @@ impl<'a> Iterator for SequentialSubModelIter<'a> {
     type Item = Step<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        let surf_idx = self.index + 1;
         if self.index == self.gaps.len() - 1 {
             // We are at the image space gap
-            let result = Some((&self.gaps[self.index], &self.surfaces[self.index + 1], None));
+            let result = Some(Step {
+                gap_before: &self.gaps[self.index],
+                surface: self.surfaces[surf_idx].as_ref(),
+                gap_after: None,
+                placement: &self.placements[surf_idx],
+            });
             self.index += 1;
             result
         } else if self.index < self.gaps.len() {
-            let result = Some((
-                &self.gaps[self.index],
-                &self.surfaces[self.index + 1],
-                Some(&self.gaps[self.index + 1]),
-            ));
+            let result = Some(Step {
+                gap_before: &self.gaps[self.index],
+                surface: self.surfaces[surf_idx].as_ref(),
+                gap_after: Some(&self.gaps[self.index + 1]),
+                placement: &self.placements[surf_idx],
+            });
             self.index += 1;
             result
         } else {
@@ -589,7 +539,11 @@ impl ExactSizeIterator for SequentialSubModelIter<'_> {
 }
 
 impl<'a> SequentialSubModelReverseIter<'a> {
-    fn new(surfaces: &'a [Surface], gaps: &'a [Gap]) -> Result<Self> {
+    fn new(
+        surfaces: &'a [Box<dyn Surface>],
+        placements: &'a [Placement],
+        gaps: &'a [Gap],
+    ) -> Result<Self> {
         // Note that this requirement is different than the forward iterator.
         if surfaces.len() != gaps.len() + 1 {
             return Err(anyhow!(
@@ -599,6 +553,7 @@ impl<'a> SequentialSubModelReverseIter<'a> {
 
         Ok(Self {
             surfaces,
+            placements,
             gaps,
             // We will never iterate from the image space surface in reverse.
             index: 1,
@@ -615,11 +570,12 @@ impl<'a> Iterator for SequentialSubModelReverseIter<'a> {
         let forward_index = n - self.index;
         if self.index < n {
             // We are somewhere in the middle of the system or at the object space gap.
-            let result = Some((
-                &self.gaps[forward_index],
-                &self.surfaces[forward_index],
-                Some(&self.gaps[forward_index - 1]),
-            ));
+            let result = Some(Step {
+                gap_before: &self.gaps[forward_index],
+                surface: self.surfaces[forward_index].as_ref(),
+                gap_after: Some(&self.gaps[forward_index - 1]),
+                placement: &self.placements[forward_index],
+            });
             self.index += 1;
             result
         } else {
@@ -628,328 +584,62 @@ impl<'a> Iterator for SequentialSubModelReverseIter<'a> {
     }
 }
 
-impl Surface {
-    /// Returns the z-coordinate of the surface's vertex.
-    pub fn z(&self) -> Float {
-        self.pos().z()
-    }
-
-    /// Returns the cumulative path length (track) to this surface along the
-    /// beam.
-    pub fn track(&self) -> Float {
-        match self {
-            Surface::Conic(s) => s.track,
-            Surface::Image(s) => s.track,
-            Surface::Object(s) => s.track,
-            Surface::Probe(s) => s.track,
-            Surface::Stop(s) => s.track,
-        }
-    }
-
-    /// Creates a new surface from a specification.
-    ///
-    /// The position and rotation of the surface are determined by the input
-    /// cursor, which serves as a frame of reference. The optical axis is
-    /// understood to be the forward or z-direction of the cursor's
-    /// orientation. The `rotation` argument is used to apply a rotation of
-    /// the surface about the reference frame.
-    ///
-    /// # Arguments
-    /// * `spec` - The specification of the surface.
-    /// * `cursor` - The reference frame in which the surface is defined.
-    pub(crate) fn from_spec(spec: &SurfaceSpec, cursor: &Cursor) -> Self {
-        let pos = cursor.pos();
-        let track = cursor.track();
-        let rot_mat_global_to_cursor = cursor.rotation_matrix();
-
-        match spec {
-            SurfaceSpec::Conic {
-                semi_diameter,
-                radius_of_curvature,
-                conic_constant,
-                surf_type,
-                rotation,
-            } => {
-                // Cursor to local rotation matrix * global to cursor rotation matrix
-                let rotation_matrix = rotation.rotation_matrix() * rot_mat_global_to_cursor;
-                let inv_rotation_matrix = rotation_matrix.transpose();
-                Self::Conic(Conic {
-                    pos,
-                    track,
-                    rotation_matrix,
-                    inv_rotation_matrix,
-                    rotation_matrix_global_to_cursor: rot_mat_global_to_cursor,
-                    semi_diameter: *semi_diameter,
-                    radius_of_curvature: *radius_of_curvature,
-                    conic_constant: *conic_constant,
-                    surface_type: *surf_type,
-                })
-            }
-            SurfaceSpec::Image { rotation } => {
-                let rotation_matrix = rotation.rotation_matrix() * rot_mat_global_to_cursor;
-                let inv_rotation_matrix = rotation_matrix.transpose();
-                Self::Image(Image {
-                    pos,
-                    track,
-                    rotation_matrix,
-                    inv_rotation_matrix,
-                })
-            }
-            SurfaceSpec::Object => Self::Object(Object { pos, track }),
-            SurfaceSpec::Probe { rotation } => {
-                let rotation_matrix = rotation.rotation_matrix() * rot_mat_global_to_cursor;
-                let inv_rotation_matrix = rotation_matrix.transpose();
-                Self::Probe(Probe {
-                    pos,
-                    track,
-                    rotation_matrix,
-                    inv_rotation_matrix,
-                })
-            }
-            SurfaceSpec::Stop {
-                semi_diameter,
-                rotation,
-            } => {
-                let rotation_matrix = rotation.rotation_matrix() * rot_mat_global_to_cursor;
-                let inv_rotation_matrix = rotation_matrix.transpose();
-                Self::Stop(Stop {
-                    pos,
-                    track,
-                    rotation_matrix,
-                    inv_rotation_matrix,
-                    rotation_matrix_global_to_cursor: rot_mat_global_to_cursor,
-                    semi_diameter: *semi_diameter,
-                })
-            }
-            // SurfaceSpec::Toric {
-            //     semi_diameter,
-            //     radius_of_curvature_vert,
-            //     radius_of_curvature_horz,
-            //     conic_constant,
-            //     surf_type,
-            // } => Self::Toric(Toric {
-            //     pos,
-            //     rotation_matrix,
-            //     semi_diameter: *semi_diameter,
-            //     radius_of_curvature_y: *radius_of_curvature_vert,
-            //     radius_of_curvature_x: *radius_of_curvature_horz,
-            //     conic_constant: *conic_constant,
-            //     surface_type: *surf_type,
-            // }),
-        }
-    }
-
-    pub(crate) fn is_infinite(&self) -> bool {
-        if self.pos().z().is_infinite()
-            || self.pos().y().is_infinite()
-            || self.pos().x().is_infinite()
-        {
-            return true;
-        }
-
-        false
-    }
-
-    /// Determines whether a transverse point is outside the clear aperture of
-    /// the surface.
-    ///
-    /// The axial z-position is ignored.
-    pub(crate) fn outside_clear_aperture(&self, pos: Vec3) -> bool {
-        let r_transv = pos.x() * pos.x() + pos.y() * pos.y();
-        let r_max = self.semi_diameter();
-
-        r_transv > r_max * r_max
-    }
-
-    pub(crate) fn roc(&self) -> Float {
-        self.rocx()
-    }
-
-    /// The radius of curvature in the horizontal direction.
-    fn rocx(&self) -> Float {
-        match self {
-            Self::Conic(conic) => conic.radius_of_curvature,
-            //Self::Toric(toric) => toric.radius_of_curvature_x,
-            _ => Float::INFINITY,
-        }
-    }
-
-    /// Returns the rotation matrix of the surface into the local coordinate
-    /// system.
-    pub(crate) fn rot_mat(&self) -> Mat3x3 {
-        match self {
-            Self::Conic(conic) => conic.rotation_matrix,
-            Self::Image(image) => image.rotation_matrix,
-            Self::Object(_) => Mat3x3::identity(), /* Object surfaces start aligned to the
-                                                     * global */
-            // frame
-            Self::Probe(probe) => probe.rotation_matrix,
-            Self::Stop(stop) => stop.rotation_matrix,
-            //Self::Toric(toric) => toric.rotation_matrix,
-        }
-    }
-
-    /// Returns the inverse rotation matrix of the surface into the global
-    /// coordinate system.
-    pub(crate) fn inv_rot_mat(&self) -> Mat3x3 {
-        match self {
-            Self::Conic(conic) => conic.inv_rotation_matrix,
-            Self::Image(image) => image.inv_rotation_matrix,
-            Self::Object(_) => Mat3x3::identity(), // Object surfaces start aligned to the global
-            Self::Probe(probe) => probe.inv_rotation_matrix,
-            Self::Stop(stop) => stop.inv_rotation_matrix,
-            //Self::Toric(toric) => toric.inv_rotation_matrix,
-        }
-    }
-
-    /// Returns the position of the surface in the global coordinate system.
-    pub(crate) fn pos(&self) -> Vec3 {
-        match self {
-            Self::Conic(conic) => conic.pos,
-            Self::Image(image) => image.pos,
-            Self::Object(object) => object.pos,
-            Self::Probe(probe) => probe.pos,
-            Self::Stop(stop) => stop.pos,
-            //Self::Toric(toric) => toric.pos,
-        }
-    }
-
-    /// Returns the surface sag and normal vector on the surface at a given
-    /// position.
-    ///
-    /// The position is given in the local coordinate system of the surface.
-    ///
-    /// The normal vector is not normalized. Its magnitude is important for
-    /// Newton-Raphson ray tracing calculations.
-    pub(crate) fn sag_norm(&self, pos: Vec3) -> (Float, Vec3) {
-        match self {
-            Self::Conic(conic) => conic.sag_norm(pos),
-            // Flat surfaces
-            Self::Image(_) | Self::Object(_) | Self::Probe(_) | Self::Stop(_) => {
-                (0.0, Vec3::new(0.0, 0.0, 1.0))
-            } //Self::Toric(_) => unimplemented!(),
-        }
-    }
-
-    pub(crate) fn semi_diameter(&self) -> Float {
-        match self {
-            Self::Conic(conic) => conic.semi_diameter,
-            //Self::Toric(toric) => toric.semi_diameter,
-            Self::Stop(stop) => stop.semi_diameter,
-            _ => Float::INFINITY,
-        }
-    }
-
-    /// Returns the semi-diameter of the surface as seen by a paraxial ray
-    /// traveling along the cursor axis in the tangential plane defined by `v`.
-    ///
-    /// `v` is a unit vector in the global frame that lies in the transverse
-    /// (R–U) plane and defines the meridional plane of interest (e.g.
-    /// `(1, 0, 0)` for the R/XZ plane, `(0, 1, 0)` for the U/YZ plane).
-    ///
-    /// For a tilted surface, the clear aperture radius `r` is in the surface's
-    /// local plane.  A paraxial ray at cursor height `h` intersects the surface
-    /// at a transverse distance larger than `h` by a foreshortening factor, so
-    /// the effective limit on cursor height is `r · |n_F| / sqrt(n_φ² + n_F²)`
-    /// where `(n_R, n_U, n_F)` are the surface-normal components in the cursor
-    /// frame and `n_φ = n_R · v_x + n_U · v_y` is the component along `v`.
-    pub(crate) fn projected_semi_diameter(&self, v: Vec3) -> Float {
-        let (r, rotation_matrix, rotation_matrix_global_to_cursor) = match self {
-            Self::Conic(c) => (
-                c.semi_diameter,
-                c.rotation_matrix,
-                c.rotation_matrix_global_to_cursor,
-            ),
-            Self::Stop(s) => (
-                s.semi_diameter,
-                s.rotation_matrix,
-                s.rotation_matrix_global_to_cursor,
-            ),
-            _ => return Float::INFINITY,
-        };
-
-        // R_surf = cursor_to_local = global_to_local · cursor_to_global
-        let r_surf = rotation_matrix * rotation_matrix_global_to_cursor.transpose();
-
-        // Third row of R_surf is the surface normal expressed in cursor frame: (n_R,
-        // n_U, n_F)
-        let n_r = r_surf.e[2][0];
-        let n_u = r_surf.e[2][1];
-        let n_f = r_surf.e[2][2];
-
-        // Component of the surface normal along the tangential direction v.
-        let n_phi = n_r * v.x() + n_u * v.y();
-        let denom = (n_phi * n_phi + n_f * n_f).sqrt();
-
-        if denom < 1e-12 {
-            return 0.0;
-        }
-
-        r * n_f.abs() / denom
-    }
-
-    pub(crate) fn surface_type(&self) -> SurfaceType {
-        match self {
-            Self::Conic(conic) => conic.surface_type,
-            //Self::Toric(toric) => toric.surface_type,
-            _ => SurfaceType::NoOp,
-        }
-    }
-}
-
-impl Display for Surface {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        match self {
-            Self::Conic(_) => write!(f, "Conic"),
-            Self::Image(_) => write!(f, "Image"),
-            Self::Object(_) => write!(f, "Object"),
-            Self::Probe(_) => write!(f, "Probe"),
-            Self::Stop(_) => write!(f, "Stop"),
-            //Self::Toric(toric) => write!(f, "Toric surface at z = {}", toric.pos.z()),
-        }
+/// Build a [`Surface`] trait object from a surface specification.
+pub(crate) fn surface_from_spec(spec: &SurfaceSpec) -> Box<dyn Surface> {
+    match spec {
+        SurfaceSpec::Conic {
+            semi_diameter,
+            radius_of_curvature,
+            conic_constant,
+            surf_type,
+            ..
+        } => Box::new(Conic::new(
+            *semi_diameter,
+            *radius_of_curvature,
+            *conic_constant,
+            *surf_type,
+        )),
+        SurfaceSpec::Image { .. } => Box::new(Image),
+        SurfaceSpec::Object => Box::new(Object),
+        SurfaceSpec::Probe { .. } => Box::new(Probe),
+        SurfaceSpec::Stop { semi_diameter, .. } => Box::new(Stop::new(*semi_diameter)),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{EulerAngles, Rotation3D, core::Float, n, specs::surfaces::SurfaceType};
+    use crate::{EulerAngles, Rotation3D, core::Float, n, specs::surfaces::BoundaryType};
 
-    // Helper: build a Conic surface with the given semi-diameter and rotation spec
-    // in an identity cursor frame.
-    fn conic_with_rotation(semi_diameter: Float, rotation: Rotation3D) -> Surface {
-        let rot_mat_g2c = Mat3x3::identity();
-        let rotation_matrix = rotation.rotation_matrix() * rot_mat_g2c;
-        let inv_rotation_matrix = rotation_matrix.transpose();
-        Surface::Conic(Conic {
-            pos: Vec3::new(0.0, 0.0, 0.0),
-            track: 0.0,
+    // Helper: build a Placement for a surface with the given rotation, in an
+    // identity cursor frame (cursor aligned with global axes, origin at (0,0,0)).
+    fn placement_with_rotation(rotation: Rotation3D) -> Placement {
+        let cursor_rotation_matrix = Mat3x3::identity();
+        let rotation_matrix = rotation.rotation_matrix() * cursor_rotation_matrix;
+        Placement::new(
+            Vec3::new(0.0, 0.0, 0.0),
+            0.0,
             rotation_matrix,
-            inv_rotation_matrix,
-            rotation_matrix_global_to_cursor: rot_mat_g2c,
-            semi_diameter,
-            radius_of_curvature: Float::INFINITY,
-            conic_constant: 0.0,
-            surface_type: SurfaceType::Refracting,
-        })
+            cursor_rotation_matrix,
+        )
     }
 
     #[test]
     fn projected_sd_untilted_surface() {
         let r = 10.0;
-        let surf = conic_with_rotation(r, Rotation3D::None);
+        let placement = placement_with_rotation(Rotation3D::None);
         let tol = 1e-12;
         let v_u = Vec3::new(0.0, 1.0, 0.0);
         let v_r = Vec3::new(1.0, 0.0, 0.0);
         assert!(
-            (surf.projected_semi_diameter(v_u) - r).abs() < tol,
+            (placement.projected_semi_diameter(r, v_u) - r).abs() < tol,
             "U axis: expected {r}, got {}",
-            surf.projected_semi_diameter(v_u)
+            placement.projected_semi_diameter(r, v_u)
         );
         assert!(
-            (surf.projected_semi_diameter(v_r) - r).abs() < tol,
+            (placement.projected_semi_diameter(r, v_r) - r).abs() < tol,
             "R axis: expected {r}, got {}",
-            surf.projected_semi_diameter(v_r)
+            placement.projected_semi_diameter(r, v_r)
         );
     }
 
@@ -958,23 +648,22 @@ mod tests {
         // 45° rotation about cursor-R; foreshortens only the U axis.
         let r = 10.0;
         let theta = 45.0_f64.to_radians();
-        let surf = conic_with_rotation(
-            r,
-            Rotation3D::IntrinsicPassiveRUF(EulerAngles(theta, 0.0, 0.0)),
-        );
+        let placement = placement_with_rotation(Rotation3D::IntrinsicPassiveRUF(EulerAngles(
+            theta, 0.0, 0.0,
+        )));
         let tol = 1e-10;
         let v_u = Vec3::new(0.0, 1.0, 0.0);
         let v_r = Vec3::new(1.0, 0.0, 0.0);
         assert!(
-            (surf.projected_semi_diameter(v_u) - r * theta.cos()).abs() < tol,
+            (placement.projected_semi_diameter(r, v_u) - r * theta.cos()).abs() < tol,
             "U axis: expected {}, got {}",
             r * theta.cos(),
-            surf.projected_semi_diameter(v_u)
+            placement.projected_semi_diameter(r, v_u)
         );
         assert!(
-            (surf.projected_semi_diameter(v_r) - r).abs() < tol,
+            (placement.projected_semi_diameter(r, v_r) - r).abs() < tol,
             "R axis: expected {r}, got {}",
-            surf.projected_semi_diameter(v_r)
+            placement.projected_semi_diameter(r, v_r)
         );
     }
 
@@ -983,23 +672,21 @@ mod tests {
         // 30° rotation about cursor-U; foreshortens only the R axis.
         let r = 10.0;
         let psi = 30.0_f64.to_radians();
-        let surf = conic_with_rotation(
-            r,
-            Rotation3D::IntrinsicPassiveRUF(EulerAngles(0.0, psi, 0.0)),
-        );
+        let placement =
+            placement_with_rotation(Rotation3D::IntrinsicPassiveRUF(EulerAngles(0.0, psi, 0.0)));
         let tol = 1e-10;
         let v_u = Vec3::new(0.0, 1.0, 0.0);
         let v_r = Vec3::new(1.0, 0.0, 0.0);
         assert!(
-            (surf.projected_semi_diameter(v_r) - r * psi.cos()).abs() < tol,
+            (placement.projected_semi_diameter(r, v_r) - r * psi.cos()).abs() < tol,
             "R axis: expected {}, got {}",
             r * psi.cos(),
-            surf.projected_semi_diameter(v_r)
+            placement.projected_semi_diameter(r, v_r)
         );
         assert!(
-            (surf.projected_semi_diameter(v_u) - r).abs() < tol,
+            (placement.projected_semi_diameter(r, v_u) - r).abs() < tol,
             "U axis: expected {r}, got {}",
-            surf.projected_semi_diameter(v_u)
+            placement.projected_semi_diameter(r, v_u)
         );
     }
 
@@ -1012,6 +699,7 @@ mod tests {
         let wavelengths = [0.5876];
         let model = mirrors_figure_z::sequential_model(air, &wavelengths);
         let surfaces = model.surfaces();
+        let placements = model.placements();
         let r = 12.7_f64;
         let expected_u = r * (30.0_f64.to_radians()).cos();
         let tol = 1e-10;
@@ -1020,16 +708,17 @@ mod tests {
 
         // Surface indices: 0 = Object, 1 = Mirror 1, 2 = Mirror 2, 3 = Image
         for &mirror_idx in &[1usize, 2usize] {
-            let surf = &surfaces[mirror_idx];
+            let sd = surfaces[mirror_idx].semi_diameter();
+            let placement = &placements[mirror_idx];
             assert!(
-                (surf.projected_semi_diameter(v_u) - expected_u).abs() < tol,
+                (placement.projected_semi_diameter(sd, v_u) - expected_u).abs() < tol,
                 "Mirror {mirror_idx} U: expected {expected_u}, got {}",
-                surf.projected_semi_diameter(v_u)
+                placement.projected_semi_diameter(sd, v_u)
             );
             assert!(
-                (surf.projected_semi_diameter(v_r) - r).abs() < tol,
+                (placement.projected_semi_diameter(sd, v_r) - r).abs() < tol,
                 "Mirror {mirror_idx} R: expected {r}, got {}",
-                surf.projected_semi_diameter(v_r)
+                placement.projected_semi_diameter(sd, v_r)
             );
         }
     }
@@ -1048,10 +737,9 @@ mod tests {
         use approx::assert_abs_diff_eq;
 
         let model = mirrors_figure_z::sequential_model(n!(1.0), &[0.5876]);
-        let surfaces = model.surfaces();
         let v_init = Vec3::new(0.0, 1.0, 0.0); // phi = 90°
 
-        let vecs = propagate_tangential_vec(v_init, surfaces);
+        let vecs = propagate_tangential_vec(v_init, model.surfaces(), model.placements());
 
         let sqrt3_over_2 = (3.0_f64 / 4.0_f64).sqrt();
 
@@ -1068,35 +756,13 @@ mod tests {
 
     #[test]
     fn is_rotationally_symmetric() {
-        let surfaces = vec![
-            Surface::Conic(Conic {
-                pos: Vec3::new(0.0, 0.0, 0.0),
-                track: 0.0,
-                rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                inv_rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                rotation_matrix_global_to_cursor: Mat3x3::new(
-                    1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
-                ),
-                semi_diameter: 1.0,
-                radius_of_curvature: 1.0,
-                conic_constant: 0.0,
-                surface_type: SurfaceType::Refracting,
-            }),
-            Surface::Conic(Conic {
-                pos: Vec3::new(0.0, 0.0, 0.0),
-                track: 0.0,
-                rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                inv_rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                rotation_matrix_global_to_cursor: Mat3x3::new(
-                    1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
-                ),
-                semi_diameter: 1.0,
-                radius_of_curvature: 1.0,
-                conic_constant: 0.0,
-                surface_type: SurfaceType::Refracting,
-            }),
+        // A system with identity rotations is rotationally symmetric.
+        let id = Mat3x3::identity();
+        let placements = vec![
+            Placement::new(Vec3::new(0.0, 0.0, 0.0), 0.0, id, id),
+            Placement::new(Vec3::new(0.0, 0.0, 0.0), 0.0, id, id),
         ];
-        assert!(SequentialModel::is_rotationally_symmetric(&surfaces));
+        assert!(SequentialModel::is_rotationally_symmetric(&placements));
 
         // A system with tilted surfaces is not rotationally symmetric.
         use crate::examples::mirrors_figure_z;
@@ -1104,55 +770,20 @@ mod tests {
         let wavelengths = [0.5876];
         let figure_z = mirrors_figure_z::sequential_model(air, &wavelengths);
         assert!(!SequentialModel::is_rotationally_symmetric(
-            figure_z.surfaces()
+            figure_z.placements()
         ));
     }
 
     #[test]
     fn test_first_physical_surface() {
-        let surfaces = vec![
-            Surface::Object(Object {
-                pos: Vec3::new(0.0, 0.0, 0.0),
-                track: 0.0,
-            }),
-            Surface::Probe(Probe {
-                pos: Vec3::new(0.0, 0.0, 0.0),
-                track: 0.0,
-                rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                inv_rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-            }),
-            Surface::Conic(Conic {
-                pos: Vec3::new(0.0, 0.0, 0.0),
-                track: 0.0,
-                rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                inv_rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                rotation_matrix_global_to_cursor: Mat3x3::new(
-                    1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
-                ),
-                semi_diameter: 1.0,
-                radius_of_curvature: 1.0,
-                conic_constant: 0.0,
-                surface_type: SurfaceType::Refracting,
-            }),
-            Surface::Conic(Conic {
-                pos: Vec3::new(0.0, 0.0, 0.0),
-                track: 0.0,
-                rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                inv_rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                rotation_matrix_global_to_cursor: Mat3x3::new(
-                    1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
-                ),
-                semi_diameter: 1.0,
-                radius_of_curvature: 1.0,
-                conic_constant: 0.0,
-                surface_type: SurfaceType::Refracting,
-            }),
-            Surface::Image(Image {
-                pos: Vec3::new(0.0, 0.0, 0.0),
-                track: 0.0,
-                rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                inv_rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-            }),
+        // Object(0), Probe(1), Conic(2), Conic(3), Image(4) — first physical is index
+        // 2.
+        let surfaces: Vec<Box<dyn Surface>> = vec![
+            Box::new(Object),
+            Box::new(Probe),
+            Box::new(Conic::new(1.0, 1.0, 0.0, BoundaryType::Refracting)),
+            Box::new(Conic::new(1.0, 1.0, 0.0, BoundaryType::Refracting)),
+            Box::new(Image),
         ];
 
         let result = first_physical_surface(&surfaces);
@@ -1161,49 +792,13 @@ mod tests {
 
     #[test]
     fn test_last_physical_surface() {
-        let surfaces = vec![
-            Surface::Object(Object {
-                pos: Vec3::new(0.0, 0.0, 0.0),
-                track: 0.0,
-            }),
-            Surface::Conic(Conic {
-                pos: Vec3::new(0.0, 0.0, 0.0),
-                track: 0.0,
-                rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                inv_rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                rotation_matrix_global_to_cursor: Mat3x3::new(
-                    1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
-                ),
-                semi_diameter: 1.0,
-                radius_of_curvature: 1.0,
-                conic_constant: 0.0,
-                surface_type: SurfaceType::Refracting,
-            }),
-            Surface::Conic(Conic {
-                pos: Vec3::new(0.0, 0.0, 0.0),
-                track: 0.0,
-                rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                inv_rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                rotation_matrix_global_to_cursor: Mat3x3::new(
-                    1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
-                ),
-                semi_diameter: 1.0,
-                radius_of_curvature: 1.0,
-                conic_constant: 0.0,
-                surface_type: SurfaceType::Refracting,
-            }),
-            Surface::Probe(Probe {
-                pos: Vec3::new(0.0, 0.0, 0.0),
-                track: 0.0,
-                rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                inv_rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-            }),
-            Surface::Image(Image {
-                pos: Vec3::new(0.0, 0.0, 0.0),
-                track: 0.0,
-                rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                inv_rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-            }),
+        // Object(0), Conic(1), Conic(2), Probe(3), Image(4) — last physical is index 2.
+        let surfaces: Vec<Box<dyn Surface>> = vec![
+            Box::new(Object),
+            Box::new(Conic::new(1.0, 1.0, 0.0, BoundaryType::Refracting)),
+            Box::new(Conic::new(1.0, 1.0, 0.0, BoundaryType::Refracting)),
+            Box::new(Probe),
+            Box::new(Image),
         ];
 
         let result = last_physical_surface(&surfaces);
@@ -1212,114 +807,33 @@ mod tests {
 
     #[test]
     fn test_reversed_surface_id() {
-        let surfaces = vec![
-            Surface::Object(Object {
-                pos: Vec3::new(0.0, 0.0, 0.0),
-                track: 0.0,
-            }),
-            Surface::Conic(Conic {
-                pos: Vec3::new(0.0, 0.0, 0.0),
-                track: 0.0,
-                rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                inv_rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                rotation_matrix_global_to_cursor: Mat3x3::new(
-                    1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
-                ),
-                semi_diameter: 1.0,
-                radius_of_curvature: 1.0,
-                conic_constant: 0.0,
-                surface_type: SurfaceType::Refracting,
-            }),
-            Surface::Conic(Conic {
-                pos: Vec3::new(0.0, 0.0, 0.0),
-                track: 0.0,
-                rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                inv_rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                rotation_matrix_global_to_cursor: Mat3x3::new(
-                    1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
-                ),
-                semi_diameter: 1.0,
-                radius_of_curvature: 1.0,
-                conic_constant: 0.0,
-                surface_type: SurfaceType::Refracting,
-            }),
-            Surface::Probe(Probe {
-                pos: Vec3::new(0.0, 0.0, 0.0),
-                track: 0.0,
-                rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                inv_rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-            }),
-            Surface::Image(Image {
-                pos: Vec3::new(0.0, 0.0, 0.0),
-                track: 0.0,
-                rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                inv_rotation_matrix: Mat3x3::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-            }),
-        ];
-
-        let result = reversed_surface_id(&surfaces, 2);
+        // 5-surface system (indices 0-4): reversed_surface_id(5, i) = 5 - i - 1 = 4 - i
+        let result = reversed_surface_id(5, 2);
         assert_eq!(result, 2);
 
-        let result = reversed_surface_id(&surfaces, 1);
+        let result = reversed_surface_id(5, 1);
         assert_eq!(result, 3);
     }
 
     #[test]
-    fn surface_is_infinite() {
+    fn placement_is_infinite() {
+        let id = Mat3x3::identity();
+
         // z-coordinate infinite
-        let surf = Surface::Conic(Conic {
-            pos: Vec3::new(0.0, 0.0, Float::INFINITY),
-            track: 0.0,
-            rotation_matrix: Mat3x3::identity(),
-            inv_rotation_matrix: Mat3x3::identity(),
-            rotation_matrix_global_to_cursor: Mat3x3::identity(),
-            semi_diameter: 1.0,
-            radius_of_curvature: 1.0,
-            conic_constant: 0.0,
-            surface_type: SurfaceType::Refracting,
-        });
-        assert!(surf.is_infinite());
+        let p = Placement::new(Vec3::new(0.0, 0.0, Float::INFINITY), 0.0, id, id);
+        assert!(p.is_infinite());
 
-        // x- or y-coordinate infinite
-        let surf = Surface::Conic(Conic {
-            pos: Vec3::new(0.0, Float::INFINITY, 0.0),
-            track: 0.0,
-            rotation_matrix: Mat3x3::identity(),
-            inv_rotation_matrix: Mat3x3::identity(),
-            rotation_matrix_global_to_cursor: Mat3x3::identity(),
-            semi_diameter: 1.0,
-            radius_of_curvature: 1.0,
-            conic_constant: 0.0,
-            surface_type: SurfaceType::Refracting,
-        });
-        assert!(surf.is_infinite());
+        // y-coordinate infinite
+        let p = Placement::new(Vec3::new(0.0, Float::INFINITY, 0.0), 0.0, id, id);
+        assert!(p.is_infinite());
 
-        let surf = Surface::Conic(Conic {
-            pos: Vec3::new(Float::INFINITY, 0.0, 0.0),
-            track: 0.0,
-            rotation_matrix: Mat3x3::identity(),
-            inv_rotation_matrix: Mat3x3::identity(),
-            rotation_matrix_global_to_cursor: Mat3x3::identity(),
-            semi_diameter: 1.0,
-            radius_of_curvature: 1.0,
-            conic_constant: 0.0,
-            surface_type: SurfaceType::Refracting,
-        });
-        assert!(surf.is_infinite());
+        // x-coordinate infinite
+        let p = Placement::new(Vec3::new(Float::INFINITY, 0.0, 0.0), 0.0, id, id);
+        assert!(p.is_infinite());
 
-        // Finite coordinates
-        let surf = Surface::Conic(Conic {
-            pos: Vec3::new(0.0, 0.0, 0.0),
-            track: 0.0,
-            rotation_matrix: Mat3x3::identity(),
-            inv_rotation_matrix: Mat3x3::identity(),
-            rotation_matrix_global_to_cursor: Mat3x3::identity(),
-            semi_diameter: 1.0,
-            radius_of_curvature: 1.0,
-            conic_constant: 0.0,
-            surface_type: SurfaceType::Refracting,
-        });
-        assert!(!surf.is_infinite());
+        // finite
+        let p = Placement::new(Vec3::new(0.0, 0.0, 0.0), 0.0, id, id);
+        assert!(!p.is_infinite());
     }
 
     #[test]
@@ -1329,16 +843,29 @@ mod tests {
         let nbk7 = n!(1.515);
         let wavelengths = [0.5876];
         let model = convexplano_lens::sequential_model(air, nbk7, &wavelengths);
-        let surfaces = model.surfaces();
-        for surf in surfaces {
-            if surf.z().is_finite() {
+        for placement in model.placements() {
+            if placement.position.z().is_finite() {
                 assert!(
-                    (surf.track() - surf.z()).abs() < 1e-10,
+                    (placement.track - placement.position.z()).abs() < 1e-10,
                     "Expected track == z for straight system, got track={}, z={}",
-                    surf.track(),
-                    surf.z()
+                    placement.track,
+                    placement.position.z()
                 );
             }
+        }
+    }
+
+    /// For a straight system, axis_direction should equal (0, 0, 1) everywhere.
+    #[test]
+    fn placement_axis_direction_straight_system() {
+        use crate::examples::convexplano_lens;
+        use approx::assert_abs_diff_eq;
+        let model = convexplano_lens::sequential_model(n!(1.0), n!(1.515), &[0.5876]);
+        for placement in model.placements() {
+            let axis = placement.axis_direction();
+            assert_abs_diff_eq!(axis.x(), 0.0, epsilon = 1e-12);
+            assert_abs_diff_eq!(axis.y(), 0.0, epsilon = 1e-12);
+            assert_abs_diff_eq!(axis.z(), 1.0, epsilon = 1e-12);
         }
     }
 }

--- a/crates/cherry-rs/src/core/surfaces/conic.rs
+++ b/crates/cherry-rs/src/core/surfaces/conic.rs
@@ -1,0 +1,174 @@
+use crate::{
+    core::{Float, math::vec3::Vec3},
+    specs::surfaces::BoundaryType,
+};
+
+use super::{Surface, SurfaceKind};
+
+/// A conic surface (sphere, paraboloid, hyperboloid, etc.).
+#[derive(Debug, Clone)]
+pub struct Conic {
+    pub semi_diameter: Float,
+    pub radius_of_curvature: Float,
+    pub conic_constant: Float,
+    pub boundary_type: BoundaryType,
+}
+
+impl Conic {
+    pub fn new(
+        semi_diameter: Float,
+        radius_of_curvature: Float,
+        conic_constant: Float,
+        boundary_type: BoundaryType,
+    ) -> Self {
+        Self {
+            semi_diameter,
+            radius_of_curvature,
+            conic_constant,
+            boundary_type,
+        }
+    }
+}
+
+impl Surface for Conic {
+    fn roc(&self, _azimuth_rad: Float) -> Float {
+        self.radius_of_curvature
+    }
+
+    fn sag_norm(&self, pos: Vec3) -> (Float, Vec3) {
+        if self.radius_of_curvature.is_infinite() {
+            return (0.0, Vec3::new(0.0, 0.0, 1.0));
+        }
+
+        // Convert to polar coordinates in the xy-plane
+        let r = (pos.x().powi(2) + pos.y().powi(2)).sqrt();
+        let theta = pos.y().atan2(pos.x());
+
+        // Compute surface sag using the standard conic equation
+        let a = r.powi(2) / self.radius_of_curvature;
+        let sag =
+            a / (1.0 + (1.0 - (1.0 + self.conic_constant) * a / self.radius_of_curvature).sqrt());
+
+        // Compute surface normal (not normalized — magnitude matters for
+        // Newton-Raphson)
+        let denom = (self.radius_of_curvature.powi(4)
+            - (1.0 + self.conic_constant) * (r * self.radius_of_curvature).powi(2))
+        .sqrt();
+        let dfdx = -r * self.radius_of_curvature * theta.cos() / denom;
+        let dfdy = -r * self.radius_of_curvature * theta.sin() / denom;
+        let dfdz = 1.0_f64 as Float;
+
+        (sag, Vec3::new(dfdx, dfdy, dfdz))
+    }
+
+    fn semi_diameter(&self) -> Float {
+        self.semi_diameter
+    }
+
+    fn boundary_type(&self) -> BoundaryType {
+        self.boundary_type
+    }
+
+    fn surface_kind(&self) -> SurfaceKind {
+        SurfaceKind::Conic
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_abs_diff_eq;
+
+    fn sphere(roc: Float, semi_diameter: Float) -> Conic {
+        Conic::new(semi_diameter, roc, 0.0, BoundaryType::Refracting)
+    }
+
+    #[test]
+    fn flat_surface_sag_is_zero() {
+        let conic = Conic::new(10.0, Float::INFINITY, 0.0, BoundaryType::Refracting);
+        let (sag, norm) = conic.sag_norm(Vec3::new(3.0, 4.0, 0.0));
+        assert_eq!(sag, 0.0);
+        assert_abs_diff_eq!(norm.x(), 0.0);
+        assert_abs_diff_eq!(norm.y(), 0.0);
+        assert_abs_diff_eq!(norm.z(), 1.0);
+    }
+
+    #[test]
+    fn flat_surface_at_origin_sag_is_zero() {
+        let conic = Conic::new(10.0, Float::INFINITY, 0.0, BoundaryType::Refracting);
+        let (sag, norm) = conic.sag_norm(Vec3::new(0.0, 0.0, 0.0));
+        assert_eq!(sag, 0.0);
+        assert_abs_diff_eq!(norm.z(), 1.0);
+    }
+
+    #[test]
+    fn sphere_sag_at_vertex_is_zero() {
+        let conic = sphere(100.0, 10.0);
+        let (sag, _) = conic.sag_norm(Vec3::new(0.0, 0.0, 0.0));
+        assert_abs_diff_eq!(sag, 0.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn sphere_sag_matches_analytic_formula() {
+        // For a sphere: sag = R - sqrt(R² - r²)
+        let roc = 50.0;
+        let conic = sphere(roc, 10.0);
+        let r = 5.0;
+        let (sag, _) = conic.sag_norm(Vec3::new(r, 0.0, 0.0));
+        let expected_sag = roc - (roc * roc - r * r).sqrt();
+        assert_abs_diff_eq!(sag, expected_sag, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn sphere_sag_is_symmetric_in_xy() {
+        let conic = sphere(50.0, 15.0);
+        let r = 5.0;
+        let (sag_x, _) = conic.sag_norm(Vec3::new(r, 0.0, 0.0));
+        let (sag_y, _) = conic.sag_norm(Vec3::new(0.0, r, 0.0));
+        assert_abs_diff_eq!(sag_x, sag_y, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn sphere_normal_at_vertex_points_along_z() {
+        let conic = sphere(50.0, 10.0);
+        let (_, norm) = conic.sag_norm(Vec3::new(0.001, 0.0, 0.0));
+        // Near the vertex the normal should be nearly (0, 0, 1)
+        assert_abs_diff_eq!(norm.x() / norm.z(), 0.0, epsilon = 1e-3);
+        assert_abs_diff_eq!(norm.y() / norm.z(), 0.0, epsilon = 1e-3);
+    }
+
+    #[test]
+    fn roc_returns_configured_value() {
+        let conic = Conic::new(10.0, 77.3, 0.0, BoundaryType::Refracting);
+        assert_abs_diff_eq!(conic.roc(0.0), 77.3);
+        // Circularly symmetric — azimuth does not change roc
+        assert_abs_diff_eq!(conic.roc(1.23), 77.3);
+    }
+
+    #[test]
+    fn roc_flat_returns_infinity() {
+        let conic = Conic::new(10.0, Float::INFINITY, 0.0, BoundaryType::Refracting);
+        assert!(conic.roc(0.0).is_infinite());
+    }
+
+    #[test]
+    fn semi_diameter_round_trips() {
+        let conic = Conic::new(12.5, 50.0, 0.0, BoundaryType::Refracting);
+        assert_abs_diff_eq!(conic.semi_diameter(), 12.5);
+    }
+
+    #[test]
+    fn boundary_type_round_trips() {
+        let r = Conic::new(5.0, 30.0, 0.0, BoundaryType::Refracting);
+        let m = Conic::new(5.0, 30.0, 0.0, BoundaryType::Reflecting);
+        assert!(matches!(r.boundary_type(), BoundaryType::Refracting));
+        assert!(matches!(m.boundary_type(), BoundaryType::Reflecting));
+    }
+
+    #[test]
+    fn outside_clear_aperture_default_impl() {
+        let conic = Conic::new(10.0, Float::INFINITY, 0.0, BoundaryType::Refracting);
+        assert!(!conic.outside_clear_aperture(Vec3::new(5.0, 0.0, 0.0)));
+        assert!(conic.outside_clear_aperture(Vec3::new(11.0, 0.0, 0.0)));
+    }
+}

--- a/crates/cherry-rs/src/core/surfaces/image.rs
+++ b/crates/cherry-rs/src/core/surfaces/image.rs
@@ -1,0 +1,28 @@
+use crate::{
+    core::{Float, math::vec3::Vec3},
+    specs::surfaces::BoundaryType,
+};
+
+use super::{Surface, SurfaceKind};
+
+/// The image plane — a flat surface with no optical effect on rays.
+#[derive(Debug, Clone)]
+pub struct Image;
+
+impl Surface for Image {
+    fn sag_norm(&self, _pos: Vec3) -> (Float, Vec3) {
+        (0.0, Vec3::new(0.0, 0.0, 1.0))
+    }
+
+    fn semi_diameter(&self) -> Float {
+        Float::INFINITY
+    }
+
+    fn boundary_type(&self) -> BoundaryType {
+        BoundaryType::NoOp
+    }
+
+    fn surface_kind(&self) -> SurfaceKind {
+        SurfaceKind::Image
+    }
+}

--- a/crates/cherry-rs/src/core/surfaces/mod.rs
+++ b/crates/cherry-rs/src/core/surfaces/mod.rs
@@ -1,0 +1,97 @@
+/// Surface logic and traits used by sequential models.
+use crate::core::{Float, math::vec3::Vec3};
+
+use crate::specs::surfaces::BoundaryType;
+
+pub mod conic;
+pub mod image;
+pub mod object;
+pub mod probe;
+pub mod stop;
+
+pub use conic::Conic;
+pub use image::Image;
+pub use object::Object;
+pub use probe::Probe;
+pub use stop::Stop;
+
+/// The role of a surface in the optical system.
+///
+/// Used by rendering and analysis code to distinguish surface roles that cannot
+/// be inferred from geometry alone (e.g., Image vs. Probe vs. Object — all flat
+/// with the same `boundary_type()`).
+///
+/// Library-provided surfaces return their specific kind. User-defined surfaces
+/// should return [`SurfaceKind::Custom`] (the default).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SurfaceKind {
+    Conic,
+    Image,
+    Object,
+    Probe,
+    Stop,
+    Custom,
+}
+
+/// A surface is the primary unit of abstraction in sequential optical models.
+/// It is a boundary between two media and can be used to model lenses, mirrors,
+/// and other optical elements.
+///
+/// Surfaces are defined by their geometry, most notably their sag and normal
+/// vector. By convention, the vertex of a curved surface lies at the origin of
+/// its local coordinate system. A flat surface lies in the local xy-plane.
+pub trait Surface: std::fmt::Debug + Send + Sync {
+    /// Returns the boundary type (refracting, reflecting, etc.).
+    fn boundary_type(&self) -> BoundaryType;
+
+    /// Determines whether a transverse point is outside the clear aperture of
+    /// the surface.
+    ///
+    /// The axial z-position is ignored.
+    fn outside_clear_aperture(&self, pos: Vec3) -> bool {
+        let r_transv = pos.x() * pos.x() + pos.y() * pos.y();
+        let r_max = self.semi_diameter();
+        r_transv > r_max * r_max
+    }
+
+    /// Returns the radius of curvature of the base sphere of the surface.
+    ///
+    /// `azimuth_rad` is the angle in the surface's **local** xy-plane,
+    /// measured from the local x-axis. Callers can obtain this angle by
+    /// transforming a global-frame direction `v` via `Placement::rot_mat` and
+    /// then computing `local_v.y().atan2(local_v.x())`.
+    ///
+    /// For circularly symmetric surfaces the argument is ignored and a single
+    /// constant is returned. For non-circularly-symmetric surfaces such as
+    /// cylinders and torics the curvature varies with azimuth.
+    ///
+    /// Flat surfaces should return [`Float::INFINITY`], which is
+    /// the physically correct value and the default implementation.
+    fn roc(&self, _azimuth_rad: Float) -> Float {
+        Float::INFINITY
+    }
+
+    /// Returns the surface sag and normal vector at a given position.
+    ///
+    /// The position is given in the surface's local coordinate system.
+    /// Use [`crate::core::placement::Placement`] to transform a global-frame
+    /// position into local coordinates before calling this method.
+    ///
+    /// The normal vector is not normalized. Its magnitude is important for
+    /// Newton-Raphson ray tracing calculations.
+    fn sag_norm(&self, pos: Vec3) -> (Float, Vec3);
+
+    /// Returns the semi-diameter of the surface's clear aperture.
+    fn semi_diameter(&self) -> Float;
+
+    /// Returns the role of this surface in the optical system.
+    ///
+    /// Used by rendering and analysis code to distinguish Object, Image, Probe,
+    /// Conic, and Stop surfaces, which cannot all be differentiated from
+    /// `boundary_type()` and `semi_diameter()` alone.
+    ///
+    /// User-defined surfaces should return [`SurfaceKind::Custom`].
+    fn surface_kind(&self) -> SurfaceKind {
+        SurfaceKind::Custom
+    }
+}

--- a/crates/cherry-rs/src/core/surfaces/object.rs
+++ b/crates/cherry-rs/src/core/surfaces/object.rs
@@ -1,0 +1,28 @@
+use crate::{
+    core::{Float, math::vec3::Vec3},
+    specs::surfaces::BoundaryType,
+};
+
+use super::{Surface, SurfaceKind};
+
+/// The object plane — a flat surface with no optical effect on rays.
+#[derive(Debug, Clone)]
+pub struct Object;
+
+impl Surface for Object {
+    fn sag_norm(&self, _pos: Vec3) -> (Float, Vec3) {
+        (0.0, Vec3::new(0.0, 0.0, 1.0))
+    }
+
+    fn semi_diameter(&self) -> Float {
+        Float::INFINITY
+    }
+
+    fn boundary_type(&self) -> BoundaryType {
+        BoundaryType::NoOp
+    }
+
+    fn surface_kind(&self) -> SurfaceKind {
+        SurfaceKind::Object
+    }
+}

--- a/crates/cherry-rs/src/core/surfaces/probe.rs
+++ b/crates/cherry-rs/src/core/surfaces/probe.rs
@@ -1,0 +1,28 @@
+use crate::{
+    core::{Float, math::vec3::Vec3},
+    specs::surfaces::BoundaryType,
+};
+
+use super::{Surface, SurfaceKind};
+
+/// A probe surface — a flat, non-optical surface used to measure ray positions.
+#[derive(Debug, Clone)]
+pub struct Probe;
+
+impl Surface for Probe {
+    fn sag_norm(&self, _pos: Vec3) -> (Float, Vec3) {
+        (0.0, Vec3::new(0.0, 0.0, 1.0))
+    }
+
+    fn semi_diameter(&self) -> Float {
+        Float::INFINITY
+    }
+
+    fn boundary_type(&self) -> BoundaryType {
+        BoundaryType::NoOp
+    }
+
+    fn surface_kind(&self) -> SurfaceKind {
+        SurfaceKind::Probe
+    }
+}

--- a/crates/cherry-rs/src/core/surfaces/stop.rs
+++ b/crates/cherry-rs/src/core/surfaces/stop.rs
@@ -1,0 +1,83 @@
+use crate::{
+    core::{Float, math::vec3::Vec3},
+    specs::surfaces::BoundaryType,
+};
+
+use super::{Surface, SurfaceKind};
+
+/// An aperture stop — a flat surface that limits the beam.
+#[derive(Debug, Clone)]
+pub struct Stop {
+    pub semi_diameter: Float,
+}
+
+impl Stop {
+    pub fn new(semi_diameter: Float) -> Self {
+        Self { semi_diameter }
+    }
+}
+
+impl Surface for Stop {
+    fn sag_norm(&self, _pos: Vec3) -> (Float, Vec3) {
+        (0.0, Vec3::new(0.0, 0.0, 1.0))
+    }
+
+    fn semi_diameter(&self) -> Float {
+        self.semi_diameter
+    }
+
+    fn boundary_type(&self) -> BoundaryType {
+        BoundaryType::NoOp
+    }
+
+    fn surface_kind(&self) -> SurfaceKind {
+        SurfaceKind::Stop
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_abs_diff_eq;
+
+    #[test]
+    fn sag_norm_is_always_flat() {
+        let stop = Stop::new(5.0);
+        for pos in [
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(3.0, 4.0, 0.0),
+            Vec3::new(-1.0, 2.5, 0.0),
+        ] {
+            let (sag, norm) = stop.sag_norm(pos);
+            assert_abs_diff_eq!(sag, 0.0);
+            assert_abs_diff_eq!(norm.x(), 0.0);
+            assert_abs_diff_eq!(norm.y(), 0.0);
+            assert_abs_diff_eq!(norm.z(), 1.0);
+        }
+    }
+
+    #[test]
+    fn semi_diameter_round_trips() {
+        let stop = Stop::new(7.5);
+        assert_abs_diff_eq!(stop.semi_diameter(), 7.5);
+    }
+
+    #[test]
+    fn boundary_type_is_noop() {
+        let stop = Stop::new(5.0);
+        assert!(matches!(stop.boundary_type(), BoundaryType::NoOp));
+    }
+
+    #[test]
+    fn roc_default_is_infinity() {
+        let stop = Stop::new(5.0);
+        assert!(stop.roc(0.0).is_infinite());
+    }
+
+    #[test]
+    fn outside_clear_aperture_default_impl() {
+        let stop = Stop::new(5.0);
+        assert!(!stop.outside_clear_aperture(Vec3::new(4.9, 0.0, 0.0)));
+        assert!(stop.outside_clear_aperture(Vec3::new(5.1, 0.0, 0.0)));
+    }
+}

--- a/crates/cherry-rs/src/examples/biconvex_lens_finite_object.rs
+++ b/crates/cherry-rs/src/examples/biconvex_lens_finite_object.rs
@@ -3,7 +3,7 @@
 //! Thorlabs Part No.: LB1676-A
 use std::rc::Rc;
 
-use crate::{GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel, SurfaceSpec, SurfaceType};
+use crate::{BoundaryType, GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel, SurfaceSpec};
 
 pub fn sequential_model(
     n_air: Rc<dyn RefractiveIndexSpec>,
@@ -29,14 +29,14 @@ pub fn sequential_model(
         semi_diameter: 12.7,
         radius_of_curvature: 102.4,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Refracting,
+        surf_type: BoundaryType::Refracting,
         rotation: Rotation3D::None,
     };
     let surf_2 = SurfaceSpec::Conic {
         semi_diameter: 12.7,
         radius_of_curvature: -102.4,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Refracting,
+        surf_type: BoundaryType::Refracting,
         rotation: Rotation3D::None,
     };
     let surf_3 = SurfaceSpec::Image {

--- a/crates/cherry-rs/src/examples/concave_mirror.rs
+++ b/crates/cherry-rs/src/examples/concave_mirror.rs
@@ -1,7 +1,7 @@
 //! A f=+100 mm concave mirror with infinite field points.
 use std::rc::Rc;
 
-use crate::{GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel, SurfaceSpec, SurfaceType};
+use crate::{BoundaryType, GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel, SurfaceSpec};
 
 pub fn sequential_model(
     n_air: Rc<dyn RefractiveIndexSpec>,
@@ -22,7 +22,7 @@ pub fn sequential_model(
         semi_diameter: 12.5,
         radius_of_curvature: -200.0,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Reflecting,
+        surf_type: BoundaryType::Reflecting,
         rotation: Rotation3D::None,
     };
     let surf_2 = SurfaceSpec::Image {

--- a/crates/cherry-rs/src/examples/convexplano_lens.rs
+++ b/crates/cherry-rs/src/examples/convexplano_lens.rs
@@ -1,7 +1,7 @@
 //! A f = 50 mm convexplano lens.
 use std::rc::Rc;
 
-use crate::{GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel, SurfaceSpec, SurfaceType};
+use crate::{BoundaryType, GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel, SurfaceSpec};
 
 pub fn sequential_model(
     n_air: Rc<dyn RefractiveIndexSpec>,
@@ -27,14 +27,14 @@ pub fn sequential_model(
         semi_diameter: 12.5,
         radius_of_curvature: 25.8,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Refracting,
+        surf_type: BoundaryType::Refracting,
         rotation: Rotation3D::None,
     };
     let surf_2 = SurfaceSpec::Conic {
         semi_diameter: 12.5,
         radius_of_curvature: f64::INFINITY,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Refracting,
+        surf_type: BoundaryType::Refracting,
         rotation: Rotation3D::None,
     };
     let surf_3 = SurfaceSpec::Image {

--- a/crates/cherry-rs/src/examples/f_theta_scan_lens.rs
+++ b/crates/cherry-rs/src/examples/f_theta_scan_lens.rs
@@ -9,7 +9,7 @@
 use std::rc::Rc;
 
 use crate::{
-    FieldSpec, GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel, SurfaceSpec, SurfaceType,
+    BoundaryType, FieldSpec, GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel, SurfaceSpec,
 };
 
 pub fn sequential_model(
@@ -60,42 +60,42 @@ pub fn sequential_model(
         semi_diameter: 2.0,
         radius_of_curvature: -2.2136,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Refracting,
+        surf_type: BoundaryType::Refracting,
         rotation: Rotation3D::None,
     };
     let surf_3 = SurfaceSpec::Conic {
         semi_diameter: 2.0,
         radius_of_curvature: -2.6575,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Refracting,
+        surf_type: BoundaryType::Refracting,
         rotation: Rotation3D::None,
     };
     let surf_4 = SurfaceSpec::Conic {
         semi_diameter: 2.0,
         radius_of_curvature: -5.5022,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Refracting,
+        surf_type: BoundaryType::Refracting,
         rotation: Rotation3D::None,
     };
     let surf_5 = SurfaceSpec::Conic {
         semi_diameter: 2.0,
         radius_of_curvature: -3.8129,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Refracting,
+        surf_type: BoundaryType::Refracting,
         rotation: Rotation3D::None,
     };
     let surf_6 = SurfaceSpec::Conic {
         semi_diameter: 3.0,
         radius_of_curvature: 7.9951,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Refracting,
+        surf_type: BoundaryType::Refracting,
         rotation: Rotation3D::None,
     };
     let surf_7 = SurfaceSpec::Conic {
         semi_diameter: 3.0,
         radius_of_curvature: 8.3651,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Refracting,
+        surf_type: BoundaryType::Refracting,
         rotation: Rotation3D::None,
     };
     let surf_8 = SurfaceSpec::Image {

--- a/crates/cherry-rs/src/examples/mirrors_figure_z.rs
+++ b/crates/cherry-rs/src/examples/mirrors_figure_z.rs
@@ -5,8 +5,8 @@
 use std::rc::Rc;
 
 use crate::{
-    EulerAngles, GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel, SurfaceSpec,
-    SurfaceType, core::Float,
+    BoundaryType, EulerAngles, GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel,
+    SurfaceSpec, core::Float,
 };
 
 pub fn sequential_model(
@@ -32,7 +32,7 @@ pub fn sequential_model(
         semi_diameter: 12.7,
         radius_of_curvature: Float::INFINITY,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Reflecting,
+        surf_type: BoundaryType::Reflecting,
         rotation: Rotation3D::IntrinsicPassiveRUF(EulerAngles(
             (30 as Float).to_radians(),
             0.0,
@@ -43,7 +43,7 @@ pub fn sequential_model(
         semi_diameter: 12.7,
         radius_of_curvature: f64::INFINITY,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Reflecting,
+        surf_type: BoundaryType::Reflecting,
         rotation: Rotation3D::IntrinsicPassiveRUF(EulerAngles(
             (30 as Float).to_radians(),
             0.0,

--- a/crates/cherry-rs/src/examples/petzval_lens.rs
+++ b/crates/cherry-rs/src/examples/petzval_lens.rs
@@ -1,4 +1,4 @@
-use crate::{FieldSpec, GapSpec, Rotation3D, SequentialModel, SurfaceSpec, SurfaceType, n};
+use crate::{BoundaryType, FieldSpec, GapSpec, Rotation3D, SequentialModel, SurfaceSpec, n};
 
 pub fn sequential_model() -> SequentialModel {
     let air = n!(1.0);
@@ -52,21 +52,21 @@ pub fn sequential_model() -> SequentialModel {
         semi_diameter: 28.478,
         radius_of_curvature: 99.56266,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Refracting,
+        surf_type: BoundaryType::Refracting,
         rotation: Rotation3D::None,
     };
     let surf_2 = SurfaceSpec::Conic {
         semi_diameter: 26.276,
         radius_of_curvature: -86.84002,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Refracting,
+        surf_type: BoundaryType::Refracting,
         rotation: Rotation3D::None,
     };
     let surf_3 = SurfaceSpec::Conic {
         semi_diameter: 21.02,
         radius_of_curvature: -1187.63858,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Refracting,
+        surf_type: BoundaryType::Refracting,
         rotation: Rotation3D::None,
     };
     let surf_4 = SurfaceSpec::Stop {
@@ -77,35 +77,35 @@ pub fn sequential_model() -> SequentialModel {
         semi_diameter: 20.543,
         radius_of_curvature: 57.47491,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Refracting,
+        surf_type: BoundaryType::Refracting,
         rotation: Rotation3D::None,
     };
     let surf_6 = SurfaceSpec::Conic {
         semi_diameter: 20.074,
         radius_of_curvature: -54.61685,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Refracting,
+        surf_type: BoundaryType::Refracting,
         rotation: Rotation3D::None,
     };
     let surf_7 = SurfaceSpec::Conic {
         semi_diameter: 20.074,
         radius_of_curvature: -614.68633,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Refracting,
+        surf_type: BoundaryType::Refracting,
         rotation: Rotation3D::None,
     };
     let surf_8 = SurfaceSpec::Conic {
         semi_diameter: 17.297,
         radius_of_curvature: -38.17110,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Refracting,
+        surf_type: BoundaryType::Refracting,
         rotation: Rotation3D::None,
     };
     let surf_9 = SurfaceSpec::Conic {
         semi_diameter: 18.94,
         radius_of_curvature: f64::INFINITY,
         conic_constant: 0.0,
-        surf_type: SurfaceType::Refracting,
+        surf_type: BoundaryType::Refracting,
         rotation: Rotation3D::None,
     };
     let surf_10 = SurfaceSpec::Image {

--- a/crates/cherry-rs/src/gui/compute.rs
+++ b/crates/cherry-rs/src/gui/compute.rs
@@ -196,23 +196,25 @@ fn run_compute(
 }
 
 fn build_surface_descs(seq: &SequentialModel) -> Vec<SurfaceDesc> {
-    use crate::core::sequential_model::Surface;
+    use crate::SurfaceKind;
     seq.surfaces()
         .iter()
+        .zip(seq.placements().iter())
         .enumerate()
-        .map(|(i, s)| {
-            let name = match s {
-                Surface::Conic(_) => "Conic",
-                Surface::Image(_) => "Image",
-                Surface::Object(_) => "Object",
-                Surface::Probe(_) => "Probe",
-                Surface::Stop(_) => "Stop",
+        .map(|(i, (s, p))| {
+            let name = match s.surface_kind() {
+                SurfaceKind::Conic => "Conic",
+                SurfaceKind::Image => "Image",
+                SurfaceKind::Object => "Object",
+                SurfaceKind::Probe => "Probe",
+                SurfaceKind::Stop => "Stop",
+                SurfaceKind::Custom => "Custom",
             };
             SurfaceDesc {
                 index: i,
                 label: format!("{name} [{i}]"),
-                pos: s.pos(),
-                rot_mat: s.rot_mat(),
+                pos: p.position,
+                rot_mat: p.rotation_matrix,
             }
         })
         .collect()

--- a/crates/cherry-rs/src/gui/convert.rs
+++ b/crates/cherry-rs/src/gui/convert.rs
@@ -3,8 +3,8 @@ use std::rc::Rc;
 use anyhow::{Context, Result, bail};
 
 use crate::{
-    ApertureSpec, ConstantRefractiveIndex, EulerAngles, FieldSpec, GapSpec, RefractiveIndexSpec,
-    Rotation3D, SurfaceSpec, SurfaceType,
+    ApertureSpec, BoundaryType, ConstantRefractiveIndex, EulerAngles, FieldSpec, GapSpec,
+    RefractiveIndexSpec, Rotation3D, SurfaceSpec,
 };
 
 use super::model::{FieldMode, SurfaceKind, SurfaceVariant, SystemSpecs};
@@ -74,10 +74,10 @@ fn convert_specs_inner(
                 let conic = parse_float(&row.conic_constant)
                     .with_context(|| format!("surface {i}: conic constant"))?;
                 let surf_type = match row.surface_kind {
-                    SurfaceKind::Refracting => SurfaceType::Refracting,
-                    SurfaceKind::Reflecting => SurfaceType::Reflecting,
+                    SurfaceKind::Refracting => BoundaryType::Refracting,
+                    SurfaceKind::Reflecting => BoundaryType::Reflecting,
                 };
-                let rotation = if matches!(surf_type, SurfaceType::Reflecting) {
+                let rotation = if matches!(surf_type, BoundaryType::Reflecting) {
                     let theta_deg =
                         parse_float(&row.theta).with_context(|| format!("surface {i}: theta"))?;
                     let psi_deg =

--- a/crates/cherry-rs/src/gui/windows/ray_fan.rs
+++ b/crates/cherry-rs/src/gui/windows/ray_fan.rs
@@ -520,24 +520,26 @@ mod tests {
         let wls = seq.wavelengths().to_vec();
 
         // Build surface descs manually (mirrors compute.rs logic).
-        use crate::{core::sequential_model::Surface, gui::result_package::SurfaceDesc};
+        use crate::{SurfaceKind, gui::result_package::SurfaceDesc};
         let surfaces: Vec<SurfaceDesc> = seq
             .surfaces()
             .iter()
+            .zip(seq.placements().iter())
             .enumerate()
-            .map(|(i, s)| {
-                let name = match s {
-                    Surface::Conic(_) => "Conic",
-                    Surface::Image(_) => "Image",
-                    Surface::Object(_) => "Object",
-                    Surface::Probe(_) => "Probe",
-                    Surface::Stop(_) => "Stop",
+            .map(|(i, (s, p))| {
+                let name = match s.surface_kind() {
+                    SurfaceKind::Conic => "Conic",
+                    SurfaceKind::Image => "Image",
+                    SurfaceKind::Object => "Object",
+                    SurfaceKind::Probe => "Probe",
+                    SurfaceKind::Stop => "Stop",
+                    SurfaceKind::Custom => "Custom",
                 };
                 SurfaceDesc {
                     index: i,
                     label: format!("{name} [{i}]"),
-                    pos: s.pos(),
-                    rot_mat: s.rot_mat(),
+                    pos: p.position,
+                    rot_mat: p.rotation_matrix,
                 }
             })
             .collect();

--- a/crates/cherry-rs/src/gui/windows/spot_diagram.rs
+++ b/crates/cherry-rs/src/gui/windows/spot_diagram.rs
@@ -454,12 +454,13 @@ mod tests {
             surfaces: seq
                 .surfaces()
                 .iter()
+                .zip(seq.placements().iter())
                 .enumerate()
-                .map(|(i, s)| crate::gui::result_package::SurfaceDesc {
+                .map(|(i, (_s, p))| crate::gui::result_package::SurfaceDesc {
                     index: i,
                     label: format!("S{i}"),
-                    pos: s.pos(),
-                    rot_mat: s.rot_mat(),
+                    pos: p.position,
+                    rot_mat: p.rotation_matrix,
                 })
                 .collect(),
             fields: vec![

--- a/crates/cherry-rs/src/lib.rs
+++ b/crates/cherry-rs/src/lib.rs
@@ -39,7 +39,7 @@
 //! use cherry_rs::{
 //!     n, ray_trace_3d_view, trace_ray_bundle, ApertureSpec, FieldSpec, GapSpec, ImagePlane,
 //!     ParaxialView, Pupil, SamplingConfig, RefractiveIndexSpec, Rotation3D,
-//!     SequentialModel, SurfaceSpec, SurfaceType,
+//!     SequentialModel, SurfaceSpec, BoundaryType,
 //! };
 //!
 //! // Create a convexplano lens with an object at infinity.
@@ -69,14 +69,14 @@
 //!         semi_diameter: 12.5,
 //!         radius_of_curvature: 25.8,
 //!         conic_constant: 0.0,
-//!         surf_type: SurfaceType::Refracting,
+//!         surf_type: BoundaryType::Refracting,
 //!         rotation: Rotation3D::None,
 //!     },
 //!     SurfaceSpec::Conic {
 //!         semi_diameter: 12.5,
 //!         radius_of_curvature: f64::INFINITY,
 //!         conic_constant: 0.0,
-//!         surf_type: SurfaceType::Refracting,
+//!         surf_type: BoundaryType::Refracting,
 //!         rotation: Rotation3D::None,
 //!     },
 //!     SurfaceSpec::Image { rotation: Rotation3D::None },
@@ -137,14 +137,16 @@ pub mod examples;
 pub use core::{
     math::linalg::rotations::{EulerAngles, Rotation3D},
     math::vec3::Vec3,
+    placement::Placement,
     sequential_model::{SequentialModel, SequentialSubModel, Step},
+    surfaces::{Conic, Image, Object, Probe, Stop, Surface, SurfaceKind},
 };
 pub use specs::{
     aperture::ApertureSpec,
     fields::{FieldSpec, PupilSampling},
     gaps::{ConstantRefractiveIndex, GapSpec, RefractiveIndexSpec},
+    surfaces::BoundaryType,
     surfaces::SurfaceSpec,
-    surfaces::SurfaceType,
 };
 pub use views::{
     components::{Component, components_view},

--- a/crates/cherry-rs/src/specs/surfaces.rs
+++ b/crates/cherry-rs/src/specs/surfaces.rs
@@ -4,7 +4,7 @@ use crate::core::{Float, math::linalg::rotations::Rotation3D};
 
 /// Specifies the type of interaction of light with a sequential model surface.
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
-pub enum SurfaceType {
+pub enum BoundaryType {
     Refracting,
     Reflecting,
     NoOp,
@@ -20,7 +20,7 @@ pub enum SurfaceSpec {
         semi_diameter: Float,
         radius_of_curvature: Float,
         conic_constant: Float,
-        surf_type: SurfaceType,
+        surf_type: BoundaryType,
         rotation: Rotation3D,
     },
     Image {
@@ -39,6 +39,6 @@ pub enum SurfaceSpec {
     //     radius_of_curvature_vert: Float,
     //     radius_of_curvature_horz: Float,
     //     conic_constant: Float,
-    //     surf_type: SurfaceType,
+    //     surf_type: BoundaryType,
     // },
 }

--- a/crates/cherry-rs/src/views/components/mod.rs
+++ b/crates/cherry-rs/src/views/components/mod.rs
@@ -5,8 +5,8 @@ use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    RefractiveIndexSpec, SequentialModel, SequentialSubModel, SurfaceType,
-    core::{Float, refractive_index::RefractiveIndex, sequential_model::Surface},
+    BoundaryType, RefractiveIndexSpec, SequentialModel, SequentialSubModel, SurfaceKind,
+    core::{Float, refractive_index::RefractiveIndex},
 };
 
 const TOL: Float = 1e-6;
@@ -79,28 +79,28 @@ pub fn components_view(
         }
 
         // Detect reflecting surfaces explicitly by type — before any gap-based logic.
-        if matches!(surf_pair.0.surface_type(), SurfaceType::Reflecting) {
+        if matches!(surf_pair.0.boundary_type(), BoundaryType::Reflecting) {
             components.insert(Component::Mirror { surf_idx: i });
             continue;
         }
 
-        if let Surface::Probe(_) = surf_pair.0 {
+        if surf_pair.0.surface_kind() == SurfaceKind::Probe {
             // Probe surfaces are observation planes, not optical components.
             continue;
         }
 
-        if let Surface::Stop(_) = surf_pair.0 {
+        if surf_pair.0.surface_kind() == SurfaceKind::Stop {
             // Stops are special, so be sure that they're added before anything else.
             components.insert(Component::Stop { stop_idx: i });
             continue;
         }
 
-        if let Surface::Stop(_) = surf_pair.1 {
+        if surf_pair.1.surface_kind() == SurfaceKind::Stop {
             // Ensure that stops following surfaces are NOT added as a component
             continue;
         }
 
-        if let Surface::Image(_) = surf_pair.1 {
+        if surf_pair.1.surface_kind() == SurfaceKind::Image {
             // Check whether the next to last surface has already been paired with another.
             if !paired_surfaces.contains(&i) {
                 components.insert(Component::UnpairedSurface { surf_idx: i });
@@ -176,7 +176,7 @@ mod tests {
             semi_diameter: 12.5,
             radius_of_curvature: 25.8,
             conic_constant: 0.0,
-            surf_type: crate::SurfaceType::Refracting,
+            surf_type: crate::BoundaryType::Refracting,
             rotation: Rotation3D::None,
         };
         let gap_1 = GapSpec {
@@ -187,7 +187,7 @@ mod tests {
             semi_diameter: 12.5,
             radius_of_curvature: Float::INFINITY,
             conic_constant: 0.0,
-            surf_type: crate::SurfaceType::Refracting,
+            surf_type: crate::BoundaryType::Refracting,
             rotation: Rotation3D::None,
         };
         let gap_2 = GapSpec {
@@ -198,7 +198,7 @@ mod tests {
             semi_diameter: 12.5,
             radius_of_curvature: 25.8,
             conic_constant: 0.0,
-            surf_type: crate::SurfaceType::Refracting,
+            surf_type: crate::BoundaryType::Refracting,
             rotation: Rotation3D::None,
         }; // Surface is unpaired
         let gap_3 = GapSpec {
@@ -230,7 +230,7 @@ mod tests {
             semi_diameter: 12.5,
             radius_of_curvature: 25.8,
             conic_constant: 0.0,
-            surf_type: crate::SurfaceType::Refracting,
+            surf_type: crate::BoundaryType::Refracting,
             rotation: Rotation3D::None,
         };
         let gap_1 = GapSpec {
@@ -280,7 +280,7 @@ mod tests {
             semi_diameter: 6.882,
             radius_of_curvature: Float::INFINITY,
             conic_constant: 0.0,
-            surf_type: crate::SurfaceType::Refracting,
+            surf_type: crate::BoundaryType::Refracting,
             rotation: Rotation3D::None,
         };
         let gap_2 = GapSpec {
@@ -291,7 +291,7 @@ mod tests {
             semi_diameter: 7.367,
             radius_of_curvature: -25.84,
             conic_constant: 0.0,
-            surf_type: crate::SurfaceType::Refracting,
+            surf_type: crate::BoundaryType::Refracting,
             rotation: Rotation3D::None,
         };
         let gap_3 = GapSpec {
@@ -316,19 +316,19 @@ mod tests {
     //             semi_diameter: 28.478,
     //             radius_of_curvature: 99.56266,
     //             conic_constant: 0.0,
-    //             surf_type: crate::SurfaceType::Refracting,
+    //             surf_type: crate::BoundaryType::Refracting,
     //         },
     //         SurfaceSpec::Conic {
     //             semi_diameter: 26.276,
     //             radius_of_curvature: -86.84002,
     //             conic_constant: 0.0,
-    //             surf_type: crate::SurfaceType::Refracting,
+    //             surf_type: crate::BoundaryType::Refracting,
     //         },
     //         SurfaceSpec::Conic {
     //             semi_diameter: 21.01,
     //             radius_of_curvature: -1187.63858,
     //             conic_constant: 0.0,
-    //             surf_type: crate::SurfaceType::Refracting,
+    //             surf_type: crate::BoundaryType::Refracting,
     //         },
     //         SurfaceSpec::Stop {
     //             semi_diameter: 33.262,
@@ -337,31 +337,31 @@ mod tests {
     //             semi_diameter: 20.543,
     //             radius_of_curvature: 57.47491,
     //             conic_constant: 0.0,
-    //             surf_type: crate::SurfaceType::Refracting,
+    //             surf_type: crate::BoundaryType::Refracting,
     //         },
     //         SurfaceSpec::Conic {
     //             semi_diameter: 20.074,
     //             radius_of_curvature: -54.61685,
     //             conic_constant: 0.0,
-    //             surf_type: crate::SurfaceType::Refracting,
+    //             surf_type: crate::BoundaryType::Refracting,
     //         },
     //         SurfaceSpec::Conic {
     //             semi_diameter: 16.492,
     //             radius_of_curvature: -614.68633,
     //             conic_constant: 0.0,
-    //             surf_type: crate::SurfaceType::Refracting,
+    //             surf_type: crate::BoundaryType::Refracting,
     //         },
     //         SurfaceSpec::Conic {
     //             semi_diameter: 17.297,
     //             radius_of_curvature: -38.17110,
     //             conic_constant: 0.0,
-    //             surf_type: crate::SurfaceType::Refracting,
+    //             surf_type: crate::BoundaryType::Refracting,
     //         },
     //         SurfaceSpec::Conic {
     //             semi_diameter: 18.94,
     //             radius_of_curvature: Float::INFINITY,
     //             conic_constant: 0.0,
-    //             surf_type: crate::SurfaceType::Refracting,
+    //             surf_type: crate::BoundaryType::Refracting,
     //         },
     //         SurfaceSpec::Image,
     //     ];
@@ -456,7 +456,7 @@ mod tests {
                 semi_diameter: 12.5,
                 radius_of_curvature: -200.0,
                 conic_constant: 0.0,
-                surf_type: crate::SurfaceType::Reflecting,
+                surf_type: crate::BoundaryType::Reflecting,
                 rotation: Rotation3D::None,
             },
             SurfaceSpec::Probe {

--- a/crates/cherry-rs/src/views/cross_section.rs
+++ b/crates/cherry-rs/src/views/cross_section.rs
@@ -3,8 +3,8 @@
 use std::collections::HashSet;
 
 use crate::{
-    SequentialModel,
-    core::{Float, math::vec3::Vec3, sequential_model::Surface},
+    SequentialModel, SurfaceKind,
+    core::{Float, math::vec3::Vec3, placement::Placement, surfaces::Surface},
     views::{components::Component, ray_trace_3d::RayBundle},
 };
 
@@ -117,6 +117,7 @@ fn build_plane_geometry(
     components: &HashSet<Component>,
 ) -> PlaneGeometry {
     let surfaces = model.surfaces();
+    let placements = model.placements();
     let largest_sd = model.largest_semi_diameter();
 
     let mut elements: Vec<DrawElement> = Vec::new();
@@ -134,10 +135,8 @@ fn build_plane_geometry(
     for comp in &sorted_components {
         match comp {
             Component::Element { surf_idxs: (i, j) } => {
-                let front = &surfaces[*i];
-                let back = &surfaces[*j];
-                let front_pts = sample_surface(front, axis, N_PTS);
-                let back_pts = sample_surface(back, axis, N_PTS);
+                let front_pts = sample_surface(surfaces[*i].as_ref(), &placements[*i], axis, N_PTS);
+                let back_pts = sample_surface(surfaces[*j].as_ref(), &placements[*j], axis, N_PTS);
                 if !front_pts.is_empty() && !back_pts.is_empty() {
                     elements.push(DrawElement::LensGroup {
                         front_pts,
@@ -146,9 +145,8 @@ fn build_plane_geometry(
                 }
             }
             Component::Stop { stop_idx } => {
-                let surf = &surfaces[*stop_idx];
-                let z = surf.pos().z();
-                let sd = surf.semi_diameter();
+                let z = placements[*stop_idx].position.z();
+                let sd = surfaces[*stop_idx].semi_diameter();
                 elements.push(DrawElement::Stop {
                     z,
                     half_gap: sd,
@@ -156,15 +154,23 @@ fn build_plane_geometry(
                 });
             }
             Component::Mirror { surf_idx } => {
-                let surf = &surfaces[*surf_idx];
-                let pts = sample_surface(surf, axis, N_PTS);
+                let pts = sample_surface(
+                    surfaces[*surf_idx].as_ref(),
+                    &placements[*surf_idx],
+                    axis,
+                    N_PTS,
+                );
                 if !pts.is_empty() {
                     elements.push(DrawElement::SurfaceProfile { points: pts });
                 }
             }
             Component::UnpairedSurface { surf_idx } => {
-                let surf = &surfaces[*surf_idx];
-                let pts = sample_surface(surf, axis, N_PTS);
+                let pts = sample_surface(
+                    surfaces[*surf_idx].as_ref(),
+                    &placements[*surf_idx],
+                    axis,
+                    N_PTS,
+                );
                 if !pts.is_empty() {
                     elements.push(DrawElement::SurfaceProfile { points: pts });
                 }
@@ -173,8 +179,8 @@ fn build_plane_geometry(
     }
 
     // Add flat planes (Image, Probe, Object at finite distance).
-    for surf in surfaces.iter() {
-        if surf.is_infinite() {
+    for (surf, placement) in surfaces.iter().zip(placements.iter()) {
+        if placement.is_infinite() {
             continue;
         }
         let half = if largest_sd > 0.0 {
@@ -182,24 +188,24 @@ fn build_plane_geometry(
         } else {
             1.0
         };
-        let kind = match surf {
-            Surface::Image(_) => FlatPlaneKind::Image,
-            Surface::Probe(_) => FlatPlaneKind::Probe,
-            Surface::Object(_) => FlatPlaneKind::Object,
+        let kind = match surf.surface_kind() {
+            SurfaceKind::Image => FlatPlaneKind::Image,
+            SurfaceKind::Probe => FlatPlaneKind::Probe,
+            SurfaceKind::Object => FlatPlaneKind::Object,
             _ => continue,
         };
 
         // Center of the plane in (z, transverse) plot space.
-        let center_z = surf.pos().z();
+        let center_z = placement.position.z();
         let center_t = match axis {
-            GlobalAxis::Y => surf.pos().y(),
-            GlobalAxis::X => surf.pos().x(),
+            GlobalAxis::Y => placement.position.y(),
+            GlobalAxis::X => placement.position.x(),
         };
 
         // Forward direction of the cursor at this surface in global coordinates.
-        // inv_rot_mat() maps local → global; applying to (0,0,1) gives the cursor
-        // forward direction. For Object (no rotation field) this is (0,0,1).
-        let fwd = surf.inv_rot_mat() * Vec3::new(0.0, 0.0, 1.0);
+        // inv_rotation_matrix maps local → global; applying to (0,0,1) gives the
+        // cursor forward direction.
+        let fwd = placement.inv_rotation_matrix * Vec3::new(0.0, 0.0, 1.0);
         let fwd_z = fwd.z();
         let fwd_t = match axis {
             GlobalAxis::Y => fwd.y(),
@@ -274,7 +280,12 @@ fn build_plane_geometry(
 /// For axis = Y: samples at (0, y, 0) for y in [-sd, sd], returns global (z, y)
 /// pairs. For axis = X: samples at (x, 0, 0) for x in [-sd, sd], returns global
 /// (z, x) pairs.
-fn sample_surface(surf: &Surface, axis: GlobalAxis, n_pts: usize) -> Vec<[f64; 2]> {
+fn sample_surface(
+    surf: &dyn Surface,
+    placement: &Placement,
+    axis: GlobalAxis,
+    n_pts: usize,
+) -> Vec<[f64; 2]> {
     let sd = surf.semi_diameter();
     if !sd.is_finite() || sd <= 0.0 || n_pts < 2 {
         return Vec::new();
@@ -294,7 +305,7 @@ fn sample_surface(surf: &Surface, axis: GlobalAxis, n_pts: usize) -> Vec<[f64; 2
             GlobalAxis::X => Vec3::new(transverse, 0.0, sag),
         };
         // Transform to global coordinates.
-        let global_pt = surf.inv_rot_mat() * local_surface_pt + surf.pos();
+        let global_pt = placement.inv_rotation_matrix * local_surface_pt + placement.position;
         let transverse_global = match axis {
             GlobalAxis::Y => global_pt.y(),
             GlobalAxis::X => global_pt.x(),
@@ -397,8 +408,9 @@ mod tests {
         let wavelengths: [Float; 1] = [0.5876];
         let model = convexplano_lens::sequential_model(air, nbk7, &wavelengths);
         let surfaces = model.surfaces();
+        let placements = model.placements();
         // Surface 2 is the plano (flat) back surface.
-        let pts = sample_surface(&surfaces[2], GlobalAxis::Y, 10);
+        let pts = sample_surface(surfaces[2].as_ref(), &placements[2], GlobalAxis::Y, 10);
         // All sag values should be zero for a flat surface.
         for &[_z, _t] in &pts {
             // Just ensure we got points back

--- a/crates/cherry-rs/src/views/paraxial.rs
+++ b/crates/cherry-rs/src/views/paraxial.rs
@@ -7,8 +7,6 @@
 /// paraxial view is used to compute the paraxial parameters of an optical
 /// system, such as the entrance and exit pupils, the back and front focal
 /// distances, and the effective focal length.
-use std::borrow::Borrow;
-
 use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
 
@@ -17,12 +15,14 @@ use crate::{
     core::{
         Float,
         math::{linalg::mat2x2::Mat2x2, vec3::Vec3},
+        placement::Placement,
         sequential_model::{
-            SequentialModel, SequentialSubModel, Step, Surface, first_physical_surface,
+            SequentialModel, SequentialSubModel, Step, first_physical_surface,
             last_physical_surface, propagate_tangential_vec, reversed_surface_id,
         },
+        surfaces::Surface,
     },
-    specs::{fields::unique_tangential_vecs, surfaces::SurfaceType},
+    specs::{fields::unique_tangential_vecs, surfaces::BoundaryType},
 };
 
 const DEFAULT_THICKNESS: Float = 0.0;
@@ -265,8 +265,9 @@ impl ParaxialView {
         is_obj_space_telecentric: bool,
     ) -> Result<Self> {
         let surfaces = sequential_model.surfaces();
+        let placements = sequential_model.placements();
         let tangential_vecs: Vec<TangentialVector> =
-            if SequentialModel::is_rotationally_symmetric(surfaces) {
+            if SequentialModel::is_rotationally_symmetric(placements) {
                 vec![Vec3::new(0.0, 1.0, 0.0)]
             } else {
                 unique_tangential_vecs(field_specs)
@@ -275,15 +276,14 @@ impl ParaxialView {
         let mut subviews = Vec::new();
         for (wav_idx, submodel) in sequential_model.submodels().iter().enumerate() {
             for (v_idx, &v) in tangential_vecs.iter().enumerate() {
-                let subview = ParaxialSubView::new(
-                    wav_idx,
-                    v_idx,
-                    submodel,
+                let data = SubModelData {
+                    sequential_sub_model: submodel as &dyn SequentialSubModel,
                     surfaces,
-                    v,
+                    placements,
                     field_specs,
-                    is_obj_space_telecentric,
-                )?;
+                };
+                let subview =
+                    ParaxialSubView::new(wav_idx, v_idx, &data, v, is_obj_space_telecentric)?;
                 subviews.push(subview);
             }
         }
@@ -403,6 +403,17 @@ impl ParaxialView {
     }
 }
 
+/// Bundles the per-submodel slices that `ParaxialSubView::new` needs.
+///
+/// Grouping these avoids exceeding the clippy `too_many_arguments` limit while
+/// keeping the call sites readable.
+struct SubModelData<'a> {
+    sequential_sub_model: &'a dyn SequentialSubModel,
+    surfaces: &'a [Box<dyn Surface>],
+    placements: &'a [Placement],
+    field_specs: &'a [FieldSpec],
+}
+
 impl ParaxialSubView {
     /// Create a new paraxial subview for the given tangential direction.
     ///
@@ -412,28 +423,39 @@ impl ParaxialSubView {
     fn new(
         wavelength_id: usize,
         tangential_vec_id: usize,
-        sequential_sub_model: &impl SequentialSubModel,
-        surfaces: &[Surface],
+        data: &SubModelData<'_>,
         v: TangentialVector,
-        field_specs: &[FieldSpec],
         is_obj_space_telecentric: bool,
     ) -> Result<Self> {
+        let sequential_sub_model = data.sequential_sub_model;
+        let surfaces = data.surfaces;
+        let placements = data.placements;
+        let field_specs = data.field_specs;
         // Propagate v through mirror surfaces to get per-surface tangential vectors.
-        let per_surf_v: Vec<TangentialVector> = propagate_tangential_vec(v, surfaces);
+        let per_surf_v: Vec<TangentialVector> = propagate_tangential_vec(v, surfaces, placements);
 
-        let pseudo_marginal_ray = Self::calc_pseudo_marginal_ray(sequential_sub_model, surfaces)?;
-        let parallel_ray = Self::calc_parallel_ray(sequential_sub_model, surfaces)?;
-        let reverse_parallel_ray = Self::calc_reverse_parallel_ray(sequential_sub_model, surfaces)?;
+        let pseudo_marginal_ray =
+            Self::calc_pseudo_marginal_ray(sequential_sub_model, surfaces, placements)?;
+        let parallel_ray = Self::calc_parallel_ray(sequential_sub_model, surfaces, placements)?;
+        let reverse_parallel_ray =
+            Self::calc_reverse_parallel_ray(sequential_sub_model, surfaces, placements)?;
 
-        let aperture_stop = Self::calc_aperture_stop(surfaces, &pseudo_marginal_ray, &per_surf_v);
+        let aperture_stop =
+            Self::calc_aperture_stop(surfaces, placements, &pseudo_marginal_ray, &per_surf_v);
         let back_focal_distance = Self::calc_back_focal_distance(surfaces, &parallel_ray)?;
         let front_focal_distance =
             Self::calc_front_focal_distance(surfaces, &reverse_parallel_ray)?;
-        let marginal_ray =
-            Self::calc_marginal_ray(surfaces, &pseudo_marginal_ray, &aperture_stop, &per_surf_v);
+        let marginal_ray = Self::calc_marginal_ray(
+            surfaces,
+            placements,
+            &pseudo_marginal_ray,
+            &aperture_stop,
+            &per_surf_v,
+        );
         let entrance_pupil = Self::calc_entrance_pupil(
             sequential_sub_model,
             surfaces,
+            placements,
             is_obj_space_telecentric,
             &aperture_stop,
             &per_surf_v,
@@ -442,6 +464,7 @@ impl ParaxialSubView {
         let exit_pupil = Self::calc_exit_pupil(
             sequential_sub_model,
             surfaces,
+            placements,
             &aperture_stop,
             &marginal_ray,
         )?;
@@ -455,12 +478,13 @@ impl ParaxialSubView {
         let chief_ray = Self::calc_chief_ray(
             surfaces,
             sequential_sub_model,
+            placements,
             v,
             field_specs,
             &entrance_pupil,
         )?;
         let paraxial_image_plane =
-            Self::calc_paraxial_image_plane(surfaces, &marginal_ray, &chief_ray)?;
+            Self::calc_paraxial_image_plane(surfaces, placements, &marginal_ray, &chief_ray)?;
 
         Ok(Self {
             wavelength_id,
@@ -556,7 +580,8 @@ impl ParaxialSubView {
     }
 
     fn calc_aperture_stop(
-        surfaces: &[Surface],
+        surfaces: &[Box<dyn Surface>],
+        placements: &[Placement],
         pseudo_marginal_ray: &ParaxialRayBundle,
         per_surf_v: &[TangentialVector],
     ) -> usize {
@@ -569,8 +594,11 @@ impl ParaxialSubView {
         let last_surface_height = pseudo_marginal_ray.last_surface().unwrap()[0].height;
         let ratios: Vec<Float> = surfaces
             .iter()
+            .zip(placements.iter())
             .zip(per_surf_v.iter())
-            .map(|(s, &v)| (s.projected_semi_diameter(v) / last_surface_height).abs())
+            .map(|((s, p), &v)| {
+                (p.projected_semi_diameter(s.semi_diameter(), v) / last_surface_height).abs()
+            })
             .collect();
 
         // Do not include the object or image surfaces when computing the aperture stop.
@@ -578,7 +606,7 @@ impl ParaxialSubView {
     }
 
     fn calc_back_focal_distance(
-        surfaces: &[Surface],
+        surfaces: &[Box<dyn Surface>],
         parallel_ray: &ParaxialRayBundle,
     ) -> Result<Float> {
         let last_physical_surface_index =
@@ -620,17 +648,18 @@ impl ParaxialSubView {
     /// submodel's chief ray is computed from the fields that lie in its
     /// meridional plane.
     fn calc_chief_ray(
-        surfaces: &[Surface],
-        sequential_sub_model: &impl SequentialSubModel,
+        surfaces: &[Box<dyn Surface>],
+        sequential_sub_model: &dyn SequentialSubModel,
+        placements: &[Placement],
         v: TangentialVector,
         field_specs: &[FieldSpec],
         entrance_pupil: &Pupil,
     ) -> Result<ParaxialRayBundle> {
         let enp_loc = entrance_pupil.location;
-        let obj_loc = surfaces
+        let obj_loc = placements
             .first()
             .ok_or(anyhow!("No surfaces provided"))?
-            .track();
+            .track;
         let sep = if obj_loc.is_infinite() {
             0.0
         } else {
@@ -657,7 +686,13 @@ impl ParaxialSubView {
             height,
             angle: paraxial_angle,
         }];
-        Self::trace(initial_ray, sequential_sub_model, surfaces, false)
+        Self::trace(
+            initial_ray,
+            sequential_sub_model,
+            surfaces,
+            placements,
+            false,
+        )
     }
 
     fn calc_effective_focal_length(parallel_ray: &ParaxialRayBundle) -> Float {
@@ -678,8 +713,9 @@ impl ParaxialSubView {
     }
 
     fn calc_entrance_pupil(
-        sequential_sub_model: &impl SequentialSubModel,
-        surfaces: &[Surface],
+        sequential_sub_model: &dyn SequentialSubModel,
+        surfaces: &[Box<dyn Surface>],
+        placements: &[Placement],
         is_obj_space_telecentric: bool,
         aperture_stop: &usize,
         per_surf_v: &[TangentialVector],
@@ -697,7 +733,8 @@ impl ParaxialSubView {
         if *aperture_stop == 1usize {
             return Ok(Pupil {
                 location: 0.0,
-                semi_diameter: surfaces[1].projected_semi_diameter(per_surf_v[1]),
+                semi_diameter: placements[1]
+                    .projected_semi_diameter(surfaces[1].semi_diameter(), per_surf_v[1]),
             });
         }
 
@@ -711,6 +748,7 @@ impl ParaxialSubView {
             ray,
             &sequential_sub_model.slice(0..*aperture_stop),
             &surfaces[0..aperture_stop + 1],
+            &placements[0..aperture_stop + 1],
             true,
         )?;
         let location = axis_intercepts(results.last_surface().unwrap())?[0];
@@ -736,8 +774,9 @@ impl ParaxialSubView {
     }
 
     fn calc_exit_pupil(
-        sequential_sub_model: &impl SequentialSubModel,
-        surfaces: &[Surface],
+        sequential_sub_model: &dyn SequentialSubModel,
+        surfaces: &[Box<dyn Surface>],
+        placements: &[Placement],
         aperture_stop: &usize,
         marginal_ray: &ParaxialRayBundle,
     ) -> Result<Pupil> {
@@ -760,6 +799,7 @@ impl ParaxialSubView {
             ray,
             &sequential_sub_model.slice(*aperture_stop..sequential_sub_model.len()),
             &surfaces[*aperture_stop..],
+            &placements[*aperture_stop..],
             false,
         )?;
 
@@ -782,12 +822,12 @@ impl ParaxialSubView {
     }
 
     fn calc_front_focal_distance(
-        surfaces: &[Surface],
+        surfaces: &[Box<dyn Surface>],
         reverse_parallel_ray: &ParaxialRayBundle,
     ) -> Result<Float> {
         let first_physical_surface_index =
             first_physical_surface(surfaces).ok_or(anyhow!("There are no physical surfaces"))?;
-        let index = reversed_surface_id(surfaces, first_physical_surface_index);
+        let index = reversed_surface_id(surfaces.len(), first_physical_surface_index);
         let intercepts = axis_intercepts(reverse_parallel_ray.rays_at_surface(index))?;
 
         let ffd = intercepts[0];
@@ -814,16 +854,20 @@ impl ParaxialSubView {
     }
 
     fn calc_marginal_ray(
-        surfaces: &[Surface],
+        surfaces: &[Box<dyn Surface>],
+        placements: &[Placement],
         pseudo_marginal_ray: &ParaxialRayBundle,
         aperture_stop: &usize,
         per_surf_v: &[TangentialVector],
     ) -> ParaxialRayBundle {
         let ratios: Vec<Float> = surfaces
             .iter()
+            .zip(placements.iter())
             .zip(pseudo_marginal_ray.iter_surfaces())
             .zip(per_surf_v.iter())
-            .map(|((s, rays), &v)| s.projected_semi_diameter(v) / rays[0].height)
+            .map(|(((s, p), rays), &v)| {
+                p.projected_semi_diameter(s.semi_diameter(), v) / rays[0].height
+            })
             .collect();
         let scale_factor = ratios[*aperture_stop];
 
@@ -844,33 +888,34 @@ impl ParaxialSubView {
 
     /// Compute the parallel ray.
     fn calc_parallel_ray(
-        sequential_sub_model: &impl SequentialSubModel,
-        surfaces: &[Surface],
+        sequential_sub_model: &dyn SequentialSubModel,
+        surfaces: &[Box<dyn Surface>],
+        placements: &[Placement],
     ) -> Result<ParaxialRayBundle> {
         let ray = vec![ParaxialRay {
             height: 1.0,
             angle: 0.0,
         }];
 
-        Self::trace(ray, sequential_sub_model, surfaces, false)
+        Self::trace(ray, sequential_sub_model, surfaces, placements, false)
     }
 
     /// Compute the paraxial image plane.
     fn calc_paraxial_image_plane(
-        surfaces: &[Surface],
+        surfaces: &[Box<dyn Surface>],
+        placements: &[Placement],
         marginal_ray: &ParaxialRayBundle,
         chief_ray: &ParaxialRayBundle,
     ) -> Result<ImagePlane> {
         let last_physical_surface_id =
             last_physical_surface(surfaces).ok_or(anyhow!("There are no physical surfaces"))?;
-        let last_surface = surfaces[last_physical_surface_id].borrow();
 
         let d_axis = axis_intercepts(marginal_ray.rays_at_surface(last_physical_surface_id))?[0];
         let location = if d_axis.is_infinite() {
             // Ensure positive infinity is returned for infinite image planes
             Float::INFINITY
         } else {
-            last_surface.track() + d_axis
+            placements[last_physical_surface_id].track + d_axis
         };
 
         // Propagate the chief ray from the last physical surface to the image plane to
@@ -886,8 +931,9 @@ impl ParaxialSubView {
 
     /// Compute the pseudo-marginal ray.
     fn calc_pseudo_marginal_ray(
-        sequential_sub_model: &impl SequentialSubModel,
-        surfaces: &[Surface],
+        sequential_sub_model: &dyn SequentialSubModel,
+        surfaces: &[Box<dyn Surface>],
+        placements: &[Placement],
     ) -> Result<ParaxialRayBundle> {
         let ray = if sequential_sub_model.is_obj_at_inf() {
             // Ray parallel to axis at a height of 1
@@ -903,41 +949,51 @@ impl ParaxialSubView {
             }]
         };
 
-        Self::trace(ray, sequential_sub_model, surfaces, false)
+        Self::trace(ray, sequential_sub_model, surfaces, placements, false)
     }
 
     /// Compute the reverse parallel ray.
     fn calc_reverse_parallel_ray(
-        sequential_sub_model: &impl SequentialSubModel,
-        surfaces: &[Surface],
+        sequential_sub_model: &dyn SequentialSubModel,
+        surfaces: &[Box<dyn Surface>],
+        placements: &[Placement],
     ) -> Result<ParaxialRayBundle> {
         let ray = vec![ParaxialRay {
             height: 1.0,
             angle: 0.0,
         }];
 
-        Self::trace(ray, sequential_sub_model, surfaces, true)
+        Self::trace(ray, sequential_sub_model, surfaces, placements, true)
     }
 
     /// Compute the ray transfer matrix for each gap/surface pair.
     fn rtms(
-        sequential_sub_model: &impl SequentialSubModel,
-        surfaces: &[Surface],
+        sequential_sub_model: &dyn SequentialSubModel,
+        surfaces: &[Box<dyn Surface>],
+        placements: &[Placement],
         reverse: bool,
     ) -> Result<Vec<RayTransferMatrix>> {
         let mut txs: Vec<RayTransferMatrix> = Vec::new();
         let mut forward_iter;
         let mut reverse_iter;
         let steps: &mut dyn Iterator<Item = Step> = if reverse {
-            reverse_iter = sequential_sub_model.try_iter(surfaces)?.try_reverse()?;
+            reverse_iter = sequential_sub_model
+                .try_iter(surfaces, placements)?
+                .try_reverse()?;
             &mut reverse_iter
         } else {
-            forward_iter = sequential_sub_model.try_iter(surfaces)?;
+            forward_iter = sequential_sub_model.try_iter(surfaces, placements)?;
             &mut forward_iter
         };
         let mut reflected: i8 = 1;
 
-        for (gap_0, surface, gap_1) in steps {
+        for Step {
+            gap_before: gap_0,
+            surface,
+            gap_after: gap_1,
+            ..
+        } in steps
+        {
             let t = if gap_0.thickness.is_infinite() {
                 DEFAULT_THICKNESS
             } else if reverse {
@@ -948,8 +1004,8 @@ impl ParaxialSubView {
                 reflected as Float * gap_0.thickness
             };
 
-            let roc = surface.roc();
-            if let SurfaceType::Reflecting = surface.surface_type() {
+            let roc = surface.roc(0.0);
+            if let BoundaryType::Reflecting = surface.boundary_type() {
                 reflected *= -1;
             }
 
@@ -969,11 +1025,12 @@ impl ParaxialSubView {
 
     fn trace(
         initial_rays: Vec<ParaxialRay>,
-        sequential_sub_model: &impl SequentialSubModel,
-        surfaces: &[Surface],
+        sequential_sub_model: &dyn SequentialSubModel,
+        surfaces: &[Box<dyn Surface>],
+        placements: &[Placement],
         reverse: bool,
     ) -> Result<ParaxialRayBundle> {
-        let txs = Self::rtms(sequential_sub_model, surfaces, reverse)?;
+        let txs = Self::rtms(sequential_sub_model, surfaces, placements, reverse)?;
         let num_surfaces = txs.len() + 1;
         let num_rays = initial_rays.len();
         let mut flat: Vec<ParaxialRay> = Vec::with_capacity(num_surfaces * num_rays);
@@ -1002,29 +1059,23 @@ impl ParaxialSubView {
 /// Compute the ray transfer matrix for propagation to and interaction with a
 /// surface.
 fn surface_to_rtm(
-    surface: &Surface,
+    surface: &dyn Surface,
     t: Float,
     roc: Float,
     n_0: Float,
     n_1: Float,
 ) -> RayTransferMatrix {
-    match surface {
-        // Conics and torics behave the same in paraxial subviews.
-        Surface::Conic(_) => match surface.surface_type() {
-            SurfaceType::Refracting => Mat2x2::new(
-                1.0,
-                t,
-                (n_0 - n_1) / n_1 / roc,
-                t * (n_0 - n_1) / n_1 / roc + n_0 / n_1,
-            ),
-
-            // -1.0 in the second row flips the angle upon reflection so that we don't have to do
-            // acrobatics flipping by the +z-direction instead
-            SurfaceType::Reflecting => Mat2x2::new(1.0, t, -2.0 / roc, -1.0 - 2.0 * t / roc),
-            SurfaceType::NoOp => panic!("Conics and torics cannot be NoOp surfaces."),
-        },
-        Surface::Image(_) | Surface::Probe(_) | Surface::Stop(_) => Mat2x2::new(1.0, t, 0.0, 1.0),
-        Surface::Object(_) => Mat2x2::identity(),
+    match surface.boundary_type() {
+        BoundaryType::Refracting => Mat2x2::new(
+            1.0,
+            t,
+            (n_0 - n_1) / n_1 / roc,
+            t * (n_0 - n_1) / n_1 / roc + n_0 / n_1,
+        ),
+        // -1.0 in the second row flips the angle upon reflection so that we don't have to do
+        // acrobatics flipping by the +z-direction instead
+        BoundaryType::Reflecting => Mat2x2::new(1.0, t, -2.0 / roc, -1.0 - 2.0 * t / roc),
+        BoundaryType::NoOp => Mat2x2::new(1.0, t, 0.0, 1.0),
     }
 }
 
@@ -1147,14 +1198,18 @@ mod test {
             },
         ];
 
+        let data = SubModelData {
+            sequential_sub_model: seq_sub_model as &dyn SequentialSubModel,
+            surfaces: sequential_model.surfaces(),
+            placements: sequential_model.placements(),
+            field_specs: &field_specs,
+        };
         (
             ParaxialSubView::new(
                 0,
                 0,
-                seq_sub_model,
-                sequential_model.surfaces(),
+                &data,
                 Vec3::new(0.0, 1.0, 0.0), // v = Y (phi=90°)
-                &field_specs,
                 false,
             )
             .unwrap(),
@@ -1216,9 +1271,12 @@ mod test {
         let wavelengths: [Float; 1] = [0.5876];
         let sequential_model = convexplano_lens::sequential_model(air, nbk7, &wavelengths);
         let seq_sub_model = sequential_model.submodel(0).expect("Submodel not found.");
-        let pseudo_marginal_ray =
-            ParaxialSubView::calc_pseudo_marginal_ray(seq_sub_model, sequential_model.surfaces())
-                .unwrap();
+        let pseudo_marginal_ray = ParaxialSubView::calc_pseudo_marginal_ray(
+            seq_sub_model,
+            sequential_model.surfaces(),
+            sequential_model.placements(),
+        )
+        .unwrap();
 
         let expected = [
             (1.0000, 0.0),
@@ -1243,9 +1301,12 @@ mod test {
         let wavelengths: [Float; 1] = [0.5876];
         let sequential_model = convexplano_lens::sequential_model(air, nbk7, &wavelengths);
         let seq_sub_model = sequential_model.submodel(0).expect("Submodel not found.");
-        let reverse_parallel_ray =
-            ParaxialSubView::calc_reverse_parallel_ray(seq_sub_model, sequential_model.surfaces())
-                .unwrap();
+        let reverse_parallel_ray = ParaxialSubView::calc_reverse_parallel_ray(
+            seq_sub_model,
+            sequential_model.surfaces(),
+            sequential_model.placements(),
+        )
+        .unwrap();
 
         let expected = [(1.0000, 0.0), (1.0000, 0.0), (1.0000, 0.0200)];
 

--- a/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
@@ -12,7 +12,9 @@ use crate::{
     core::{
         Float, PI,
         math::vec3::Vec3,
-        sequential_model::{SequentialModel, SequentialSubModel, Surface},
+        placement::Placement,
+        sequential_model::{SequentialModel, SequentialSubModel},
+        surfaces::Surface,
     },
     specs::{
         aperture::ApertureSpec,
@@ -129,6 +131,7 @@ pub fn trace_ray_bundle(
                 let bundle = ray_trace_submodel(
                     sequential_submodel,
                     sequential_model.surfaces(),
+                    sequential_model.placements(),
                     aperture_spec,
                     &field_specs[field_id],
                     paraxial_subview,
@@ -188,10 +191,12 @@ pub fn ray_trace_3d_view(
 
             let field_spec = &field_specs[field_id];
             let surfaces = sequential_model.surfaces();
+            let placements = sequential_model.placements();
 
             let chief_ray = ray_trace_submodel(
                 sequential_submodel,
                 surfaces,
+                placements,
                 aperture_spec,
                 field_spec,
                 paraxial_subview,
@@ -200,6 +205,7 @@ pub fn ray_trace_3d_view(
             let full_pupil = ray_trace_submodel(
                 sequential_submodel,
                 surfaces,
+                placements,
                 aperture_spec,
                 field_spec,
                 paraxial_subview,
@@ -210,6 +216,7 @@ pub fn ray_trace_3d_view(
             let tangential_fan = ray_trace_submodel(
                 sequential_submodel,
                 surfaces,
+                placements,
                 aperture_spec,
                 field_spec,
                 paraxial_subview,
@@ -220,6 +227,7 @@ pub fn ray_trace_3d_view(
             let sagittal_fan = ray_trace_submodel(
                 sequential_submodel,
                 surfaces,
+                placements,
                 aperture_spec,
                 field_spec,
                 paraxial_subview,
@@ -339,21 +347,22 @@ impl TraceResults {
 
 fn ray_trace_submodel(
     sequential_submodel: &impl SequentialSubModel,
-    surfaces: &[Surface],
+    surfaces: &[Box<dyn Surface>],
+    placements: &[Placement],
     aperture_spec: &ApertureSpec,
     field_spec: &FieldSpec,
     paraxial_subview: &ParaxialSubView,
     pupil_sampling: PupilSampling,
 ) -> Result<RayBundle> {
     let rays = rays(
-        surfaces,
+        placements,
         aperture_spec,
         paraxial_subview,
         field_spec,
         pupil_sampling,
     )?;
 
-    let mut sequential_sub_model_iter = sequential_submodel.try_iter(surfaces)?;
+    let mut sequential_sub_model_iter = sequential_submodel.try_iter(surfaces, placements)?;
     Ok(trace(&mut sequential_sub_model_iter, rays))
 }
 
@@ -368,7 +377,7 @@ fn ray_trace_submodel(
 /// * `field_spec` - The field specification.
 /// * `sampling` - The pupil sampling method.
 fn rays(
-    surfaces: &[Surface],
+    placements: &[Placement],
     aperture_spec: &ApertureSpec,
     paraxial_subview: &ParaxialSubView,
     field_spec: &FieldSpec,
@@ -381,14 +390,14 @@ fn rays(
 
             match sampling {
                 PupilSampling::ChiefRay => chief_ray_from_angle(
-                    surfaces,
+                    placements,
                     aperture_spec,
                     paraxial_subview,
                     phi_rad,
                     chi_rad,
                 )?,
                 PupilSampling::SquareGrid { spacing } => parallel_ray_bundle_on_sq_grid(
-                    surfaces,
+                    placements,
                     aperture_spec,
                     paraxial_subview,
                     spacing,
@@ -397,7 +406,7 @@ fn rays(
                 PupilSampling::TangentialRayFan { n } => {
                     let tan_phi = field_spec.tangential_fan_phi();
                     parallel_ray_fan(
-                        surfaces,
+                        placements,
                         aperture_spec,
                         paraxial_subview,
                         n,
@@ -410,7 +419,7 @@ fn rays(
                     let tan_phi = field_spec.tangential_fan_phi();
                     let sag_phi = field_spec.sagittal_fan_phi();
                     parallel_ray_fan(
-                        surfaces,
+                        placements,
                         aperture_spec,
                         paraxial_subview,
                         n,
@@ -423,10 +432,9 @@ fn rays(
         }
 
         FieldSpec::PointSource { x, y } => {
-            let obj_z = surfaces
+            let obj_z = placements
                 .first()
                 .expect("There should always be at least two surfaces")
-                .pos()
                 .z();
             if obj_z.is_infinite() {
                 return Err(anyhow!(
@@ -470,13 +478,13 @@ fn rays(
 /// * `phi` - The azimuthal angle of the ray in the x-y plane, radians.
 /// * `chi` - The zenith angle of the ray w.r.t. the z-axis, radians.
 fn chief_ray_from_angle(
-    surfaces: &[Surface],
+    placements: &[Placement],
     aperture_spec: &ApertureSpec,
     paraxial_subview: &ParaxialSubView,
     phi: Float,
     chi: Float,
 ) -> Result<Vec<Ray>> {
-    let origin = parallel_ray_bundle_origin(surfaces, aperture_spec, paraxial_subview, phi, chi)?;
+    let origin = parallel_ray_bundle_origin(placements, aperture_spec, paraxial_subview, phi, chi)?;
     let dir = Vec3::new(phi.cos() * chi.sin(), phi.sin() * chi.sin(), chi.cos()).normalize();
 
     Ok(vec![Ray::new(origin, dir)])
@@ -516,7 +524,7 @@ fn chief_ray_from_pos(
 /// * `chi` - The zenith angle of the ray w.r.t. the z-axis, radians.
 #[allow(clippy::too_many_arguments)]
 fn parallel_ray_fan(
-    surfaces: &[Surface],
+    placements: &[Placement],
     aperture_spec: &ApertureSpec,
     paraxial_subview: &ParaxialSubView,
     num_rays: usize,
@@ -526,7 +534,7 @@ fn parallel_ray_fan(
 ) -> Result<Vec<Ray>> {
     let enp = entrance_pupil(aperture_spec, paraxial_subview)?;
     let origin = parallel_ray_bundle_origin(
-        surfaces,
+        placements,
         aperture_spec,
         paraxial_subview,
         fan_origin_phi,
@@ -577,7 +585,7 @@ fn parallel_ray_fan(
 ///   (marginal rays).
 /// * `chi` - The zenith angle of the ray bundle w.r.t. the z-axis in radians.
 fn parallel_ray_bundle_on_sq_grid(
-    surfaces: &[Surface],
+    placements: &[Placement],
     aperture_spec: &ApertureSpec,
     paraxial_subview: &ParaxialSubView,
     spacing: Float,
@@ -586,7 +594,7 @@ fn parallel_ray_bundle_on_sq_grid(
     let enp = entrance_pupil(aperture_spec, paraxial_subview)?;
     let abs_spacing = enp.semi_diameter * spacing;
     let origin =
-        parallel_ray_bundle_origin(surfaces, aperture_spec, paraxial_subview, PI / 2.0, chi)?;
+        parallel_ray_bundle_origin(placements, aperture_spec, paraxial_subview, PI / 2.0, chi)?;
 
     let rays = Ray::parallel_ray_bundle_on_sq_grid(
         enp.semi_diameter,
@@ -761,15 +769,15 @@ fn axial_launch_point(obj_z: Float, sur_z: Float, enp_z: Float) -> Float {
 /// * `phi` - The azimuthal angle of the ray fan in the x-y plane, radians.
 /// * `chi` - The zenith angle of the ray w.r.t. the z-axis, radians.
 fn parallel_ray_bundle_origin(
-    surfaces: &[Surface],
+    placements: &[Placement],
     aperture_spec: &ApertureSpec,
     paraxial_subview: &ParaxialSubView,
     phi: Float,
     chi: Float,
 ) -> Result<Vec3> {
     let enp = entrance_pupil(aperture_spec, paraxial_subview)?;
-    let obj_z = surfaces[0].pos().z();
-    let sur_z = surfaces[1].pos().z();
+    let obj_z = placements[0].z();
+    let sur_z = placements[1].z();
     let enp_z = enp.location;
 
     let launch_point_z = axial_launch_point(obj_z, sur_z, enp_z);
@@ -915,7 +923,7 @@ mod tests {
         let s = setup();
 
         let rays = rays(
-            s.sequential_model.surfaces(),
+            s.sequential_model.placements(),
             &s.aperture_spec,
             s.paraxial_view.get(0, 0).unwrap(),
             &s.field_specs[0],
@@ -944,7 +952,7 @@ mod tests {
         let paraxial_view = ParaxialView::new(&seq_model, &field_specs, false).unwrap();
 
         let fan_rays = rays(
-            seq_model.surfaces(),
+            seq_model.placements(),
             &aperture_spec,
             paraxial_view.get(0, 0).unwrap(),
             &field_specs[0],
@@ -990,7 +998,7 @@ mod tests {
         let paraxial_view = ParaxialView::new(&seq_model, &[field_spec], false).unwrap();
 
         let chief = rays(
-            seq_model.surfaces(),
+            seq_model.placements(),
             &aperture_spec,
             paraxial_view.get(0, 0).unwrap(),
             &field_spec,
@@ -998,7 +1006,7 @@ mod tests {
         )
         .unwrap();
         let sag_fan = rays(
-            seq_model.surfaces(),
+            seq_model.placements(),
             &aperture_spec,
             paraxial_view.get(0, 0).unwrap(),
             &field_spec,
@@ -1027,7 +1035,7 @@ mod tests {
         let field_spec = FieldSpec::PointSource { x: 0.0, y: 0.0 };
 
         let result = rays(
-            s.sequential_model.surfaces(),
+            s.sequential_model.placements(),
             &s.aperture_spec,
             s.paraxial_view.get(0, 0).unwrap(),
             &field_spec,
@@ -1046,7 +1054,7 @@ mod tests {
         let s = setup();
 
         let rays = chief_ray_from_angle(
-            s.sequential_model.surfaces(),
+            s.sequential_model.placements(),
             &s.aperture_spec,
             s.paraxial_view.get(0, 0).unwrap(),
             0.0,
@@ -1068,7 +1076,7 @@ mod tests {
         let s = setup();
 
         let rays = chief_ray_from_angle(
-            s.sequential_model.surfaces(),
+            s.sequential_model.placements(),
             &s.aperture_spec,
             s.paraxial_view.get(0, 0).unwrap(),
             PI / 2.0,
@@ -1130,7 +1138,7 @@ mod tests {
         let s = setup();
 
         let rays = parallel_ray_bundle_on_sq_grid(
-            s.sequential_model.surfaces(),
+            s.sequential_model.placements(),
             &s.aperture_spec,
             s.paraxial_view.get(0, 0).unwrap(),
             1.0,
@@ -1142,7 +1150,7 @@ mod tests {
         assert_eq!(rays.unwrap().len(), 5);
 
         let rays = parallel_ray_bundle_on_sq_grid(
-            s.sequential_model.surfaces(),
+            s.sequential_model.placements(),
             &s.aperture_spec,
             s.paraxial_view.get(0, 0).unwrap(),
             0.5,
@@ -1289,7 +1297,7 @@ mod tests {
         };
 
         let generated = rays(
-            s.sequential_model.surfaces(),
+            s.sequential_model.placements(),
             &s.aperture_spec,
             s.paraxial_view.get(0, 0).unwrap(),
             &field_spec,

--- a/crates/cherry-rs/src/views/ray_trace_3d/rays.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/rays.rs
@@ -3,11 +3,10 @@ use serde::{Deserialize, Serialize};
 use tracing::{error, trace, trace_span};
 
 use crate::{
-    SurfaceType,
+    BoundaryType,
     core::{
-        Float, PI,
-        math::vec3::Vec3,
-        sequential_model::{Step, Surface},
+        Float, PI, math::vec3::Vec3, placement::Placement, sequential_model::Step,
+        surfaces::Surface,
     },
 };
 
@@ -56,7 +55,7 @@ impl Ray {
     /// # Arguments
     /// - surf: Surface to intersect with
     /// - max_iter: Maximum number of iterations for the Newton-Raphson method
-    pub fn intersect(&self, surf: &Surface, max_iter: usize) -> Result<(Vec3, Vec3)> {
+    pub fn intersect(&self, surf: &dyn Surface, max_iter: usize) -> Result<(Vec3, Vec3)> {
         let _intersect_span = trace_span!("intersect").entered();
 
         // Initial guess for the intersection point
@@ -181,7 +180,12 @@ impl Ray {
     pub fn redirect(&mut self, step: &Step, norm: Vec3) {
         // Do not match on the wildcard "_" to ensure that this function is updated when
         // new surfaces are added
-        let (gap_0, surf, gap_1) = step;
+        let Step {
+            gap_before: gap_0,
+            surface: surf,
+            gap_after: gap_1,
+            ..
+        } = step;
         let n_0 = gap_0.refractive_index.n();
         let n_1 = if let Some(gap_1) = gap_1 {
             gap_1.refractive_index.n()
@@ -192,31 +196,20 @@ impl Ray {
         // Ensure the normal vector is normalized for the redirect calculations.
         let norm = norm.normalize();
 
-        match surf {
-            //Surface::Conic(_) | Surface::Toric(_) => {
-            Surface::Conic(_) => {
-                match surf.surface_type() {
-                    SurfaceType::Refracting => {
-                        let mu = n_0 / n_1;
-                        let cos_theta_1 = self.dir.dot(&norm);
-                        let term_1 =
-                            norm * (1.0 - mu * mu * (1.0 - cos_theta_1 * cos_theta_1)).sqrt();
-                        let term_2 = (self.dir - norm * cos_theta_1) * mu;
+        match surf.boundary_type() {
+            BoundaryType::Refracting => {
+                let mu = n_0 / n_1;
+                let cos_theta_1 = self.dir.dot(&norm);
+                let term_1 = norm * (1.0 - mu * mu * (1.0 - cos_theta_1 * cos_theta_1)).sqrt();
+                let term_2 = (self.dir - norm * cos_theta_1) * mu;
 
-                        self.dir = term_1 + term_2;
-                    }
-                    SurfaceType::Reflecting => {
-                        let cos_theta_1 = self.dir.dot(&norm);
-                        self.dir = self.dir - norm * (2.0 * cos_theta_1);
-                    }
-                    SurfaceType::NoOp => {}
-                };
+                self.dir = term_1 + term_2;
             }
-            // No-op surfaces
-            Surface::Image(_) => {}
-            Surface::Object(_) => {}
-            Surface::Probe(_) => {}
-            Surface::Stop(_) => {}
+            BoundaryType::Reflecting => {
+                let cos_theta_1 = self.dir.dot(&norm);
+                self.dir = self.dir - norm * (2.0 * cos_theta_1);
+            }
+            BoundaryType::NoOp => {}
         }
     }
 
@@ -227,16 +220,16 @@ impl Ray {
 
     /// Transform a ray into the local coordinate system of a surface from the
     /// global system.
-    pub fn transform(&mut self, surf: &Surface) {
-        self.pos = surf.rot_mat() * (self.pos - surf.pos());
-        self.dir = surf.rot_mat() * self.dir;
+    pub fn transform(&mut self, placement: &Placement) {
+        self.pos = placement.rotation_matrix * (self.pos - placement.position);
+        self.dir = placement.rotation_matrix * self.dir;
     }
 
     /// Transform a ray from the local coordinate system of a surface into the
     /// global system.
-    pub fn i_transform(&mut self, surf: &Surface) {
-        self.pos = (surf.inv_rot_mat() * self.pos) + surf.pos();
-        self.dir = surf.inv_rot_mat() * self.dir;
+    pub fn i_transform(&mut self, placement: &Placement) {
+        self.pos = (placement.inv_rotation_matrix * self.pos) + placement.position;
+        self.dir = placement.inv_rotation_matrix * self.dir;
     }
 
     // Return the x-coordinate of the ray position
@@ -361,26 +354,20 @@ impl Ray {
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        Rotation3D,
-        core::math::geometry::reference_frames::Cursor,
-        specs::surfaces::{SurfaceSpec, SurfaceType},
-    };
+    use crate::core::surfaces::Conic;
+    use crate::specs::surfaces::BoundaryType;
 
     use super::*;
     // Test the intersection of a ray with a flat surface
     #[test]
     fn test_ray_intersection_flat_surface() {
-        let cursor = Cursor::new(0.0);
         let ray = Ray::new(Vec3::new(0.0, 0.0, -1.0), Vec3::new(0.0, 0.0, 1.0));
-        let surf_spec = SurfaceSpec::Conic {
+        let surf = Conic {
             semi_diameter: 4.0,
             radius_of_curvature: Float::INFINITY,
             conic_constant: 0.0,
-            surf_type: SurfaceType::Refracting,
-            rotation: Rotation3D::None,
+            boundary_type: BoundaryType::Refracting,
         };
-        let surf = Surface::from_spec(&surf_spec, &cursor);
         let max_iter = 1000;
 
         let (p, _) = ray.intersect(&surf, max_iter).unwrap();
@@ -391,22 +378,18 @@ mod test {
     // Test the intersection of a ray with a circular surface
     #[test]
     fn test_ray_intersection_conic() {
-        let cursor = Cursor::new(0.0);
-
         // Ray starts at z = -1.0 and travels at 45 degrees to the optics axis
         let l = (std::f64::consts::PI as Float / 4.0).sin();
         let m = (std::f64::consts::PI as Float / 4.0).cos();
         let ray = Ray::new(Vec3::new(0.0, 0.0, -1.0), Vec3::new(0.0, l, m));
 
         // Surface has radius of curvature -1.0 and conic constant 0.0, i.e. a circle
-        let surf_spec = SurfaceSpec::Conic {
+        let surf = Conic {
             semi_diameter: 4.0,
             radius_of_curvature: -1.0,
             conic_constant: 0.0,
-            surf_type: SurfaceType::Refracting,
-            rotation: Rotation3D::None,
+            boundary_type: BoundaryType::Refracting,
         };
-        let surf = Surface::from_spec(&surf_spec, &cursor);
         let max_iter = 1000;
 
         let (p, _) = ray.intersect(&surf, max_iter).unwrap();

--- a/crates/cherry-rs/src/views/ray_trace_3d/trace.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/trace.rs
@@ -36,7 +36,7 @@ pub fn trace(sequential_submodel: &mut SequentialSubModelIter, mut rays: Vec<Ray
     let mut ray_bundle = initialize_bundle(&rays, num_surfaces);
 
     for (ctr, step) in sequential_submodel.enumerate() {
-        let (_, surf, _) = step;
+        let surf = step.surface;
         let surface_id = ctr + 1;
 
         // Copy the ray states into here after they have been traced through the surface
@@ -51,11 +51,11 @@ pub fn trace(sequential_submodel: &mut SequentialSubModelIter, mut rays: Vec<Ray
             }
 
             // Transform into coordinate system of the surface
-            ray.transform(surf);
+            ray.transform(step.placement);
 
             // Find the ray intersection with the surface.
             // Errors if the intersection point does not converge.
-            let (pos, norm) = match ray.intersect(surf, MAX_INTERSECTION_ITER) {
+            let (pos, norm) = match ray.intersect(step.surface, MAX_INTERSECTION_ITER) {
                 Ok((pos, norm)) => (pos, norm),
                 Err(e) => {
                     if !ray_is_terminated(ray_id, &terminated) {
@@ -88,7 +88,7 @@ pub fn trace(sequential_submodel: &mut SequentialSubModelIter, mut rays: Vec<Ray
             ray.redirect(&step, norm);
 
             // Transform back to the global coordinate system
-            ray.i_transform(surf);
+            ray.i_transform(step.placement);
 
             rays_at_surface[ray_id] = ray.clone();
         }

--- a/crates/cherry-rs/tests/mirrors_figure_z.rs
+++ b/crates/cherry-rs/tests/mirrors_figure_z.rs
@@ -29,14 +29,13 @@ const EXIT_PUPIL_LOCATION: f64 = 100.0;
 fn track_equals_z_for_straight_system() {
     use cherry_rs::examples::convexplano_lens;
     let model = convexplano_lens::sequential_model(n!(1.0), n!(1.515), &WAVELENGTHS);
-    let surfaces = model.surfaces();
-    for surf in surfaces {
-        if surf.z().is_finite() {
+    for p in model.placements() {
+        if p.position.z().is_finite() {
             assert!(
-                (surf.track() - surf.z()).abs() < 1e-10,
+                (p.track - p.position.z()).abs() < 1e-10,
                 "Expected track == z for straight system, got track={}, z={}",
-                surf.track(),
-                surf.z()
+                p.track,
+                p.position.z()
             );
         }
     }
@@ -139,25 +138,25 @@ fn chief_ray_uses_matching_field_phi() {
 #[test]
 fn track_coordinates_folded_system() {
     let model = mirrors_figure_z::sequential_model(n!(1.0), &WAVELENGTHS);
-    let surfaces = model.surfaces();
+    let placements = model.placements();
 
-    // surf[0] Object: cursor initialized at -inf
-    assert!(surfaces[0].track().is_infinite() && surfaces[0].track() < 0.0);
+    // placements[0] Object: cursor initialized at -inf
+    assert!(placements[0].track.is_infinite() && placements[0].track < 0.0);
 
-    // surf[1] Mirror 1: special-case advance from -inf resets track to 0
-    assert_eq!(surfaces[1].track(), 0.0);
+    // placements[1] Mirror 1: special-case advance from -inf resets track to 0
+    assert_eq!(placements[1].track, 0.0);
 
-    // surf[2] Mirror 2: 0 + gap_1 (100 mm)
+    // placements[2] Mirror 2: 0 + gap_1 (100 mm)
     assert!(
-        (surfaces[2].track() - 100.0).abs() < 1e-10,
+        (placements[2].track - 100.0).abs() < 1e-10,
         "Mirror 2 track should be 100, got {}",
-        surfaces[2].track()
+        placements[2].track
     );
 
-    // surf[3] Image: 100 + gap_2 (50 mm)
+    // placements[3] Image: 100 + gap_2 (50 mm)
     assert!(
-        (surfaces[3].track() - 150.0).abs() < 1e-10,
+        (placements[3].track - 150.0).abs() < 1e-10,
         "Image track should be 150, got {}",
-        surfaces[3].track()
+        placements[3].track
     );
 }


### PR DESCRIPTION
This is a major refactoring to change the `Surface` enum into a trait. The purpose is to allow user-defined surfaces.

To achieve a small trait footprint, the surface geometry was separated from surface placement by introduction of a `Placement` struct. This struct contains all the information necessary for the 3D placement of the surface in the global coordinate system and is provided by the library, not by the implementers of the `Surface` trait. `Placement` is now part of a sequential `Step`, the info returned when iterating over a `SequentialSubModel`.

This refactor has no effect on the benchmarks.

Future work is necessary to:
- create custom Surface types from specs
- specify an intersection algo for different surface types