### PR TITLE
refactor: Separate clear aperture logic into a Mask enum

### DIFF
--- a/crates/cherry-rs/src/core/ray.rs
+++ b/crates/cherry-rs/src/core/ray.rs
@@ -239,12 +239,7 @@ mod tests {
     #[test]
     fn test_ray_intersection_flat_surface() {
         let ray = Ray::new(Vec3::new(0.0, 0.0, -1.0), Vec3::new(0.0, 0.0, 1.0));
-        let surf = Conic {
-            semi_diameter: 4.0,
-            radius_of_curvature: Float::INFINITY,
-            conic_constant: 0.0,
-            boundary_type: BoundaryType::Refracting,
-        };
+        let surf = Conic::new(4.0, Float::INFINITY, 0.0, BoundaryType::Refracting);
 
         let (p, _) = surf.intersect(&ray, 1000).unwrap();
 
@@ -256,12 +251,7 @@ mod tests {
         let l = (std::f64::consts::PI as Float / 4.0).sin();
         let m = (std::f64::consts::PI as Float / 4.0).cos();
         let ray = Ray::new(Vec3::new(0.0, 0.0, -1.0), Vec3::new(0.0, l, m));
-        let surf = Conic {
-            semi_diameter: 4.0,
-            radius_of_curvature: -1.0,
-            conic_constant: 0.0,
-            boundary_type: BoundaryType::Refracting,
-        };
+        let surf = Conic::new(4.0, -1.0, 0.0, BoundaryType::Refracting);
 
         let (p, _) = surf.intersect(&ray, 1000).unwrap();
 

--- a/crates/cherry-rs/src/core/sequential_model.rs
+++ b/crates/cherry-rs/src/core/sequential_model.rs
@@ -222,7 +222,7 @@ pub(crate) fn propagate_tangential_vec(
 pub(crate) fn first_physical_surface(surfaces: &[Box<dyn Surface>]) -> Option<usize> {
     surfaces
         .iter()
-        .position(|surf| surf.semi_diameter().is_finite())
+        .position(|surf| surf.mask().semi_diameter().is_finite())
 }
 
 /// Returns the index of the last physical surface in the system.
@@ -232,7 +232,7 @@ pub(crate) fn first_physical_surface(surfaces: &[Box<dyn Surface>]) -> Option<us
 pub fn last_physical_surface(surfaces: &[Box<dyn Surface>]) -> Option<usize> {
     surfaces
         .iter()
-        .rposition(|surf| surf.semi_diameter().is_finite())
+        .rposition(|surf| surf.mask().semi_diameter().is_finite())
 }
 
 /// Returns the id of a surface in a reversed system.
@@ -373,7 +373,7 @@ impl SequentialModel {
         self.surfaces
             .iter()
             .filter_map(|surf| {
-                let sd = surf.semi_diameter();
+                let sd = surf.mask().semi_diameter();
                 if sd.is_finite() { Some(sd) } else { None }
             })
             .fold(0.0, |acc, x| acc.max(x))
@@ -727,9 +727,9 @@ pub(crate) fn surface_from_spec(
                 )
             })?
             .build(type_id, params),
-        SurfaceSpec::Image { .. } => Ok(Box::new(Image)),
-        SurfaceSpec::Object => Ok(Box::new(Object)),
-        SurfaceSpec::Probe { .. } => Ok(Box::new(Probe)),
+        SurfaceSpec::Image { .. } => Ok(Box::new(Image::new())),
+        SurfaceSpec::Object => Ok(Box::new(Object::new())),
+        SurfaceSpec::Probe { .. } => Ok(Box::new(Probe::new())),
         SurfaceSpec::Stop { semi_diameter, .. } => Ok(Box::new(Stop::new(*semi_diameter))),
     }
 }
@@ -836,7 +836,7 @@ mod tests {
 
         // Surface indices: 0 = Object, 1 = Mirror 1, 2 = Mirror 2, 3 = Image
         for &mirror_idx in &[1usize, 2usize] {
-            let sd = surfaces[mirror_idx].semi_diameter();
+            let sd = surfaces[mirror_idx].mask().semi_diameter();
             let placement = &placements[mirror_idx];
             assert!(
                 (placement.projected_semi_diameter(sd, v_u) - expected_u).abs() < tol,
@@ -907,11 +907,11 @@ mod tests {
         // Object(0), Probe(1), Conic(2), Conic(3), Image(4) — first physical is index
         // 2.
         let surfaces: Vec<Box<dyn Surface>> = vec![
-            Box::new(Object),
-            Box::new(Probe),
+            Box::new(Object::new()),
+            Box::new(Probe::new()),
             Box::new(Conic::new(1.0, 1.0, 0.0, BoundaryType::Refracting)),
             Box::new(Conic::new(1.0, 1.0, 0.0, BoundaryType::Refracting)),
-            Box::new(Image),
+            Box::new(Image::new()),
         ];
 
         let result = first_physical_surface(&surfaces);
@@ -922,11 +922,11 @@ mod tests {
     fn test_last_physical_surface() {
         // Object(0), Conic(1), Conic(2), Probe(3), Image(4) — last physical is index 2.
         let surfaces: Vec<Box<dyn Surface>> = vec![
-            Box::new(Object),
+            Box::new(Object::new()),
             Box::new(Conic::new(1.0, 1.0, 0.0, BoundaryType::Refracting)),
             Box::new(Conic::new(1.0, 1.0, 0.0, BoundaryType::Refracting)),
-            Box::new(Probe),
-            Box::new(Image),
+            Box::new(Probe::new()),
+            Box::new(Image::new()),
         ];
 
         let result = last_physical_surface(&surfaces);

--- a/crates/cherry-rs/src/core/surfaces/conic.rs
+++ b/crates/cherry-rs/src/core/surfaces/conic.rs
@@ -1,6 +1,6 @@
 use crate::{
     core::{Float, math::vec3::Vec3},
-    specs::surfaces::BoundaryType,
+    specs::surfaces::{BoundaryType, Mask},
 };
 
 use super::{Surface, SurfaceKind};
@@ -8,10 +8,10 @@ use super::{Surface, SurfaceKind};
 /// A conic surface (sphere, paraboloid, hyperboloid, etc.).
 #[derive(Debug, Clone)]
 pub struct Conic {
-    pub semi_diameter: Float,
     pub radius_of_curvature: Float,
     pub conic_constant: Float,
     pub boundary_type: BoundaryType,
+    mask: Mask,
 }
 
 impl Conic {
@@ -22,10 +22,10 @@ impl Conic {
         boundary_type: BoundaryType,
     ) -> Self {
         Self {
-            semi_diameter,
             radius_of_curvature,
             conic_constant,
             boundary_type,
+            mask: Mask::Circular { semi_diameter },
         }
     }
 }
@@ -64,8 +64,8 @@ impl Surface for Conic {
         Vec3::new(dfdx, dfdy, dfdz)
     }
 
-    fn semi_diameter(&self) -> Float {
-        self.semi_diameter
+    fn mask(&self) -> &Mask {
+        &self.mask
     }
 
     fn boundary_type(&self) -> BoundaryType {
@@ -153,12 +153,6 @@ mod tests {
     }
 
     #[test]
-    fn semi_diameter_round_trips() {
-        let conic = Conic::new(12.5, 50.0, 0.0, BoundaryType::Refracting);
-        assert_abs_diff_eq!(conic.semi_diameter(), 12.5);
-    }
-
-    #[test]
     fn boundary_type_round_trips() {
         let r = Conic::new(5.0, 30.0, 0.0, BoundaryType::Refracting);
         let m = Conic::new(5.0, 30.0, 0.0, BoundaryType::Reflecting);
@@ -167,9 +161,23 @@ mod tests {
     }
 
     #[test]
-    fn outside_clear_aperture_default_impl() {
+    fn mask_blocks_ray_outside_aperture() {
         let conic = Conic::new(10.0, Float::INFINITY, 0.0, BoundaryType::Refracting);
-        assert!(!conic.outside_clear_aperture(Vec3::new(5.0, 0.0, 0.0)));
-        assert!(conic.outside_clear_aperture(Vec3::new(11.0, 0.0, 0.0)));
+        assert!(
+            !conic
+                .mask()
+                .outside_clear_aperture(Vec3::new(5.0, 0.0, 0.0))
+        );
+        assert!(
+            conic
+                .mask()
+                .outside_clear_aperture(Vec3::new(11.0, 0.0, 0.0))
+        );
+    }
+
+    #[test]
+    fn mask_preserves_semi_diameter() {
+        let conic = Conic::new(12.5, 50.0, 0.0, BoundaryType::Refracting);
+        assert_abs_diff_eq!(conic.mask().semi_diameter(), 12.5);
     }
 }

--- a/crates/cherry-rs/src/core/surfaces/image.rs
+++ b/crates/cherry-rs/src/core/surfaces/image.rs
@@ -1,13 +1,29 @@
 use crate::{
     core::{Float, math::vec3::Vec3},
-    specs::surfaces::BoundaryType,
+    specs::surfaces::{BoundaryType, Mask},
 };
 
 use super::{Surface, SurfaceKind};
 
 /// The image plane — a flat surface with no optical effect on rays.
 #[derive(Debug, Clone)]
-pub struct Image;
+pub struct Image {
+    mask: Mask,
+}
+
+impl Image {
+    pub fn new() -> Self {
+        Self {
+            mask: Mask::Unbounded,
+        }
+    }
+}
+
+impl Default for Image {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl Surface for Image {
     fn sag(&self, _pos: Vec3) -> Float {
@@ -18,8 +34,8 @@ impl Surface for Image {
         Vec3::new(0.0, 0.0, 1.0)
     }
 
-    fn semi_diameter(&self) -> Float {
-        Float::INFINITY
+    fn mask(&self) -> &Mask {
+        &self.mask
     }
 
     fn boundary_type(&self) -> BoundaryType {

--- a/crates/cherry-rs/src/core/surfaces/mod.rs
+++ b/crates/cherry-rs/src/core/surfaces/mod.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 
 use crate::core::{Float, math::vec3::Vec3, ray::Ray};
 
-use crate::specs::surfaces::BoundaryType;
+use crate::specs::surfaces::{BoundaryType, Mask};
 
 pub mod conic;
 pub mod image;
@@ -46,7 +46,7 @@ pub enum SurfaceKind {
 /// vector. By convention, the vertex of a curved surface lies at the origin of
 /// its local coordinate system. A flat surface lies in the local xy-plane.
 pub trait Surface: std::fmt::Debug + Send + Sync {
-    /// Returns the boundary type (refracting, reflecting, etc.).
+    /// Returns the surface boundary type (refracting, reflecting, etc.).
     fn boundary_type(&self) -> BoundaryType;
 
     /// Finds the intersection of a ray with the surface using Newton-Raphson
@@ -67,15 +67,8 @@ pub trait Surface: std::fmt::Debug + Send + Sync {
         solvers::newton_raphson(ray, self, max_iter)
     }
 
-    /// Determines whether a transverse point is outside the clear aperture of
-    /// the surface.
-    ///
-    /// The axial z-position is ignored.
-    fn outside_clear_aperture(&self, pos: Vec3) -> bool {
-        let r_transv = pos.x() * pos.x() + pos.y() * pos.y();
-        let r_max = self.semi_diameter();
-        r_transv > r_max * r_max
-    }
+    /// Returns a reference to the surface's clear-aperture mask.
+    fn mask(&self) -> &Mask;
 
     /// Returns the radius of curvature of the base sphere of the surface.
     ///
@@ -103,9 +96,6 @@ pub trait Surface: std::fmt::Debug + Send + Sync {
     /// The normal vector is not normalized. Its magnitude is important for
     /// Newton-Raphson ray tracing calculations.
     fn norm(&self, pos: Vec3) -> Vec3;
-
-    /// Returns the semi-diameter of the surface's clear aperture.
-    fn semi_diameter(&self) -> Float;
 
     /// Returns the role of this surface in the optical system.
     ///

--- a/crates/cherry-rs/src/core/surfaces/object.rs
+++ b/crates/cherry-rs/src/core/surfaces/object.rs
@@ -1,13 +1,29 @@
 use crate::{
     core::{Float, math::vec3::Vec3},
-    specs::surfaces::BoundaryType,
+    specs::surfaces::{BoundaryType, Mask},
 };
 
 use super::{Surface, SurfaceKind};
 
 /// The object plane — a flat surface with no optical effect on rays.
 #[derive(Debug, Clone)]
-pub struct Object;
+pub struct Object {
+    mask: Mask,
+}
+
+impl Object {
+    pub fn new() -> Self {
+        Self {
+            mask: Mask::Unbounded,
+        }
+    }
+}
+
+impl Default for Object {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl Surface for Object {
     fn sag(&self, _pos: Vec3) -> Float {
@@ -18,8 +34,8 @@ impl Surface for Object {
         Vec3::new(0.0, 0.0, 1.0)
     }
 
-    fn semi_diameter(&self) -> Float {
-        Float::INFINITY
+    fn mask(&self) -> &Mask {
+        &self.mask
     }
 
     fn boundary_type(&self) -> BoundaryType {

--- a/crates/cherry-rs/src/core/surfaces/probe.rs
+++ b/crates/cherry-rs/src/core/surfaces/probe.rs
@@ -1,13 +1,29 @@
 use crate::{
     core::{Float, math::vec3::Vec3},
-    specs::surfaces::BoundaryType,
+    specs::surfaces::{BoundaryType, Mask},
 };
 
 use super::{Surface, SurfaceKind};
 
 /// A probe surface — a flat, non-optical surface used to measure ray positions.
 #[derive(Debug, Clone)]
-pub struct Probe;
+pub struct Probe {
+    mask: Mask,
+}
+
+impl Probe {
+    pub fn new() -> Self {
+        Self {
+            mask: Mask::Unbounded,
+        }
+    }
+}
+
+impl Default for Probe {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl Surface for Probe {
     fn sag(&self, _pos: Vec3) -> Float {
@@ -18,8 +34,8 @@ impl Surface for Probe {
         Vec3::new(0.0, 0.0, 1.0)
     }
 
-    fn semi_diameter(&self) -> Float {
-        Float::INFINITY
+    fn mask(&self) -> &Mask {
+        &self.mask
     }
 
     fn boundary_type(&self) -> BoundaryType {

--- a/crates/cherry-rs/src/core/surfaces/solvers.rs
+++ b/crates/cherry-rs/src/core/surfaces/solvers.rs
@@ -137,12 +137,7 @@ mod tests {
     #[test]
     fn flat_surface() {
         let ray = Ray::new(Vec3::new(0.0, 0.0, -1.0), Vec3::new(0.0, 0.0, 1.0));
-        let surf = Conic {
-            semi_diameter: 4.0,
-            radius_of_curvature: Float::INFINITY,
-            conic_constant: 0.0,
-            boundary_type: BoundaryType::Refracting,
-        };
+        let surf = Conic::new(4.0, Float::INFINITY, 0.0, BoundaryType::Refracting);
 
         let (p, _) = newton_raphson(&ray, &surf, 1000).unwrap();
 
@@ -154,12 +149,7 @@ mod tests {
         let l = (std::f64::consts::PI as Float / 4.0).sin();
         let m = (std::f64::consts::PI as Float / 4.0).cos();
         let ray = Ray::new(Vec3::new(0.0, 0.0, -1.0), Vec3::new(0.0, l, m));
-        let surf = Conic {
-            semi_diameter: 4.0,
-            radius_of_curvature: -1.0,
-            conic_constant: 0.0,
-            boundary_type: BoundaryType::Refracting,
-        };
+        let surf = Conic::new(4.0, -1.0, 0.0, BoundaryType::Refracting);
 
         let (p, _) = newton_raphson(&ray, &surf, 1000).unwrap();
 

--- a/crates/cherry-rs/src/core/surfaces/stop.rs
+++ b/crates/cherry-rs/src/core/surfaces/stop.rs
@@ -1,6 +1,6 @@
 use crate::{
     core::{Float, math::vec3::Vec3},
-    specs::surfaces::BoundaryType,
+    specs::surfaces::{BoundaryType, Mask},
 };
 
 use super::{Surface, SurfaceKind};
@@ -8,12 +8,14 @@ use super::{Surface, SurfaceKind};
 /// An aperture stop — a flat surface that limits the beam.
 #[derive(Debug, Clone)]
 pub struct Stop {
-    pub semi_diameter: Float,
+    mask: Mask,
 }
 
 impl Stop {
     pub fn new(semi_diameter: Float) -> Self {
-        Self { semi_diameter }
+        Self {
+            mask: Mask::Circular { semi_diameter },
+        }
     }
 }
 
@@ -26,8 +28,8 @@ impl Surface for Stop {
         Vec3::new(0.0, 0.0, 1.0)
     }
 
-    fn semi_diameter(&self) -> Float {
-        self.semi_diameter
+    fn mask(&self) -> &Mask {
+        &self.mask
     }
 
     fn boundary_type(&self) -> BoundaryType {
@@ -61,12 +63,6 @@ mod tests {
     }
 
     #[test]
-    fn semi_diameter_round_trips() {
-        let stop = Stop::new(7.5);
-        assert_abs_diff_eq!(stop.semi_diameter(), 7.5);
-    }
-
-    #[test]
     fn boundary_type_is_noop() {
         let stop = Stop::new(5.0);
         assert!(matches!(stop.boundary_type(), BoundaryType::NoOp));
@@ -79,9 +75,15 @@ mod tests {
     }
 
     #[test]
-    fn outside_clear_aperture_default_impl() {
+    fn mask_blocks_ray_outside_aperture() {
         let stop = Stop::new(5.0);
-        assert!(!stop.outside_clear_aperture(Vec3::new(4.9, 0.0, 0.0)));
-        assert!(stop.outside_clear_aperture(Vec3::new(5.1, 0.0, 0.0)));
+        assert!(!stop.mask().outside_clear_aperture(Vec3::new(4.9, 0.0, 0.0)));
+        assert!(stop.mask().outside_clear_aperture(Vec3::new(5.1, 0.0, 0.0)));
+    }
+
+    #[test]
+    fn mask_preserves_semi_diameter() {
+        let stop = Stop::new(7.5);
+        assert_abs_diff_eq!(stop.mask().semi_diameter(), 7.5);
     }
 }

--- a/crates/cherry-rs/src/lib.rs
+++ b/crates/cherry-rs/src/lib.rs
@@ -148,8 +148,7 @@ pub use specs::{
     aperture::ApertureSpec,
     fields::{FieldSpec, PupilSampling},
     gaps::{ConstantRefractiveIndex, GapSpec, RefractiveIndexSpec},
-    surfaces::BoundaryType,
-    surfaces::SurfaceSpec,
+    surfaces::{BoundaryType, Mask, SurfaceSpec},
 };
 pub use views::{
     components::{Component, components_view},

--- a/crates/cherry-rs/src/specs/surfaces.rs
+++ b/crates/cherry-rs/src/specs/surfaces.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::core::{Float, math::linalg::rotations::Rotation3D};
+use crate::core::{Float, math::linalg::rotations::Rotation3D, math::vec3::Vec3};
 
 /// Specifies the type of interaction of light with a sequential model surface.
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
@@ -8,6 +8,19 @@ pub enum BoundaryType {
     Refracting,
     Reflecting,
     NoOp,
+}
+
+/// Specifies the clear aperture of a surface.
+///
+/// This is referred to as a "mask" to avoid confusion with
+/// [`specs::apertures::ApertureSpec`] which specifies the physical aperture of
+/// the system.
+///
+/// `Unbounded` surfaces (Object, Image, Probe) pass all rays unconditionally.
+#[derive(Debug, Clone, Copy)]
+pub enum Mask {
+    Circular { semi_diameter: Float },
+    Unbounded,
 }
 
 /// Specifies a surface in a sequential optical system.
@@ -47,11 +60,29 @@ pub enum SurfaceSpec {
         semi_diameter: Float,
         rotation: Rotation3D,
     },
-    // Toric {
-    //     semi_diameter: Float,
-    //     radius_of_curvature_vert: Float,
-    //     radius_of_curvature_horz: Float,
-    //     conic_constant: Float,
-    //     surf_type: BoundaryType,
-    // },
+}
+
+impl Mask {
+    /// Returns `true` if `pos` lies outside the clear aperture. The axial
+    /// z-component of `pos` is ignored.
+    pub fn outside_clear_aperture(&self, pos: Vec3) -> bool {
+        match self {
+            Mask::Circular { semi_diameter } => {
+                let r_transv = pos.x() * pos.x() + pos.y() * pos.y();
+                let r_max = *semi_diameter;
+                r_transv > r_max * r_max
+            }
+            Mask::Unbounded => false,
+        }
+    }
+
+    /// Returns the semi-diameter of the mask.
+    ///
+    /// Returns [`Float::INFINITY`] for [`Mask::Unbounded`].
+    pub fn semi_diameter(&self) -> Float {
+        match self {
+            Mask::Circular { semi_diameter } => *semi_diameter,
+            Mask::Unbounded => Float::INFINITY,
+        }
+    }
 }

--- a/crates/cherry-rs/src/views/cross_section.rs
+++ b/crates/cherry-rs/src/views/cross_section.rs
@@ -146,7 +146,7 @@ fn build_plane_geometry(
             }
             Component::Stop { stop_idx } => {
                 let z = placements[*stop_idx].position.z();
-                let sd = surfaces[*stop_idx].semi_diameter();
+                let sd = surfaces[*stop_idx].mask().semi_diameter();
                 elements.push(DrawElement::Stop {
                     z,
                     half_gap: sd,
@@ -286,7 +286,7 @@ fn sample_surface(
     axis: GlobalAxis,
     n_pts: usize,
 ) -> Vec<[f64; 2]> {
-    let sd = surf.semi_diameter();
+    let sd = surf.mask().semi_diameter();
     if !sd.is_finite() || sd <= 0.0 || n_pts < 2 {
         return Vec::new();
     }

--- a/crates/cherry-rs/src/views/paraxial.rs
+++ b/crates/cherry-rs/src/views/paraxial.rs
@@ -597,7 +597,7 @@ impl ParaxialSubView {
             .zip(placements.iter())
             .zip(per_surf_v.iter())
             .map(|((s, p), &v)| {
-                (p.projected_semi_diameter(s.semi_diameter(), v) / last_surface_height).abs()
+                (p.projected_semi_diameter(s.mask().semi_diameter(), v) / last_surface_height).abs()
             })
             .collect();
 
@@ -734,7 +734,7 @@ impl ParaxialSubView {
             return Ok(Pupil {
                 location: 0.0,
                 semi_diameter: placements[1]
-                    .projected_semi_diameter(surfaces[1].semi_diameter(), per_surf_v[1]),
+                    .projected_semi_diameter(surfaces[1].mask().semi_diameter(), per_surf_v[1]),
             });
         }
 
@@ -785,7 +785,7 @@ impl ParaxialSubView {
         if last_physical_surface_id == *aperture_stop {
             return Ok(Pupil {
                 location: 0.0,
-                semi_diameter: surfaces[last_physical_surface_id].semi_diameter(),
+                semi_diameter: surfaces[last_physical_surface_id].mask().semi_diameter(),
             });
         }
 
@@ -866,7 +866,7 @@ impl ParaxialSubView {
             .zip(pseudo_marginal_ray.iter_surfaces())
             .zip(per_surf_v.iter())
             .map(|(((s, p), rays), &v)| {
-                p.projected_semi_diameter(s.semi_diameter(), v) / rays[0].height
+                p.projected_semi_diameter(s.mask().semi_diameter(), v) / rays[0].height
             })
             .collect();
         let scale_factor = ratios[*aperture_stop];

--- a/crates/cherry-rs/src/views/ray_trace_3d/trace.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/trace.rs
@@ -68,7 +68,7 @@ pub fn trace(sequential_submodel: &mut SequentialSubModelIter, mut rays: Vec<Ray
             };
 
             // Terminate ray if intersection is outside the clear aperture of surface
-            if surf.outside_clear_aperture(pos) {
+            if surf.mask().outside_clear_aperture(pos) {
                 terminated[ray_id] = surface_id;
                 reason_for_termination.insert(ray_id, "Ray outside clear aperture".to_string());
                 warn!(

--- a/crates/cherry-rs/tests/custom_surface_registry.rs
+++ b/crates/cherry-rs/tests/custom_surface_registry.rs
@@ -1,12 +1,12 @@
 use cherry_rs::{
-    BoundaryType, GapSpec, Rotation3D, SequentialModel, Surface, SurfaceRegistry, SurfaceSpec,
-    Vec3, n,
+    BoundaryType, GapSpec, Mask, Rotation3D, SequentialModel, Surface, SurfaceRegistry,
+    SurfaceSpec, Vec3, n,
 };
 use serde_json::json;
 
 #[derive(Debug)]
 struct FlatNoOp {
-    semi_diameter: f64,
+    mask: Mask,
 }
 
 impl Surface for FlatNoOp {
@@ -22,8 +22,8 @@ impl Surface for FlatNoOp {
         Vec3::new(0.0, 0.0, 1.0)
     }
 
-    fn semi_diameter(&self) -> f64 {
-        self.semi_diameter
+    fn mask(&self) -> &Mask {
+        &self.mask
     }
 }
 
@@ -38,7 +38,9 @@ fn flat_no_op_constructor(params: &serde_json::Value) -> anyhow::Result<Box<dyn 
     let sd = params["semi_diameter"]
         .as_f64()
         .ok_or_else(|| anyhow::anyhow!("missing semi_diameter"))?;
-    Ok(Box::new(FlatNoOp { semi_diameter: sd }))
+    Ok(Box::new(FlatNoOp {
+        mask: Mask::Circular { semi_diameter: sd },
+    }))
 }
 
 #[test]
@@ -123,5 +125,5 @@ fn params_are_forwarded_to_constructor() {
         .expect("model should build");
 
     // The custom surface is at index 1.
-    assert_eq!(model.surfaces()[1].semi_diameter(), 7.5);
+    assert_eq!(model.surfaces()[1].mask().semi_diameter(), 7.5);
 }

--- a/crates/cherry-rs/tests/from_surfaces.rs
+++ b/crates/cherry-rs/tests/from_surfaces.rs
@@ -1,7 +1,17 @@
-use cherry_rs::{BoundaryType, GapSpec, Rotation3D, SequentialModel, Surface, Vec3, n};
+use cherry_rs::{BoundaryType, GapSpec, Mask, Rotation3D, SequentialModel, Surface, Vec3, n};
 
 #[derive(Debug)]
-struct FlatNoOp;
+struct FlatNoOp {
+    mask: Mask,
+}
+
+impl FlatNoOp {
+    fn new() -> Self {
+        Self {
+            mask: Mask::Unbounded,
+        }
+    }
+}
 
 impl Surface for FlatNoOp {
     fn boundary_type(&self) -> BoundaryType {
@@ -16,8 +26,8 @@ impl Surface for FlatNoOp {
         Vec3::new(0.0, 0.0, 1.0)
     }
 
-    fn semi_diameter(&self) -> f64 {
-        f64::INFINITY
+    fn mask(&self) -> &Mask {
+        &self.mask
     }
 }
 
@@ -31,8 +41,8 @@ fn air_gap(thickness: f64) -> GapSpec {
 #[test]
 fn from_surfaces_constructs_minimal_model() {
     let surfaces: Vec<(Box<dyn Surface>, Rotation3D)> = vec![
-        (Box::new(FlatNoOp), Rotation3D::None),
-        (Box::new(FlatNoOp), Rotation3D::None),
+        (Box::new(FlatNoOp::new()), Rotation3D::None),
+        (Box::new(FlatNoOp::new()), Rotation3D::None),
     ];
     let gaps = vec![air_gap(10.0)];
     let wavelengths = vec![0.587];
@@ -43,8 +53,8 @@ fn from_surfaces_constructs_minimal_model() {
 #[test]
 fn from_surfaces_wrong_gap_count_errors() {
     let surfaces: Vec<(Box<dyn Surface>, Rotation3D)> = vec![
-        (Box::new(FlatNoOp), Rotation3D::None),
-        (Box::new(FlatNoOp), Rotation3D::None),
+        (Box::new(FlatNoOp::new()), Rotation3D::None),
+        (Box::new(FlatNoOp::new()), Rotation3D::None),
     ];
     let gaps = vec![air_gap(10.0), air_gap(5.0)]; // one too many
     let wavelengths = vec![0.587];
@@ -55,8 +65,8 @@ fn from_surfaces_wrong_gap_count_errors() {
 #[test]
 fn from_surfaces_wavelengths_are_preserved() {
     let surfaces: Vec<(Box<dyn Surface>, Rotation3D)> = vec![
-        (Box::new(FlatNoOp), Rotation3D::None),
-        (Box::new(FlatNoOp), Rotation3D::None),
+        (Box::new(FlatNoOp::new()), Rotation3D::None),
+        (Box::new(FlatNoOp::new()), Rotation3D::None),
     ];
     let gaps = vec![air_gap(10.0)];
     let wavelengths = vec![0.486, 0.587, 0.656];


### PR DESCRIPTION
This change moves the clear aperture logic from the Surface trait into an enum called `Mask`. It is intended as an API guard to support arbitrary clear apertures in the future, such as square optics, annular apertures, etc.