### PR TITLE
feat: Allow users to specify the stop surface

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,11 +5,18 @@ Thank you so much for considering a contribution to Cherry. I really appreciate 
 ## Table of Contents
 
 1. [Before Opening a Pull Request](#before-opening-a-pull-request)
-2. [Development](#development)
+2. [Can I use AI?](#can-i-use-ai)
+3. [Development](#development)
 
 ## Before Opening a Pull Request
 
 Your ideas and suggestions are always welcome! Before working on a new feature, I would first like to know whether it fits within the scope of Cherry. I ask that contributors [create a feature request](https://github.com/kmdouglass/cherry/discussions/new?category=ideas) so that we can discuss your idea.
+
+## Can I use AI?
+
+Yes! You are welcome to use AI tools such as Claude Code to implement a feature or bug fix. All changes, whether written by human or AI, must still be reviewed by a human in a pull request, and I expect you to have followed best practices: format the code, run the linter, and ensure that all tests are passing. I also expect that the changes fit into the overall architecture of the codebase itself with minimal friction.
+
+If you are unsure about an implementation detail, please [start a discussion](https://github.com/kmdouglass/cherry/discussions/new?category=q-a) and ask.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Cherry focuses on accessibility and interactivity to answer these questions effe
 
 ### Is Cherry for me?
 
-Cherry was designed primarily for microscopists and researchers working in optics labs on tabletop setups. As such, its goals are different from other optics software packages.
+Cherry was designed primarily for microscopists, researchers, and educators working in optics labs on tabletop setups. As such, its goals are different from other optics software packages.
 
 - If you want an open source and comprehensive Python tool for general purpose optical design, including non-sequential ray tracing, consider using [Optiland](https://github.com/optiland/optiland).
 - If you want an open source, practical, and lightweight ray tracing system in Python, consider [RayOptics](https://github.com/mjhoptics/ray-optics), which heavily inspired Cherry's initial design.
@@ -55,22 +55,29 @@ Cherry was designed primarily for microscopists and researchers working in optic
 - If you want non-sequential ray tracing for graphics rendering, then Cherry (and probably optical design software in general) is not for you.
 - If you want professional lens and system design capabilities, consider industry standards such as [CODE V](https://www.keysight.com/us/en/products/software/optical-solutions-software/optical-design-solutions/codev.html), [Zemax OpticStudio](https://www.ansys.com/products/optics/ansys-zemax-opticstudio), [OSLO](https://lambdares.com/oslo), or [FRED](https://photonengr.com/).
 
-If you want an interactive tool that performs basic optical system calculations, produces real-time visualizations, and allows you to easily share designs with others, then Cherry might be for you. And if you code in Rust and want a library for optical systems design, then again Cherry might be for you.
+Cherry might be for you if:
+
+- you want an interactive tool that performs basic optical system calculations, produces real-time visualizations, and allows you to easily share designs with others,
+- you are an educator and want a free application for teaching optical engineering concepts, or
+- you code in Rust and want a library for optical systems design.
 
 ## Roadmap
 
 ### Now
 
-- [ ] Refactor the core to support the next set of features
-- [ ] Add a solve system to enforce active constraints on a design
+- [ ] Refactor the core to support the next set of features and better future-proof the API
+  - [X] User-specified stop
+  - [ ] Serialization layer moved into a crate feature
+  - [ ] Flat and spherical ray-surface intersection solvers
+- [ ] Solve system to enforce active constraints on a design
 
 ### Next
 
-- [ ] Add a lens view for manipulating systems by lens instead of by surface
-- [ ] Add tip/tilts/decenters to individual lenses
+- [ ] Lens view for manipulating systems by lens instead of by surface
+- [ ] Tip/tilts/decenters on individual surfaces and lenses
 - [ ] Encode designs into URLs and enable sharing via tiny URLs
-- [ ] **Help Wanted** Write a mdbook to serve as the app's user documentation
-- [ ] **Help Wanted** Add coordinate axes, the optical axis, and other guides to the cross-section view
+- [ ] **Help Wanted** mdbook to serve as the app's user documentation
+- [ ] **Help Wanted** Annotate coordinate axes, the optical axis, and other elements in the cross-section view
 
 ### Later
 

--- a/crates/cherry-rs/src/core/sequential_model.rs
+++ b/crates/cherry-rs/src/core/sequential_model.rs
@@ -14,7 +14,7 @@ use crate::core::{
     },
     placement::Placement,
     refractive_index::RefractiveIndex,
-    surfaces::{Conic, Image, Object, Probe, Stop, Surface, SurfaceRegistry},
+    surfaces::{Conic, Image, Iris, Object, Probe, Surface, SurfaceKind, SurfaceRegistry},
 };
 use crate::specs::{
     gaps::GapSpec,
@@ -45,6 +45,9 @@ pub struct SequentialModel {
 
     // The cursor forward direction at each surface vertex.
     axis_directions: Vec<Vec3>,
+
+    /// User-specified aperture stop surface index, or `None` for auto-derived.
+    stop_surface: Option<usize>,
 }
 
 /// A submodel of a sequential optical system.
@@ -218,7 +221,7 @@ pub(crate) fn propagate_tangential_vec(
 /// Returns the index of the first physical surface in the system.
 ///
 /// A physical surface is one that has a finite semi-diameter,
-/// i.e., a Conic or Stop. Object, Image, and Probe surfaces are excluded.
+/// i.e., a Conic or Iris. Object, Image, and Probe surfaces are excluded.
 pub(crate) fn first_physical_surface(surfaces: &[Box<dyn Surface>]) -> Option<usize> {
     surfaces
         .iter()
@@ -228,7 +231,7 @@ pub(crate) fn first_physical_surface(surfaces: &[Box<dyn Surface>]) -> Option<us
 /// Returns the index of the last physical surface in the system.
 ///
 /// A physical surface is one that limits the has a finite semi-diameter,
-/// i.e., a Conic or Stop. Object, Image, and Probe surfaces are excluded.
+/// i.e., a Conic or Iris. Object, Image, and Probe surfaces are excluded.
 pub fn last_physical_surface(surfaces: &[Box<dyn Surface>]) -> Option<usize> {
     surfaces
         .iter()
@@ -260,18 +263,24 @@ impl SequentialModel {
     /// * `gap_specs` - The specifications for the gaps between the surfaces.
     /// * `surface_specs` - The specifications for the surfaces in the system.
     /// * `wavelengths` - The wavelengths at which to model the system.
-    ///
-    /// # Returns
-    /// A new sequential model.
+    /// * `stop_surface` - Optional index of the user-designated aperture stop.
+    ///   `None` uses the paraxial heuristic. `Some(i)` requires `i` to refer to
+    ///   a `Conic` or `Iris` surface that is neither the object nor the image
+    ///   surface; otherwise an error is returned.
     pub fn new(
         gap_specs: &[GapSpec],
         surface_specs: &[SurfaceSpec],
         wavelengths: &[Float],
+        stop_surface: Option<usize>,
     ) -> Result<Self> {
         Self::validate_specs(gap_specs, wavelengths)?;
 
         let (surfaces, placements, axis_directions) =
             Self::surf_specs_to_surfs(surface_specs, gap_specs, None)?;
+
+        if let Some(i) = stop_surface {
+            Self::validate_stop_surface(&surfaces, i)?;
+        }
 
         let mut models: Vec<SequentialSubModelBase> = Vec::new();
         for &wavelength in wavelengths.iter() {
@@ -285,6 +294,7 @@ impl SequentialModel {
             submodels: models,
             wavelengths: wavelengths.to_vec(),
             axis_directions,
+            stop_surface,
         })
     }
 
@@ -303,6 +313,7 @@ impl SequentialModel {
         surfaces: Vec<(Box<dyn Surface>, Rotation3D)>,
         gap_specs: &[GapSpec],
         wavelengths: &[Float],
+        stop_surface: Option<usize>,
     ) -> Result<Self> {
         if surfaces.len() != gap_specs.len() + 1 {
             return Err(anyhow!(
@@ -318,6 +329,10 @@ impl SequentialModel {
         let (placements, axis_directions) =
             Self::build_placements_and_directions(&surfs, &rotations, gap_specs);
 
+        if let Some(i) = stop_surface {
+            Self::validate_stop_surface(&surfs, i)?;
+        }
+
         let mut models: Vec<SequentialSubModelBase> = Vec::new();
         for &wavelength in wavelengths.iter() {
             let gaps = Self::gap_specs_to_gaps(gap_specs, wavelength)?;
@@ -330,6 +345,7 @@ impl SequentialModel {
             submodels: models,
             wavelengths: wavelengths.to_vec(),
             axis_directions,
+            stop_surface,
         })
     }
 
@@ -362,7 +378,33 @@ impl SequentialModel {
             submodels: models,
             wavelengths: wavelengths.to_vec(),
             axis_directions,
+            stop_surface: None,
         })
+    }
+
+    /// Validates that index `i` is an eligible aperture stop surface.
+    fn validate_stop_surface(surfaces: &[Box<dyn Surface>], i: usize) -> Result<()> {
+        let last = surfaces.len().saturating_sub(1);
+        if i == 0 || i >= last {
+            return Err(anyhow!(
+                "stop surface index {i} is out of range; \
+                 must be between 1 and {} (inclusive)",
+                last - 1
+            ));
+        }
+        match surfaces[i].surface_kind() {
+            SurfaceKind::Conic | SurfaceKind::Iris => Ok(()),
+            kind => Err(anyhow!(
+                "surface {i} ({kind:?}) is not eligible as the aperture stop; \
+                 only Conic and Iris surfaces are allowed"
+            )),
+        }
+    }
+
+    /// Returns the user-specified aperture stop surface index, or `None` if the
+    /// stop is derived automatically from the paraxial ray trace.
+    pub fn stop_surface(&self) -> Option<usize> {
+        self.stop_surface
     }
 
     /// Returns the largest semi-diameter of any surface in the system.
@@ -691,7 +733,7 @@ fn rotation_from_spec(spec: &SurfaceSpec) -> Rotation3D {
         | SurfaceSpec::Custom { rotation, .. }
         | SurfaceSpec::Image { rotation }
         | SurfaceSpec::Probe { rotation }
-        | SurfaceSpec::Stop { rotation, .. } => rotation.clone(),
+        | SurfaceSpec::Iris { rotation, .. } => rotation.clone(),
         SurfaceSpec::Object => Rotation3D::None,
     }
 }
@@ -730,7 +772,7 @@ pub(crate) fn surface_from_spec(
         SurfaceSpec::Image { .. } => Ok(Box::new(Image::new())),
         SurfaceSpec::Object => Ok(Box::new(Object::new())),
         SurfaceSpec::Probe { .. } => Ok(Box::new(Probe::new())),
-        SurfaceSpec::Stop { semi_diameter, .. } => Ok(Box::new(Stop::new(*semi_diameter))),
+        SurfaceSpec::Iris { semi_diameter, .. } => Ok(Box::new(Iris::new(*semi_diameter))),
     }
 }
 
@@ -995,5 +1037,93 @@ mod tests {
             assert_abs_diff_eq!(axis.y(), 0.0, epsilon = 1e-12);
             assert_abs_diff_eq!(axis.z(), 1.0, epsilon = 1e-12);
         }
+    }
+
+    // --- stop_surface validation tests ---
+    //
+    // System layout for these tests:
+    //   0: Object
+    //   1: Conic   (eligible)
+    //   2: Probe   (ineligible)
+    //   3: Iris    (eligible)
+    //   4: Image
+    fn stop_validation_specs() -> (Vec<GapSpec>, Vec<SurfaceSpec>) {
+        let air = n!(1.0);
+        let glass = n!(1.5);
+        let gaps = vec![
+            GapSpec {
+                thickness: f64::INFINITY,
+                refractive_index: air.clone(),
+            },
+            GapSpec {
+                thickness: 5.0,
+                refractive_index: glass,
+            },
+            GapSpec {
+                thickness: 1.0,
+                refractive_index: air.clone(),
+            },
+            GapSpec {
+                thickness: 5.0,
+                refractive_index: air,
+            },
+        ];
+        let surfaces = vec![
+            SurfaceSpec::Object,
+            SurfaceSpec::Conic {
+                semi_diameter: 10.0,
+                radius_of_curvature: 50.0,
+                conic_constant: 0.0,
+                surf_type: BoundaryType::Refracting,
+                rotation: Rotation3D::None,
+            },
+            SurfaceSpec::Probe {
+                rotation: Rotation3D::None,
+            },
+            SurfaceSpec::Iris {
+                semi_diameter: 5.0,
+                rotation: Rotation3D::None,
+            },
+            SurfaceSpec::Image {
+                rotation: Rotation3D::None,
+            },
+        ];
+        (gaps, surfaces)
+    }
+
+    #[test]
+    fn stop_surface_conic_is_accepted() {
+        let (gaps, surfaces) = stop_validation_specs();
+        assert!(SequentialModel::new(&gaps, &surfaces, &[0.5876], Some(1)).is_ok());
+    }
+
+    #[test]
+    fn stop_surface_iris_is_accepted() {
+        let (gaps, surfaces) = stop_validation_specs();
+        assert!(SequentialModel::new(&gaps, &surfaces, &[0.5876], Some(3)).is_ok());
+    }
+
+    #[test]
+    fn stop_surface_object_is_rejected() {
+        let (gaps, surfaces) = stop_validation_specs();
+        assert!(SequentialModel::new(&gaps, &surfaces, &[0.5876], Some(0)).is_err());
+    }
+
+    #[test]
+    fn stop_surface_image_is_rejected() {
+        let (gaps, surfaces) = stop_validation_specs();
+        assert!(SequentialModel::new(&gaps, &surfaces, &[0.5876], Some(4)).is_err());
+    }
+
+    #[test]
+    fn stop_surface_out_of_range_is_rejected() {
+        let (gaps, surfaces) = stop_validation_specs();
+        assert!(SequentialModel::new(&gaps, &surfaces, &[0.5876], Some(99)).is_err());
+    }
+
+    #[test]
+    fn stop_surface_probe_is_rejected() {
+        let (gaps, surfaces) = stop_validation_specs();
+        assert!(SequentialModel::new(&gaps, &surfaces, &[0.5876], Some(2)).is_err());
     }
 }

--- a/crates/cherry-rs/src/core/surfaces/iris.rs
+++ b/crates/cherry-rs/src/core/surfaces/iris.rs
@@ -5,13 +5,13 @@ use crate::{
 
 use super::{Surface, SurfaceKind};
 
-/// An aperture stop — a flat surface that limits the beam.
+/// A physical iris — a flat surface that clips rays by a circular aperture.
 #[derive(Debug, Clone)]
-pub struct Stop {
+pub struct Iris {
     mask: Mask,
 }
 
-impl Stop {
+impl Iris {
     pub fn new(semi_diameter: Float) -> Self {
         Self {
             mask: Mask::Circular { semi_diameter },
@@ -19,7 +19,7 @@ impl Stop {
     }
 }
 
-impl Surface for Stop {
+impl Surface for Iris {
     fn sag(&self, _pos: Vec3) -> Float {
         0.0
     }
@@ -37,7 +37,7 @@ impl Surface for Stop {
     }
 
     fn surface_kind(&self) -> SurfaceKind {
-        SurfaceKind::Stop
+        SurfaceKind::Iris
     }
 }
 
@@ -48,14 +48,14 @@ mod tests {
 
     #[test]
     fn sag_and_norm_are_always_flat() {
-        let stop = Stop::new(5.0);
+        let iris = Iris::new(5.0);
         for pos in [
             Vec3::new(0.0, 0.0, 0.0),
             Vec3::new(3.0, 4.0, 0.0),
             Vec3::new(-1.0, 2.5, 0.0),
         ] {
-            assert_abs_diff_eq!(stop.sag(pos), 0.0);
-            let norm = stop.norm(pos);
+            assert_abs_diff_eq!(iris.sag(pos), 0.0);
+            let norm = iris.norm(pos);
             assert_abs_diff_eq!(norm.x(), 0.0);
             assert_abs_diff_eq!(norm.y(), 0.0);
             assert_abs_diff_eq!(norm.z(), 1.0);
@@ -64,26 +64,26 @@ mod tests {
 
     #[test]
     fn boundary_type_is_noop() {
-        let stop = Stop::new(5.0);
-        assert!(matches!(stop.boundary_type(), BoundaryType::NoOp));
+        let iris = Iris::new(5.0);
+        assert!(matches!(iris.boundary_type(), BoundaryType::NoOp));
     }
 
     #[test]
     fn roc_default_is_infinity() {
-        let stop = Stop::new(5.0);
-        assert!(stop.roc(0.0).is_infinite());
+        let iris = Iris::new(5.0);
+        assert!(iris.roc(0.0).is_infinite());
     }
 
     #[test]
     fn mask_blocks_ray_outside_aperture() {
-        let stop = Stop::new(5.0);
-        assert!(!stop.mask().outside_clear_aperture(Vec3::new(4.9, 0.0, 0.0)));
-        assert!(stop.mask().outside_clear_aperture(Vec3::new(5.1, 0.0, 0.0)));
+        let iris = Iris::new(5.0);
+        assert!(!iris.mask().outside_clear_aperture(Vec3::new(4.9, 0.0, 0.0)));
+        assert!(iris.mask().outside_clear_aperture(Vec3::new(5.1, 0.0, 0.0)));
     }
 
     #[test]
     fn mask_preserves_semi_diameter() {
-        let stop = Stop::new(7.5);
-        assert_abs_diff_eq!(stop.mask().semi_diameter(), 7.5);
+        let iris = Iris::new(7.5);
+        assert_abs_diff_eq!(iris.mask().semi_diameter(), 7.5);
     }
 }

--- a/crates/cherry-rs/src/core/surfaces/mod.rs
+++ b/crates/cherry-rs/src/core/surfaces/mod.rs
@@ -7,17 +7,17 @@ use crate::specs::surfaces::{BoundaryType, Mask};
 
 pub mod conic;
 pub mod image;
+pub mod iris;
 pub mod object;
 pub mod probe;
 pub mod solvers;
-pub mod stop;
 pub mod surface_registry;
 
 pub use conic::Conic;
 pub use image::Image;
+pub use iris::Iris;
 pub use object::Object;
 pub use probe::Probe;
-pub use stop::Stop;
 pub use surface_registry::{SurfaceConstructor, SurfaceRegistry};
 
 /// The role of a surface in the optical system.
@@ -32,9 +32,9 @@ pub use surface_registry::{SurfaceConstructor, SurfaceRegistry};
 pub enum SurfaceKind {
     Conic,
     Image,
+    Iris,
     Object,
     Probe,
-    Stop,
     Custom,
 }
 
@@ -100,7 +100,7 @@ pub trait Surface: std::fmt::Debug + Send + Sync {
     /// Returns the role of this surface in the optical system.
     ///
     /// Used by rendering and analysis code to distinguish Object, Image, Probe,
-    /// Conic, Stop, and Custom surfaces.
+    /// Conic, Iris, and Custom surfaces.
     ///
     /// User-defined surfaces should return [`SurfaceKind::Custom`].
     fn surface_kind(&self) -> SurfaceKind {

--- a/crates/cherry-rs/src/examples/biconvex_lens_finite_object.rs
+++ b/crates/cherry-rs/src/examples/biconvex_lens_finite_object.rs
@@ -45,5 +45,5 @@ pub fn sequential_model(
 
     let surfaces = vec![surf_0, surf_1, surf_2, surf_3];
 
-    SequentialModel::new(&gaps, &surfaces, wavelengths).unwrap()
+    SequentialModel::new(&gaps, &surfaces, wavelengths, None).unwrap()
 }

--- a/crates/cherry-rs/src/examples/concave_mirror.rs
+++ b/crates/cherry-rs/src/examples/concave_mirror.rs
@@ -30,5 +30,5 @@ pub fn sequential_model(
     };
     let surfaces = vec![surf_0, surf_1, surf_2];
 
-    SequentialModel::new(&gaps, &surfaces, wavelengths).unwrap()
+    SequentialModel::new(&gaps, &surfaces, wavelengths, None).unwrap()
 }

--- a/crates/cherry-rs/src/examples/convexplano_lens.rs
+++ b/crates/cherry-rs/src/examples/convexplano_lens.rs
@@ -42,5 +42,5 @@ pub fn sequential_model(
     };
     let surfaces = vec![surf_0, surf_1, surf_2, surf_3];
 
-    SequentialModel::new(&gaps, &surfaces, wavelengths).unwrap()
+    SequentialModel::new(&gaps, &surfaces, wavelengths, None).unwrap()
 }

--- a/crates/cherry-rs/src/examples/f_theta_scan_lens.rs
+++ b/crates/cherry-rs/src/examples/f_theta_scan_lens.rs
@@ -52,7 +52,7 @@ pub fn sequential_model(
     let gaps = vec![gap_0, gap_1, gap_2, gap_3, gap_4, gap_5, gap_6, gap_7];
 
     let surf_0 = SurfaceSpec::Object;
-    let surf_1 = SurfaceSpec::Stop {
+    let surf_1 = SurfaceSpec::Iris {
         semi_diameter: 0.5,
         rotation: Rotation3D::None,
     };
@@ -105,7 +105,7 @@ pub fn sequential_model(
         surf_0, surf_1, surf_2, surf_3, surf_4, surf_5, surf_6, surf_7, surf_8,
     ];
 
-    SequentialModel::new(&gaps, &surfaces, wavelengths).unwrap()
+    SequentialModel::new(&gaps, &surfaces, wavelengths, None).unwrap()
 }
 
 pub fn field_specs() -> Vec<FieldSpec> {

--- a/crates/cherry-rs/src/examples/mirrors_figure_z.rs
+++ b/crates/cherry-rs/src/examples/mirrors_figure_z.rs
@@ -55,5 +55,5 @@ pub fn sequential_model(
     };
     let surfaces = vec![surf_0, surf_1, surf_2, surf_3];
 
-    SequentialModel::new(&gaps, &surfaces, wavelengths).unwrap()
+    SequentialModel::new(&gaps, &surfaces, wavelengths, None).unwrap()
 }

--- a/crates/cherry-rs/src/examples/petzval_lens.rs
+++ b/crates/cherry-rs/src/examples/petzval_lens.rs
@@ -69,7 +69,7 @@ pub fn sequential_model() -> SequentialModel {
         surf_type: BoundaryType::Refracting,
         rotation: Rotation3D::None,
     };
-    let surf_4 = SurfaceSpec::Stop {
+    let surf_4 = SurfaceSpec::Iris {
         semi_diameter: 16.631,
         rotation: Rotation3D::None,
     };
@@ -117,7 +117,7 @@ pub fn sequential_model() -> SequentialModel {
 
     let wavelengths: Vec<f64> = vec![0.567];
 
-    SequentialModel::new(&gaps, &surfaces, &wavelengths).unwrap()
+    SequentialModel::new(&gaps, &surfaces, &wavelengths, None).unwrap()
 }
 
 pub fn field_specs() -> Vec<FieldSpec> {

--- a/crates/cherry-rs/src/gui/compute.rs
+++ b/crates/cherry-rs/src/gui/compute.rs
@@ -120,7 +120,12 @@ fn run_compute(
         Err(e) => return ResultPackage::error(req.id, format!("Specs error: {e}")),
     };
 
-    let seq = match SequentialModel::new(&parsed.gaps, &parsed.surfaces, &parsed.wavelengths) {
+    let seq = match SequentialModel::new(
+        &parsed.gaps,
+        &parsed.surfaces,
+        &parsed.wavelengths,
+        req.specs.stop_surface,
+    ) {
         Ok(s) => s,
         Err(e) => return ResultPackage::error(req.id, format!("Model error: {e}")),
     };
@@ -207,7 +212,7 @@ fn build_surface_descs(seq: &SequentialModel) -> Vec<SurfaceDesc> {
                 SurfaceKind::Image => "Image",
                 SurfaceKind::Object => "Object",
                 SurfaceKind::Probe => "Probe",
-                SurfaceKind::Stop => "Stop",
+                SurfaceKind::Iris => "Iris",
                 SurfaceKind::Custom => "Custom",
             };
             SurfaceDesc {
@@ -250,7 +255,7 @@ mod tests {
         let parsed = convert::convert_specs(&specs).expect("convert");
         #[cfg(feature = "ri-info")]
         let parsed = convert::convert_specs(&specs, &Default::default()).expect("convert");
-        let seq = SequentialModel::new(&parsed.gaps, &parsed.surfaces, &parsed.wavelengths)
+        let seq = SequentialModel::new(&parsed.gaps, &parsed.surfaces, &parsed.wavelengths, None)
             .expect("model");
         let descs = build_surface_descs(&seq);
 

--- a/crates/cherry-rs/src/gui/convert.rs
+++ b/crates/cherry-rs/src/gui/convert.rs
@@ -102,10 +102,10 @@ fn convert_specs_inner(
                     rotation,
                 }
             }
-            SurfaceVariant::Stop => {
+            SurfaceVariant::Iris => {
                 let semi_diameter = parse_float(&row.semi_diameter)
                     .with_context(|| format!("surface {i}: semi-diameter"))?;
-                SurfaceSpec::Stop {
+                SurfaceSpec::Iris {
                     semi_diameter,
                     rotation: Rotation3D::None,
                 }

--- a/crates/cherry-rs/src/gui/examples.rs
+++ b/crates/cherry-rs/src/gui/examples.rs
@@ -47,6 +47,7 @@ pub fn mirrors_figure_z() -> SystemSpecs {
         n_fan_rays: 65,
         background_n: "1.0".into(),
         background_material_key: None,
+        stop_surface: None,
     }
 }
 
@@ -58,7 +59,7 @@ pub fn petzval_lens() -> SystemSpecs {
             SurfaceRow::new_conic("28.478", "99.56266", "0.0", "13.0", "1.5168"),
             SurfaceRow::new_conic("26.276", "-86.84002", "0.0", "4.0", "1.6645"),
             SurfaceRow::new_conic("21.02", "-1187.63858", "0.0", "40.0", "1.0"),
-            SurfaceRow::new_stop("16.631", "40.0", "1.0"),
+            SurfaceRow::new_iris("16.631", "40.0", "1.0"),
             SurfaceRow::new_conic("20.543", "57.47491", "0.0", "12.0", "1.6074"),
             SurfaceRow::new_conic("20.074", "-54.61685", "0.0", "3.0", "1.6727"),
             SurfaceRow::new_conic("20.074", "-614.68633", "0.0", "46.8221", "1.0"),
@@ -88,6 +89,7 @@ pub fn petzval_lens() -> SystemSpecs {
         n_fan_rays: 65,
         background_n: "1.0".into(),
         background_material_key: None,
+        stop_surface: None,
     }
 }
 
@@ -123,6 +125,7 @@ pub fn biconvex_lens() -> SystemSpecs {
         n_fan_rays: 65,
         background_n: "1.0".into(),
         background_material_key: None,
+        stop_surface: None,
     }
 }
 
@@ -191,6 +194,7 @@ pub fn convexplano_lens_with_materials() -> SystemSpecs {
         n_fan_rays: 65,
         background_n: "1.0".into(),
         background_material_key: Some("other:air:Ciddor".into()),
+        stop_surface: None,
     }
 }
 
@@ -214,7 +218,7 @@ pub fn f_theta_scan_lens() -> SystemSpecs {
                 material_key: Some("other:air:Ciddor".into()),
             },
             SurfaceRow {
-                variant: SurfaceVariant::Stop,
+                variant: SurfaceVariant::Iris,
                 surface_kind: SurfaceKind::Refracting,
                 refractive_index: "1.0".into(),
                 thickness: "5".into(),
@@ -317,6 +321,7 @@ pub fn f_theta_scan_lens() -> SystemSpecs {
         n_fan_rays: 65,
         background_n: "1.0".into(),
         background_material_key: Some("other:air:Ciddor".into()),
+        stop_surface: None,
     }
 }
 
@@ -361,5 +366,6 @@ pub fn concave_mirror() -> SystemSpecs {
         n_fan_rays: 65,
         background_n: "1.0".into(),
         background_material_key: None,
+        stop_surface: None,
     }
 }

--- a/crates/cherry-rs/src/gui/model.rs
+++ b/crates/cherry-rs/src/gui/model.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 pub enum SurfaceVariant {
     Object,
     Conic,
-    Stop,
+    Iris,
     Probe,
     Image,
 }
@@ -15,7 +15,7 @@ impl SurfaceVariant {
     /// are fixed).
     pub const SELECTABLE: &[SurfaceVariant] = &[
         SurfaceVariant::Conic,
-        SurfaceVariant::Stop,
+        SurfaceVariant::Iris,
         SurfaceVariant::Probe,
     ];
 }
@@ -25,7 +25,7 @@ impl std::fmt::Display for SurfaceVariant {
         match self {
             SurfaceVariant::Object => write!(f, "Object"),
             SurfaceVariant::Conic => write!(f, "Conic"),
-            SurfaceVariant::Stop => write!(f, "Stop"),
+            SurfaceVariant::Iris => write!(f, "Iris"),
             SurfaceVariant::Probe => write!(f, "Probe"),
             SurfaceVariant::Image => write!(f, "Image"),
         }
@@ -114,9 +114,9 @@ impl SurfaceRow {
         }
     }
 
-    pub fn new_stop(semi_diameter: &str, thickness: &str, refractive_index: &str) -> Self {
+    pub fn new_iris(semi_diameter: &str, thickness: &str, refractive_index: &str) -> Self {
         Self {
-            variant: SurfaceVariant::Stop,
+            variant: SurfaceVariant::Iris,
             surface_kind: SurfaceKind::Refracting,
             refractive_index: refractive_index.into(),
             thickness: thickness.into(),
@@ -223,6 +223,36 @@ pub struct SystemSpecs {
     /// Material key for the background medium (used in materials mode).
     #[serde(default)]
     pub background_material_key: Option<String>,
+    /// User-designated aperture stop surface index. `None` = auto-derived.
+    #[serde(default)]
+    pub stop_surface: Option<usize>,
+}
+
+impl SystemSpecs {
+    /// Insert a default surface after index `idx` and adjust `stop_surface`.
+    pub fn insert_surface_after(&mut self, idx: usize) {
+        self.surfaces.insert(idx + 1, SurfaceRow::new_default());
+        if let Some(stop) = self.stop_surface
+            && idx < stop
+        {
+            self.stop_surface = Some(stop + 1);
+        }
+    }
+
+    /// Remove the surface at index `idx` and adjust `stop_surface`.
+    ///
+    /// Does nothing if fewer than 3 surfaces remain (must keep object + image).
+    pub fn delete_surface(&mut self, idx: usize) {
+        if self.surfaces.len() <= 2 {
+            return;
+        }
+        self.surfaces.remove(idx);
+        self.stop_surface = match self.stop_surface {
+            Some(stop) if stop == idx => None,
+            Some(stop) if idx < stop => Some(stop - 1),
+            other => other,
+        };
+    }
 }
 
 fn default_cross_section_n_rays() -> u32 {
@@ -266,6 +296,95 @@ impl Default for SystemSpecs {
             n_fan_rays: 65,
             background_n: "1.0".into(),
             background_material_key: None,
+            stop_surface: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Layout used by mutation tests:
+    //   0: Object, 1: Conic, 2: Conic, 3: Iris, 4: Image
+    fn five_surface_specs() -> SystemSpecs {
+        SystemSpecs {
+            surfaces: vec![
+                SurfaceRow::new_object("Infinity"),
+                SurfaceRow::new_conic("10.0", "50.0", "0.0", "5.0", "1.5"),
+                SurfaceRow::new_conic("10.0", "Infinity", "0.0", "5.0", "1.0"),
+                SurfaceRow::new_iris("5.0", "1.0", "1.0"),
+                SurfaceRow::new_image(),
+            ],
+            ..Default::default()
+        }
+    }
+
+    // --- insert_surface_after ---
+
+    #[test]
+    fn insert_before_stop_increments_stop() {
+        let mut specs = five_surface_specs();
+        specs.stop_surface = Some(3);
+        specs.insert_surface_after(1); // inserts at index 2, stop was 3 → becomes 4
+        assert_eq!(specs.stop_surface, Some(4));
+    }
+
+    #[test]
+    fn insert_at_stop_index_increments_stop() {
+        let mut specs = five_surface_specs();
+        specs.stop_surface = Some(2);
+        specs.insert_surface_after(2); // inserts at index 3, stop was 2 → unchanged
+        assert_eq!(specs.stop_surface, Some(2));
+    }
+
+    #[test]
+    fn insert_after_stop_leaves_stop_unchanged() {
+        let mut specs = five_surface_specs();
+        specs.stop_surface = Some(2);
+        specs.insert_surface_after(3); // inserts after stop → unchanged
+        assert_eq!(specs.stop_surface, Some(2));
+    }
+
+    #[test]
+    fn insert_with_no_stop_stays_none() {
+        let mut specs = five_surface_specs();
+        specs.stop_surface = None;
+        specs.insert_surface_after(1);
+        assert_eq!(specs.stop_surface, None);
+    }
+
+    // --- delete_surface ---
+
+    #[test]
+    fn delete_at_stop_clears_stop() {
+        let mut specs = five_surface_specs();
+        specs.stop_surface = Some(2);
+        specs.delete_surface(2);
+        assert_eq!(specs.stop_surface, None);
+    }
+
+    #[test]
+    fn delete_before_stop_decrements_stop() {
+        let mut specs = five_surface_specs();
+        specs.stop_surface = Some(3);
+        specs.delete_surface(1); // delete before stop → stop was 3, becomes 2
+        assert_eq!(specs.stop_surface, Some(2));
+    }
+
+    #[test]
+    fn delete_after_stop_leaves_stop_unchanged() {
+        let mut specs = five_surface_specs();
+        specs.stop_surface = Some(2);
+        specs.delete_surface(3);
+        assert_eq!(specs.stop_surface, Some(2));
+    }
+
+    #[test]
+    fn delete_with_no_stop_stays_none() {
+        let mut specs = five_surface_specs();
+        specs.stop_surface = None;
+        specs.delete_surface(2);
+        assert_eq!(specs.stop_surface, None);
     }
 }

--- a/crates/cherry-rs/src/gui/panels/aperture.rs
+++ b/crates/cherry-rs/src/gui/panels/aperture.rs
@@ -1,4 +1,4 @@
-use super::super::model::SystemSpecs;
+use super::super::model::{SurfaceVariant, SystemSpecs};
 use super::{format_display_float, parse_display_float};
 
 /// Draw the aperture editor panel. Returns true if any spec was modified.
@@ -21,6 +21,50 @@ pub fn aperture_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
             changed = true;
         }
     });
+
+    ui.add_space(8.0);
+    ui.label("Stop Surface");
+    ui.separator();
+
+    // Build the list of eligible stop surfaces (Conic and Iris only).
+    let eligible: Vec<usize> = specs
+        .surfaces
+        .iter()
+        .enumerate()
+        .filter(|(_, row)| matches!(row.variant, SurfaceVariant::Conic | SurfaceVariant::Iris))
+        .map(|(i, _)| i)
+        .collect();
+
+    let selected_label = match specs.stop_surface {
+        None => "Auto".to_owned(),
+        Some(i) => {
+            let variant = &specs.surfaces[i].variant;
+            format!("{variant} [{i}]")
+        }
+    };
+
+    egui::ComboBox::from_id_salt("stop_surface_combo")
+        .selected_text(selected_label)
+        .show_ui(ui, |ui| {
+            if ui
+                .selectable_label(specs.stop_surface.is_none(), "Auto")
+                .clicked()
+            {
+                specs.stop_surface = None;
+                changed = true;
+            }
+            for idx in &eligible {
+                let variant = &specs.surfaces[*idx].variant;
+                let label = format!("{variant} [{idx}]");
+                if ui
+                    .selectable_label(specs.stop_surface == Some(*idx), label)
+                    .clicked()
+                {
+                    specs.stop_surface = Some(*idx);
+                    changed = true;
+                }
+            }
+        });
 
     changed
 }

--- a/crates/cherry-rs/src/gui/panels/surfaces.rs
+++ b/crates/cherry-rs/src/gui/panels/surfaces.rs
@@ -1,6 +1,6 @@
 use egui_extras::{Column, TableBuilder};
 
-use super::super::model::{SurfaceKind, SurfaceRow, SurfaceVariant, SystemSpecs};
+use super::super::model::{SurfaceKind, SurfaceVariant, SystemSpecs};
 use super::{format_display_float, inf_formatter, inf_parser, parse_display_float};
 
 /// Draw the surfaces editor panel. Returns true if any spec was modified.
@@ -93,6 +93,9 @@ pub fn surfaces_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
 
                 for row_idx in 0..num_surfaces {
                     body.row(22.0, |mut row| {
+                        if specs.stop_surface == Some(row_idx) {
+                            row.set_selected(true);
+                        }
                         let surf = &mut specs.surfaces[row_idx];
                         let is_object = surf.variant == SurfaceVariant::Object;
                         let is_image = surf.variant == SurfaceVariant::Image;
@@ -124,6 +127,17 @@ pub fn surfaces_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
                                                 .changed()
                                             {
                                                 changed = true;
+                                                // If this row was the designated stop and
+                                                // the new variant is ineligible, clear it.
+                                                if specs.stop_surface == Some(row_idx)
+                                                    && !matches!(
+                                                        v,
+                                                        SurfaceVariant::Conic
+                                                            | SurfaceVariant::Iris
+                                                    )
+                                                {
+                                                    specs.stop_surface = None;
+                                                }
                                             }
                                         }
                                     });
@@ -306,13 +320,11 @@ pub fn surfaces_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
 
                 // Apply deferred mutations
                 if let Some(idx) = insert_after {
-                    specs.surfaces.insert(idx + 1, SurfaceRow::new_default());
+                    specs.insert_surface_after(idx);
                     changed = true;
                 }
-                if let Some(idx) = delete_at
-                    && specs.surfaces.len() > 2
-                {
-                    specs.surfaces.remove(idx);
+                if let Some(idx) = delete_at {
+                    specs.delete_surface(idx);
                     changed = true;
                 }
             });

--- a/crates/cherry-rs/src/gui/windows/cross_section.rs
+++ b/crates/cherry-rs/src/gui/windows/cross_section.rs
@@ -309,7 +309,7 @@ fn draw_element(
         DrawElement::SurfaceProfile { points } => {
             draw_surface_profile(painter, points, w2s);
         }
-        DrawElement::Stop {
+        DrawElement::Iris {
             z,
             half_gap,
             extent,
@@ -589,7 +589,7 @@ fn render_svg(geom: &PlaneGeometry, wavelengths: &[f64], dark_mode: bool) -> Str
             DrawElement::SurfaceProfile { points } => {
                 svg_polyline(&mut s, points, &w2s, profile_color, 1.5);
             }
-            DrawElement::Stop {
+            DrawElement::Iris {
                 z,
                 half_gap,
                 extent,

--- a/crates/cherry-rs/src/gui/windows/paraxial.rs
+++ b/crates/cherry-rs/src/gui/windows/paraxial.rs
@@ -226,7 +226,7 @@ mod tests {
         let parsed = convert::convert_specs(&specs).expect("convert");
         #[cfg(feature = "ri-info")]
         let parsed = convert::convert_specs(&specs, &Default::default()).expect("convert");
-        let seq = SequentialModel::new(&parsed.gaps, &parsed.surfaces, &parsed.wavelengths)
+        let seq = SequentialModel::new(&parsed.gaps, &parsed.surfaces, &parsed.wavelengths, None)
             .expect("model");
         let pv = ParaxialView::new(&seq, &parsed.fields, false).expect("paraxial");
         let wls = seq.wavelengths().to_vec();

--- a/crates/cherry-rs/src/gui/windows/ray_fan.rs
+++ b/crates/cherry-rs/src/gui/windows/ray_fan.rs
@@ -509,7 +509,7 @@ mod tests {
         let parsed = convert::convert_specs(&specs).expect("convert");
         #[cfg(feature = "ri-info")]
         let parsed = convert::convert_specs(&specs, &Default::default()).expect("convert");
-        let seq = SequentialModel::new(&parsed.gaps, &parsed.surfaces, &parsed.wavelengths)
+        let seq = SequentialModel::new(&parsed.gaps, &parsed.surfaces, &parsed.wavelengths, None)
             .expect("model");
         let pv = ParaxialView::new(&seq, &parsed.fields, false).expect("paraxial");
         let config = SamplingConfig {
@@ -532,7 +532,7 @@ mod tests {
                     SurfaceKind::Image => "Image",
                     SurfaceKind::Object => "Object",
                     SurfaceKind::Probe => "Probe",
-                    SurfaceKind::Stop => "Stop",
+                    SurfaceKind::Iris => "Iris",
                     SurfaceKind::Custom => "Custom",
                 };
                 SurfaceDesc {

--- a/crates/cherry-rs/src/gui/windows/spot_diagram.rs
+++ b/crates/cherry-rs/src/gui/windows/spot_diagram.rs
@@ -386,7 +386,7 @@ mod tests {
         let parsed = convert::convert_specs(&specs).expect("convert");
         #[cfg(feature = "ri-info")]
         let parsed = convert::convert_specs(&specs, &Default::default()).expect("convert");
-        let seq = SequentialModel::new(&parsed.gaps, &parsed.surfaces, &parsed.wavelengths)
+        let seq = SequentialModel::new(&parsed.gaps, &parsed.surfaces, &parsed.wavelengths, None)
             .expect("model");
         let pv = ParaxialView::new(&seq, &parsed.fields, false).expect("paraxial");
 
@@ -433,7 +433,7 @@ mod tests {
         let parsed = convert::convert_specs(&specs).expect("convert");
         #[cfg(feature = "ri-info")]
         let parsed = convert::convert_specs(&specs, &Default::default()).expect("convert");
-        let seq = SequentialModel::new(&parsed.gaps, &parsed.surfaces, &parsed.wavelengths)
+        let seq = SequentialModel::new(&parsed.gaps, &parsed.surfaces, &parsed.wavelengths, None)
             .expect("model");
         let pv = ParaxialView::new(&seq, &parsed.fields, false).expect("paraxial");
         let trace = ray_trace_3d_view(

--- a/crates/cherry-rs/src/lib.rs
+++ b/crates/cherry-rs/src/lib.rs
@@ -86,7 +86,7 @@
 //! let wavelengths: Vec<f64> = vec![0.567];
 //!
 //! // Create a sequential model from the gaps, surfaces, and wavelengths.
-//! let sequential_model = SequentialModel::new(&gaps, &surfaces, &wavelengths).unwrap();
+//! let sequential_model = SequentialModel::new(&gaps, &surfaces, &wavelengths, None).unwrap();
 //!
 //! // Define a user-defined system aperture.
 //! let aperture_spec = ApertureSpec::EntrancePupil { semi_diameter: 5.0 };
@@ -140,7 +140,7 @@ pub use core::{
     placement::Placement,
     sequential_model::{SequentialModel, SequentialSubModel, Step},
     surfaces::{
-        Conic, Image, Object, Probe, Stop, Surface, SurfaceConstructor, SurfaceKind,
+        Conic, Image, Iris, Object, Probe, Surface, SurfaceConstructor, SurfaceKind,
         SurfaceRegistry,
     },
 };

--- a/crates/cherry-rs/src/specs/surfaces.rs
+++ b/crates/cherry-rs/src/specs/surfaces.rs
@@ -56,7 +56,7 @@ pub enum SurfaceSpec {
     Probe {
         rotation: Rotation3D,
     },
-    Stop {
+    Iris {
         semi_diameter: Float,
         rotation: Rotation3D,
     },

--- a/crates/cherry-rs/src/views/components/mod.rs
+++ b/crates/cherry-rs/src/views/components/mod.rs
@@ -23,7 +23,7 @@ const TOL: Float = 1e-6;
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Component {
     Element { surf_idxs: (usize, usize) },
-    Stop { stop_idx: usize },
+    Iris { stop_idx: usize },
     Mirror { surf_idx: usize },
     UnpairedSurface { surf_idx: usize },
 }
@@ -31,8 +31,8 @@ pub enum Component {
 /// Determine the components of an optical system.
 ///
 /// Components are the basic building blocks of an optical system. They are
-/// either elements or stops. Elements are pairs of surfaces that interact with
-/// light rays. Stops are hard stops that block light rays.
+/// either elements or irises. Elements are pairs of surfaces that interact with
+/// light rays. Irises are hard stops that clip rays.
 ///
 /// Components serve to group surfaces together into individual lenses.
 ///
@@ -89,14 +89,13 @@ pub fn components_view(
             continue;
         }
 
-        if surf_pair.0.surface_kind() == SurfaceKind::Stop {
-            // Stops are special, so be sure that they're added before anything else.
-            components.insert(Component::Stop { stop_idx: i });
+        if surf_pair.0.surface_kind() == SurfaceKind::Iris {
+            components.insert(Component::Iris { stop_idx: i });
             continue;
         }
 
-        if surf_pair.1.surface_kind() == SurfaceKind::Stop {
-            // Ensure that stops following surfaces are NOT added as a component
+        if surf_pair.1.surface_kind() == SurfaceKind::Iris {
+            // Ensure that irises following surfaces are not added as a component.
             continue;
         }
 
@@ -159,7 +158,7 @@ mod tests {
         let gaps = vec![gap_0];
         let wavelengths = vec![0.567];
 
-        SequentialModel::new(&gaps, &surfaces, &wavelengths).unwrap()
+        SequentialModel::new(&gaps, &surfaces, &wavelengths, None).unwrap()
     }
 
     pub fn silly_unpaired_surface() -> SequentialModel {
@@ -213,7 +212,7 @@ mod tests {
         let gaps = vec![gap_0, gap_1, gap_2, gap_3];
         let wavelengths = vec![0.567];
 
-        SequentialModel::new(&gaps, &surfaces, &wavelengths).unwrap()
+        SequentialModel::new(&gaps, &surfaces, &wavelengths, None).unwrap()
     }
 
     pub fn silly_single_surface_and_stop() -> SequentialModel {
@@ -237,7 +236,7 @@ mod tests {
             thickness: 10.0,
             refractive_index: nbk7,
         };
-        let surf_2 = SurfaceSpec::Stop {
+        let surf_2 = SurfaceSpec::Iris {
             semi_diameter: 12.5,
             rotation: Rotation3D::None,
         };
@@ -253,7 +252,7 @@ mod tests {
         let gaps = vec![gap_0, gap_1, gap_2];
         let wavelengths = vec![0.567];
 
-        SequentialModel::new(&gaps, &surfaces, &wavelengths).unwrap()
+        SequentialModel::new(&gaps, &surfaces, &wavelengths, None).unwrap()
     }
 
     pub fn wollaston_landscape_lens() -> SequentialModel {
@@ -268,7 +267,7 @@ mod tests {
             thickness: Float::INFINITY,
             refractive_index: air.clone(),
         };
-        let surf_1 = SurfaceSpec::Stop {
+        let surf_1 = SurfaceSpec::Iris {
             semi_diameter: 5.0,
             rotation: Rotation3D::None,
         };
@@ -306,7 +305,7 @@ mod tests {
         let gaps = vec![gap_0, gap_1, gap_2, gap_3];
         let wavelengths = vec![0.5876];
 
-        SequentialModel::new(&gaps, &surfaces, &wavelengths).unwrap()
+        SequentialModel::new(&gaps, &surfaces, &wavelengths, None).unwrap()
     }
 
     // pub fn petzval_lens() -> SequentialModel {
@@ -330,7 +329,7 @@ mod tests {
     //             conic_constant: 0.0,
     //             surf_type: crate::BoundaryType::Refracting,
     //         },
-    //         SurfaceSpec::Stop {
+    //         SurfaceSpec::Iris {
     //             semi_diameter: 33.262,
     //         },
     //         SurfaceSpec::Conic {
@@ -379,7 +378,7 @@ mod tests {
     // 87179, 1.0),     ];
     //     let wavelengths = vec![0.5876];
 
-    //     SequentialModel::new(&gaps, &surfaces, &wavelengths).unwrap()
+    //     SequentialModel::new(&gaps, &surfaces, &wavelengths, None).unwrap()
     // }
 
     #[test]
@@ -421,7 +420,7 @@ mod tests {
         let components = components_view(&sequential_model, n!(1.0)).unwrap();
 
         assert_eq!(components.len(), 1);
-        assert!(components.contains(&Component::Stop { stop_idx: 2 })); // Hard stop
+        assert!(components.contains(&Component::Iris { stop_idx: 2 })); // Hard stop
     }
 
     #[test]
@@ -443,7 +442,7 @@ mod tests {
         let components = components_view(&sequential_model, n!(1.0)).unwrap();
 
         assert_eq!(components.len(), 2);
-        assert!(components.contains(&Component::Stop { stop_idx: 1 })); // Hard stop
+        assert!(components.contains(&Component::Iris { stop_idx: 1 })); // Hard stop
         assert!(components.contains(&Component::Element { surf_idxs: (2, 3) }));
         // Lens
     }
@@ -480,7 +479,7 @@ mod tests {
                 refractive_index: air.clone(),
             },
         ];
-        SequentialModel::new(&gaps, &surfaces, &[0.5876]).unwrap()
+        SequentialModel::new(&gaps, &surfaces, &[0.5876], None).unwrap()
     }
 
     #[test]
@@ -503,7 +502,7 @@ mod tests {
         let model = f_theta_scan_lens::sequential_model(air.clone(), glass, &[0.5876]);
         let components = components_view(&model, air).unwrap();
         assert_eq!(components.len(), 4); // 1 stop + 3 elements
-        assert!(components.contains(&Component::Stop { stop_idx: 1 }));
+        assert!(components.contains(&Component::Iris { stop_idx: 1 }));
         assert!(components.contains(&Component::Element { surf_idxs: (2, 3) }));
         assert!(components.contains(&Component::Element { surf_idxs: (4, 5) }));
         assert!(components.contains(&Component::Element { surf_idxs: (6, 7) }));

--- a/crates/cherry-rs/src/views/cross_section.rs
+++ b/crates/cherry-rs/src/views/cross_section.rs
@@ -56,7 +56,7 @@ pub enum DrawElement {
     SurfaceProfile {
         points: Vec<[f64; 2]>,
     },
-    Stop {
+    Iris {
         z: f64,
         half_gap: f64,
         extent: f64,
@@ -127,7 +127,7 @@ fn build_plane_geometry(
     let mut sorted_components: Vec<Component> = components.iter().cloned().collect();
     sorted_components.sort_by_key(|c| match c {
         Component::Element { surf_idxs: (i, _) } => *i,
-        Component::Stop { stop_idx } => *stop_idx,
+        Component::Iris { stop_idx } => *stop_idx,
         Component::Mirror { surf_idx } => *surf_idx,
         Component::UnpairedSurface { surf_idx } => *surf_idx,
     });
@@ -144,10 +144,10 @@ fn build_plane_geometry(
                     });
                 }
             }
-            Component::Stop { stop_idx } => {
+            Component::Iris { stop_idx } => {
                 let z = placements[*stop_idx].position.z();
                 let sd = surfaces[*stop_idx].mask().semi_diameter();
-                elements.push(DrawElement::Stop {
+                elements.push(DrawElement::Iris {
                     z,
                     half_gap: sd,
                     extent: largest_sd * 1.5,
@@ -349,7 +349,7 @@ fn compute_bounds(elements: &[DrawElement], ray_paths: &[Vec<Vec<[f64; 2]>>]) ->
                     update(z, t, &mut z_min, &mut z_max, &mut t_min, &mut t_max);
                 }
             }
-            DrawElement::Stop { z, extent, .. } => {
+            DrawElement::Iris { z, extent, .. } => {
                 update(*z, *extent, &mut z_min, &mut z_max, &mut t_min, &mut t_max);
                 update(*z, -extent, &mut z_min, &mut z_max, &mut t_min, &mut t_max);
             }

--- a/crates/cherry-rs/src/views/paraxial.rs
+++ b/crates/cherry-rs/src/views/paraxial.rs
@@ -273,6 +273,7 @@ impl ParaxialView {
                 unique_tangential_vecs(field_specs)
             };
 
+        let stop_surface = sequential_model.stop_surface();
         let mut subviews = Vec::new();
         for (wav_idx, submodel) in sequential_model.submodels().iter().enumerate() {
             for (v_idx, &v) in tangential_vecs.iter().enumerate() {
@@ -281,6 +282,7 @@ impl ParaxialView {
                     surfaces,
                     placements,
                     field_specs,
+                    stop_surface,
                 };
                 let subview =
                     ParaxialSubView::new(wav_idx, v_idx, &data, v, is_obj_space_telecentric)?;
@@ -412,6 +414,7 @@ struct SubModelData<'a> {
     surfaces: &'a [Box<dyn Surface>],
     placements: &'a [Placement],
     field_specs: &'a [FieldSpec],
+    stop_surface: Option<usize>,
 }
 
 impl ParaxialSubView {
@@ -440,8 +443,12 @@ impl ParaxialSubView {
         let reverse_parallel_ray =
             Self::calc_reverse_parallel_ray(sequential_sub_model, surfaces, placements)?;
 
-        let aperture_stop =
-            Self::calc_aperture_stop(surfaces, placements, &pseudo_marginal_ray, &per_surf_v);
+        let aperture_stop = match data.stop_surface {
+            Some(i) => i,
+            None => {
+                Self::calc_aperture_stop(surfaces, placements, &pseudo_marginal_ray, &per_surf_v)
+            }
+        };
         let back_focal_distance = Self::calc_back_focal_distance(surfaces, &parallel_ray)?;
         let front_focal_distance =
             Self::calc_front_focal_distance(surfaces, &reverse_parallel_ray)?;
@@ -1206,6 +1213,7 @@ mod test {
             surfaces: sequential_model.surfaces(),
             placements: sequential_model.placements(),
             field_specs: &field_specs,
+            stop_surface: None,
         };
         (
             ParaxialSubView::new(
@@ -1377,7 +1385,7 @@ mod test {
             },
         ];
 
-        let sequential_model = SequentialModel::new(&gaps, &surfaces, &wavelengths).unwrap();
+        let sequential_model = SequentialModel::new(&gaps, &surfaces, &wavelengths, None).unwrap();
         let seq_sub_model = sequential_model.submodel(0).expect("Submodel not found.");
         let field_specs = vec![crate::FieldSpec::PointSource { x: 0.0, y: 0.0 }];
 
@@ -1386,10 +1394,63 @@ mod test {
             surfaces: sequential_model.surfaces(),
             placements: sequential_model.placements(),
             field_specs: &field_specs,
+            stop_surface: None,
         };
 
         let view = ParaxialSubView::new(0, 0, &data, Vec3::new(0.0, 1.0, 0.0), false).unwrap();
 
         assert_eq!(*view.aperture_stop(), 2);
+    }
+
+    /// When a user-specified stop surface is set on the model, ParaxialView
+    /// must use it instead of the auto-derived heuristic result.
+    #[test]
+    fn user_specified_stop_overrides_auto() {
+        // Convexplano lens: auto-derived stop is surface 1 (see test_aperture_stop).
+        // Explicitly designate surface 2 and verify the paraxial view honours it.
+        let air = n!(1.0);
+        let nbk7 = n!(1.515);
+        let gaps = vec![
+            GapSpec {
+                thickness: Float::INFINITY,
+                refractive_index: air.clone(),
+            },
+            GapSpec {
+                thickness: 5.3,
+                refractive_index: nbk7,
+            },
+            GapSpec {
+                thickness: 46.6,
+                refractive_index: air,
+            },
+        ];
+        let surfaces = vec![
+            SurfaceSpec::Object,
+            SurfaceSpec::Conic {
+                semi_diameter: 12.5,
+                radius_of_curvature: 25.8,
+                conic_constant: 0.0,
+                surf_type: BoundaryType::Refracting,
+                rotation: Rotation3D::None,
+            },
+            SurfaceSpec::Conic {
+                semi_diameter: 12.5,
+                radius_of_curvature: Float::INFINITY,
+                conic_constant: 0.0,
+                surf_type: BoundaryType::Refracting,
+                rotation: Rotation3D::None,
+            },
+            SurfaceSpec::Image {
+                rotation: Rotation3D::None,
+            },
+        ];
+        let seq = SequentialModel::new(&gaps, &surfaces, &[0.5876], Some(2)).unwrap();
+        let field = vec![FieldSpec::Angle {
+            chi: 0.0,
+            phi: 90.0,
+        }];
+        let pv = ParaxialView::new(&seq, &field, false).unwrap();
+        let sub = pv.get(0, 0).unwrap();
+        assert_eq!(*sub.aperture_stop(), 2);
     }
 }

--- a/crates/cherry-rs/tests/custom_surface_registry.rs
+++ b/crates/cherry-rs/tests/custom_surface_registry.rs
@@ -98,7 +98,7 @@ fn new_without_registry_rejects_custom_spec() {
     let gaps = vec![air_gap(f64::INFINITY), air_gap(10.0)];
     let wavelengths = vec![0.587];
 
-    let result = SequentialModel::new(&gaps, &surface_specs, &wavelengths);
+    let result = SequentialModel::new(&gaps, &surface_specs, &wavelengths, None);
     assert!(result.is_err());
 }
 

--- a/crates/cherry-rs/tests/from_surfaces.rs
+++ b/crates/cherry-rs/tests/from_surfaces.rs
@@ -47,7 +47,7 @@ fn from_surfaces_constructs_minimal_model() {
     let gaps = vec![air_gap(10.0)];
     let wavelengths = vec![0.587];
 
-    assert!(SequentialModel::from_surfaces(surfaces, &gaps, &wavelengths).is_ok());
+    assert!(SequentialModel::from_surfaces(surfaces, &gaps, &wavelengths, None).is_ok());
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn from_surfaces_wrong_gap_count_errors() {
     let gaps = vec![air_gap(10.0), air_gap(5.0)]; // one too many
     let wavelengths = vec![0.587];
 
-    assert!(SequentialModel::from_surfaces(surfaces, &gaps, &wavelengths).is_err());
+    assert!(SequentialModel::from_surfaces(surfaces, &gaps, &wavelengths, None).is_err());
 }
 
 #[test]
@@ -71,8 +71,8 @@ fn from_surfaces_wavelengths_are_preserved() {
     let gaps = vec![air_gap(10.0)];
     let wavelengths = vec![0.486, 0.587, 0.656];
 
-    let model =
-        SequentialModel::from_surfaces(surfaces, &gaps, &wavelengths).expect("model should build");
+    let model = SequentialModel::from_surfaces(surfaces, &gaps, &wavelengths, None)
+        .expect("model should build");
 
     assert_eq!(model.wavelengths(), wavelengths.as_slice());
 }


### PR DESCRIPTION
Currently the aperture stop is computed from the lens clear aperture diameters, which supports people modeling tabletop setups where one does not have control over the pupil. Lens designers, however, prefer to specify the stop surface and not the clear aperture diameters.

This feature allows either setting the stop surface directly or falling back to the "automatic" behavior of having it computed from a paraxial ray trace. Like this both use cases are supported.

Minor note: the `Stop` surface variant is now called `Iris` to avoid confusion with the system stop.