### PR TITLE
refactor: Move serialization layer behind a `serde` feature gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Cherry might be for you if:
 
 - [ ] Refactor the core to support the next set of features and better future-proof the API
   - [X] User-specified stop
-  - [ ] Serialization layer moved into a crate feature
+  - [X] Serialization layer moved into a crate feature
   - [ ] Flat and spherical ray-surface intersection solvers
 - [ ] Solve system to enforce active constraints on a design
 

--- a/crates/cherry-rs/Cargo.toml
+++ b/crates/cherry-rs/Cargo.toml
@@ -21,14 +21,15 @@ path = "src/bin/gen_rii_index.rs"
 required-features = [ "ri-info" ]
 
 [features]
-gui = [ "dep:eframe", "dep:egui", "dep:egui_extras", "dep:egui_plot", "dep:env_logger", "dep:log", "dep:rfd" ]
-ri-info = [ "dep:ria", "dep:bitcode" ]
+serde = [ "dep:serde", "dep:serde_json" ]
+gui = [ "serde", "dep:eframe", "dep:egui", "dep:egui_extras", "dep:egui_plot", "dep:env_logger", "dep:log", "dep:rfd" ]
+ri-info = [ "serde", "dep:ria", "dep:bitcode" ]
 
 [dependencies]
 anyhow = "1.0"
 rayon = "1"
-serde = { version = "1", features = [ "derive" ] }
-serde_json = "1"
+serde = { version = "1", features = [ "derive" ], optional = true }
+serde_json = { version = "1", optional = true }
 tracing = "0.1"
 
 # gui (shared: native + WASM)

--- a/crates/cherry-rs/README.md
+++ b/crates/cherry-rs/README.md
@@ -3,15 +3,33 @@
 [![docs.rs](https://img.shields.io/docsrs/cherry-rs)](https://docs.rs/cherry-rs/latest/cherry_rs/)
 [![Crates.io Version](https://img.shields.io/crates/v/cherry-rs)](https://crates.io/crates/cherry-rs)
 
-Tools for designing sequential optical systems.
+Rust library for designing sequential optical systems.
 
 ## Features
 
+### serde
+
+Enables [serde](https://serde.rs) serialization and deserialization for all public types, plus `serde_json` support for the `SurfaceSpec::Custom` variant and `SurfaceRegistry`. Pure Rust library users who build models programmatically via `SequentialModel::from_surfaces` can omit this feature to avoid the serde dependency.
+
+```toml
+cherry-rs = { version = "*", features = [ "serde" ] }
+```
+
+### gui
+
+Enables the egui-based desktop and WASM GUI. Implies `serde`.
+
+```toml
+cherry-rs = { version = "*", features = [ "gui" ] }
+```
+
 ### ri-info
 
-This feature includes material refractive index data from [refractiveindex.info](https://refractiveindex.info).
+Includes material refractive index data from [refractiveindex.info](https://refractiveindex.info). Implies `serde`.
 
-Install this feature by adding the following to your Cargo.toml: `cherry-rs = { version = "*", features = [ "ri-info" ]}`
+```toml
+cherry-rs = { version = "*", features = [ "ri-info" ] }
+```
 
 #### Testing
 

--- a/crates/cherry-rs/src/core/math/linalg/rotations.rs
+++ b/crates/cherry-rs/src/core/math/linalg/rotations.rs
@@ -1,4 +1,5 @@
 /// Provides data structures and logic for rotations.
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::core::{Float, math::linalg::mat3x3::Mat3x3};
@@ -7,7 +8,8 @@ use crate::core::{Float, math::linalg::mat3x3::Mat3x3};
 ///
 /// The angles are in the order of the rotation that is applied; the exact
 /// rotation sequence is specified in the [Rotation] enum.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct EulerAngles(pub Float, pub Float, pub Float);
 
 /// 3D rotation sequences represented by Euler angles.
@@ -16,7 +18,8 @@ pub struct EulerAngles(pub Float, pub Float, pub Float);
 /// - Coordinate systems are right-handed
 /// - Counterclockwise rotations are positive
 /// - Angles are in radians
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Rotation3D {
     /// No rotation is applied.
     None,

--- a/crates/cherry-rs/src/core/math/vec3.rs
+++ b/crates/cherry-rs/src/core/math/vec3.rs
@@ -1,12 +1,14 @@
 /// A 3D vector
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serde::Serialize;
 
 use crate::core::{EPSILON, Float, PI};
 
 const TOL: Float = (1 as Float) * EPSILON;
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[serde(into = "[Float; 3]")]
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", serde(into = "[Float; 3]"))]
 pub struct Vec3 {
     pub e: [Float; 3],
 }

--- a/crates/cherry-rs/src/core/ray.rs
+++ b/crates/cherry-rs/src/core/ray.rs
@@ -1,4 +1,5 @@
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serde::Serialize;
 
 use crate::core::{Float, PI, math::vec3::Vec3, placement::Placement};
 
@@ -7,7 +8,8 @@ use crate::core::{Float, PI, math::vec3::Vec3, placement::Placement};
 /// # Attributes
 /// - pos: Position of the ray
 /// - dir: Direction of the ray (direction cosines)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Ray {
     pos: Vec3,
     dir: Vec3,

--- a/crates/cherry-rs/src/core/sequential_model.rs
+++ b/crates/cherry-rs/src/core/sequential_model.rs
@@ -5,6 +5,8 @@ type SurfsPlacementsDirs = (Vec<Box<dyn Surface>>, Vec<Placement>, Vec<Vec3>);
 
 use anyhow::{Result, anyhow};
 
+#[cfg(feature = "serde")]
+use crate::core::surfaces::SurfaceRegistry;
 use crate::core::{
     Float,
     math::{
@@ -14,7 +16,7 @@ use crate::core::{
     },
     placement::Placement,
     refractive_index::RefractiveIndex,
-    surfaces::{Conic, Image, Iris, Object, Probe, Surface, SurfaceKind, SurfaceRegistry},
+    surfaces::{Conic, Image, Iris, Object, Probe, Surface, SurfaceKind},
 };
 use crate::specs::{
     gaps::GapSpec,
@@ -267,7 +269,7 @@ impl SequentialModel {
     ///   `None` uses the paraxial heuristic. `Some(i)` requires `i` to refer to
     ///   a `Conic` or `Iris` surface that is neither the object nor the image
     ///   surface; otherwise an error is returned.
-    pub fn new(
+    pub fn from_surface_specs(
         gap_specs: &[GapSpec],
         surface_specs: &[SurfaceSpec],
         wavelengths: &[Float],
@@ -275,8 +277,12 @@ impl SequentialModel {
     ) -> Result<Self> {
         Self::validate_specs(gap_specs, wavelengths)?;
 
+        #[cfg(feature = "serde")]
         let (surfaces, placements, axis_directions) =
             Self::surf_specs_to_surfs(surface_specs, gap_specs, None)?;
+        #[cfg(not(feature = "serde"))]
+        let (surfaces, placements, axis_directions) =
+            Self::surf_specs_to_surfs(surface_specs, gap_specs)?;
 
         if let Some(i) = stop_surface {
             Self::validate_stop_surface(&surfaces, i)?;
@@ -355,6 +361,7 @@ impl SequentialModel {
     /// Identical to [`new`](Self::new) except that `registry` is consulted
     /// when a [`SurfaceSpec::Custom`] spec is encountered. Built-in surface
     /// types do not use the registry.
+    #[cfg(feature = "serde")]
     pub fn new_with_registry(
         gap_specs: &[GapSpec],
         surface_specs: &[SurfaceSpec],
@@ -441,7 +448,7 @@ impl SequentialModel {
     /// index is out of range.
     ///
     /// Wavelength indices are 0-based and match the order of the wavelengths
-    /// slice passed to [`SequentialModel::new`].
+    /// slice passed to [`SequentialModel::from_surface_specs`].
     pub fn submodel(&self, wavelength_id: usize) -> Option<&(impl SequentialSubModel + use<'_>)> {
         self.submodels.get(wavelength_id)
     }
@@ -532,6 +539,7 @@ impl SequentialModel {
         (placements, axis_directions)
     }
 
+    #[cfg(feature = "serde")]
     fn surf_specs_to_surfs(
         surf_specs: &[SurfaceSpec],
         gap_specs: &[GapSpec],
@@ -540,6 +548,21 @@ impl SequentialModel {
         let surfaces: Vec<Box<dyn Surface>> = surf_specs
             .iter()
             .map(|s| surface_from_spec(s, registry))
+            .collect::<Result<Vec<_>>>()?;
+        let rotations: Vec<Rotation3D> = surf_specs.iter().map(rotation_from_spec).collect();
+        let (placements, axis_directions) =
+            Self::build_placements_and_directions(&surfaces, &rotations, gap_specs);
+        Ok((surfaces, placements, axis_directions))
+    }
+
+    #[cfg(not(feature = "serde"))]
+    fn surf_specs_to_surfs(
+        surf_specs: &[SurfaceSpec],
+        gap_specs: &[GapSpec],
+    ) -> Result<SurfsPlacementsDirs> {
+        let surfaces: Vec<Box<dyn Surface>> = surf_specs
+            .iter()
+            .map(surface_from_spec)
             .collect::<Result<Vec<_>>>()?;
         let rotations: Vec<Rotation3D> = surf_specs.iter().map(rotation_from_spec).collect();
         let (placements, axis_directions) =
@@ -730,18 +753,17 @@ impl<'a> Iterator for SequentialSubModelReverseIter<'a> {
 fn rotation_from_spec(spec: &SurfaceSpec) -> Rotation3D {
     match spec {
         SurfaceSpec::Conic { rotation, .. }
-        | SurfaceSpec::Custom { rotation, .. }
         | SurfaceSpec::Image { rotation }
         | SurfaceSpec::Probe { rotation }
         | SurfaceSpec::Iris { rotation, .. } => rotation.clone(),
         SurfaceSpec::Object => Rotation3D::None,
+        #[cfg(feature = "serde")]
+        SurfaceSpec::Custom { rotation, .. } => rotation.clone(),
     }
 }
 
 /// Build a [`Surface`] trait object from a surface specification.
-///
-/// Pass `Some(registry)` to resolve [`SurfaceSpec::Custom`] variants.
-/// Passing `None` when a `Custom` spec is encountered returns an error.
+#[cfg(feature = "serde")]
 pub(crate) fn surface_from_spec(
     spec: &SurfaceSpec,
     registry: Option<&SurfaceRegistry>,
@@ -769,6 +791,29 @@ pub(crate) fn surface_from_spec(
                 )
             })?
             .build(type_id, params),
+        SurfaceSpec::Image { .. } => Ok(Box::new(Image::new())),
+        SurfaceSpec::Object => Ok(Box::new(Object::new())),
+        SurfaceSpec::Probe { .. } => Ok(Box::new(Probe::new())),
+        SurfaceSpec::Iris { semi_diameter, .. } => Ok(Box::new(Iris::new(*semi_diameter))),
+    }
+}
+
+/// Build a [`Surface`] trait object from a surface specification.
+#[cfg(not(feature = "serde"))]
+pub(crate) fn surface_from_spec(spec: &SurfaceSpec) -> Result<Box<dyn Surface>> {
+    match spec {
+        SurfaceSpec::Conic {
+            semi_diameter,
+            radius_of_curvature,
+            conic_constant,
+            surf_type,
+            ..
+        } => Ok(Box::new(Conic::new(
+            *semi_diameter,
+            *radius_of_curvature,
+            *conic_constant,
+            *surf_type,
+        ))),
         SurfaceSpec::Image { .. } => Ok(Box::new(Image::new())),
         SurfaceSpec::Object => Ok(Box::new(Object::new())),
         SurfaceSpec::Probe { .. } => Ok(Box::new(Probe::new())),
@@ -1094,36 +1139,38 @@ mod tests {
     #[test]
     fn stop_surface_conic_is_accepted() {
         let (gaps, surfaces) = stop_validation_specs();
-        assert!(SequentialModel::new(&gaps, &surfaces, &[0.5876], Some(1)).is_ok());
+        assert!(SequentialModel::from_surface_specs(&gaps, &surfaces, &[0.5876], Some(1)).is_ok());
     }
 
     #[test]
     fn stop_surface_iris_is_accepted() {
         let (gaps, surfaces) = stop_validation_specs();
-        assert!(SequentialModel::new(&gaps, &surfaces, &[0.5876], Some(3)).is_ok());
+        assert!(SequentialModel::from_surface_specs(&gaps, &surfaces, &[0.5876], Some(3)).is_ok());
     }
 
     #[test]
     fn stop_surface_object_is_rejected() {
         let (gaps, surfaces) = stop_validation_specs();
-        assert!(SequentialModel::new(&gaps, &surfaces, &[0.5876], Some(0)).is_err());
+        assert!(SequentialModel::from_surface_specs(&gaps, &surfaces, &[0.5876], Some(0)).is_err());
     }
 
     #[test]
     fn stop_surface_image_is_rejected() {
         let (gaps, surfaces) = stop_validation_specs();
-        assert!(SequentialModel::new(&gaps, &surfaces, &[0.5876], Some(4)).is_err());
+        assert!(SequentialModel::from_surface_specs(&gaps, &surfaces, &[0.5876], Some(4)).is_err());
     }
 
     #[test]
     fn stop_surface_out_of_range_is_rejected() {
         let (gaps, surfaces) = stop_validation_specs();
-        assert!(SequentialModel::new(&gaps, &surfaces, &[0.5876], Some(99)).is_err());
+        assert!(
+            SequentialModel::from_surface_specs(&gaps, &surfaces, &[0.5876], Some(99)).is_err()
+        );
     }
 
     #[test]
     fn stop_surface_probe_is_rejected() {
         let (gaps, surfaces) = stop_validation_specs();
-        assert!(SequentialModel::new(&gaps, &surfaces, &[0.5876], Some(2)).is_err());
+        assert!(SequentialModel::from_surface_specs(&gaps, &surfaces, &[0.5876], Some(2)).is_err());
     }
 }

--- a/crates/cherry-rs/src/core/surfaces/mod.rs
+++ b/crates/cherry-rs/src/core/surfaces/mod.rs
@@ -11,6 +11,7 @@ pub mod iris;
 pub mod object;
 pub mod probe;
 pub mod solvers;
+#[cfg(feature = "serde")]
 pub mod surface_registry;
 
 pub use conic::Conic;
@@ -18,6 +19,7 @@ pub use image::Image;
 pub use iris::Iris;
 pub use object::Object;
 pub use probe::Probe;
+#[cfg(feature = "serde")]
 pub use surface_registry::{SurfaceConstructor, SurfaceRegistry};
 
 /// The role of a surface in the optical system.

--- a/crates/cherry-rs/src/examples/biconvex_lens_finite_object.rs
+++ b/crates/cherry-rs/src/examples/biconvex_lens_finite_object.rs
@@ -45,5 +45,5 @@ pub fn sequential_model(
 
     let surfaces = vec![surf_0, surf_1, surf_2, surf_3];
 
-    SequentialModel::new(&gaps, &surfaces, wavelengths, None).unwrap()
+    SequentialModel::from_surface_specs(&gaps, &surfaces, wavelengths, None).unwrap()
 }

--- a/crates/cherry-rs/src/examples/concave_mirror.rs
+++ b/crates/cherry-rs/src/examples/concave_mirror.rs
@@ -30,5 +30,5 @@ pub fn sequential_model(
     };
     let surfaces = vec![surf_0, surf_1, surf_2];
 
-    SequentialModel::new(&gaps, &surfaces, wavelengths, None).unwrap()
+    SequentialModel::from_surface_specs(&gaps, &surfaces, wavelengths, None).unwrap()
 }

--- a/crates/cherry-rs/src/examples/convexplano_lens.rs
+++ b/crates/cherry-rs/src/examples/convexplano_lens.rs
@@ -42,5 +42,5 @@ pub fn sequential_model(
     };
     let surfaces = vec![surf_0, surf_1, surf_2, surf_3];
 
-    SequentialModel::new(&gaps, &surfaces, wavelengths, None).unwrap()
+    SequentialModel::from_surface_specs(&gaps, &surfaces, wavelengths, None).unwrap()
 }

--- a/crates/cherry-rs/src/examples/f_theta_scan_lens.rs
+++ b/crates/cherry-rs/src/examples/f_theta_scan_lens.rs
@@ -105,7 +105,7 @@ pub fn sequential_model(
         surf_0, surf_1, surf_2, surf_3, surf_4, surf_5, surf_6, surf_7, surf_8,
     ];
 
-    SequentialModel::new(&gaps, &surfaces, wavelengths, None).unwrap()
+    SequentialModel::from_surface_specs(&gaps, &surfaces, wavelengths, None).unwrap()
 }
 
 pub fn field_specs() -> Vec<FieldSpec> {

--- a/crates/cherry-rs/src/examples/mirrors_figure_z.rs
+++ b/crates/cherry-rs/src/examples/mirrors_figure_z.rs
@@ -55,5 +55,5 @@ pub fn sequential_model(
     };
     let surfaces = vec![surf_0, surf_1, surf_2, surf_3];
 
-    SequentialModel::new(&gaps, &surfaces, wavelengths, None).unwrap()
+    SequentialModel::from_surface_specs(&gaps, &surfaces, wavelengths, None).unwrap()
 }

--- a/crates/cherry-rs/src/examples/petzval_lens.rs
+++ b/crates/cherry-rs/src/examples/petzval_lens.rs
@@ -117,7 +117,7 @@ pub fn sequential_model() -> SequentialModel {
 
     let wavelengths: Vec<f64> = vec![0.567];
 
-    SequentialModel::new(&gaps, &surfaces, &wavelengths, None).unwrap()
+    SequentialModel::from_surface_specs(&gaps, &surfaces, &wavelengths, None).unwrap()
 }
 
 pub fn field_specs() -> Vec<FieldSpec> {

--- a/crates/cherry-rs/src/gui/compute.rs
+++ b/crates/cherry-rs/src/gui/compute.rs
@@ -120,7 +120,7 @@ fn run_compute(
         Err(e) => return ResultPackage::error(req.id, format!("Specs error: {e}")),
     };
 
-    let seq = match SequentialModel::new(
+    let seq = match SequentialModel::from_surface_specs(
         &parsed.gaps,
         &parsed.surfaces,
         &parsed.wavelengths,
@@ -255,8 +255,13 @@ mod tests {
         let parsed = convert::convert_specs(&specs).expect("convert");
         #[cfg(feature = "ri-info")]
         let parsed = convert::convert_specs(&specs, &Default::default()).expect("convert");
-        let seq = SequentialModel::new(&parsed.gaps, &parsed.surfaces, &parsed.wavelengths, None)
-            .expect("model");
+        let seq = SequentialModel::from_surface_specs(
+            &parsed.gaps,
+            &parsed.surfaces,
+            &parsed.wavelengths,
+            None,
+        )
+        .expect("model");
         let descs = build_surface_descs(&seq);
 
         assert!(

--- a/crates/cherry-rs/src/gui/windows/paraxial.rs
+++ b/crates/cherry-rs/src/gui/windows/paraxial.rs
@@ -226,8 +226,13 @@ mod tests {
         let parsed = convert::convert_specs(&specs).expect("convert");
         #[cfg(feature = "ri-info")]
         let parsed = convert::convert_specs(&specs, &Default::default()).expect("convert");
-        let seq = SequentialModel::new(&parsed.gaps, &parsed.surfaces, &parsed.wavelengths, None)
-            .expect("model");
+        let seq = SequentialModel::from_surface_specs(
+            &parsed.gaps,
+            &parsed.surfaces,
+            &parsed.wavelengths,
+            None,
+        )
+        .expect("model");
         let pv = ParaxialView::new(&seq, &parsed.fields, false).expect("paraxial");
         let wls = seq.wavelengths().to_vec();
         ResultPackage {

--- a/crates/cherry-rs/src/gui/windows/ray_fan.rs
+++ b/crates/cherry-rs/src/gui/windows/ray_fan.rs
@@ -509,8 +509,13 @@ mod tests {
         let parsed = convert::convert_specs(&specs).expect("convert");
         #[cfg(feature = "ri-info")]
         let parsed = convert::convert_specs(&specs, &Default::default()).expect("convert");
-        let seq = SequentialModel::new(&parsed.gaps, &parsed.surfaces, &parsed.wavelengths, None)
-            .expect("model");
+        let seq = SequentialModel::from_surface_specs(
+            &parsed.gaps,
+            &parsed.surfaces,
+            &parsed.wavelengths,
+            None,
+        )
+        .expect("model");
         let pv = ParaxialView::new(&seq, &parsed.fields, false).expect("paraxial");
         let config = SamplingConfig {
             n_fan_rays: 11,

--- a/crates/cherry-rs/src/gui/windows/spot_diagram.rs
+++ b/crates/cherry-rs/src/gui/windows/spot_diagram.rs
@@ -386,8 +386,13 @@ mod tests {
         let parsed = convert::convert_specs(&specs).expect("convert");
         #[cfg(feature = "ri-info")]
         let parsed = convert::convert_specs(&specs, &Default::default()).expect("convert");
-        let seq = SequentialModel::new(&parsed.gaps, &parsed.surfaces, &parsed.wavelengths, None)
-            .expect("model");
+        let seq = SequentialModel::from_surface_specs(
+            &parsed.gaps,
+            &parsed.surfaces,
+            &parsed.wavelengths,
+            None,
+        )
+        .expect("model");
         let pv = ParaxialView::new(&seq, &parsed.fields, false).expect("paraxial");
 
         let result = ResultPackage {
@@ -433,8 +438,13 @@ mod tests {
         let parsed = convert::convert_specs(&specs).expect("convert");
         #[cfg(feature = "ri-info")]
         let parsed = convert::convert_specs(&specs, &Default::default()).expect("convert");
-        let seq = SequentialModel::new(&parsed.gaps, &parsed.surfaces, &parsed.wavelengths, None)
-            .expect("model");
+        let seq = SequentialModel::from_surface_specs(
+            &parsed.gaps,
+            &parsed.surfaces,
+            &parsed.wavelengths,
+            None,
+        )
+        .expect("model");
         let pv = ParaxialView::new(&seq, &parsed.fields, false).expect("paraxial");
         let trace = ray_trace_3d_view(
             &parsed.aperture,

--- a/crates/cherry-rs/src/lib.rs
+++ b/crates/cherry-rs/src/lib.rs
@@ -86,7 +86,7 @@
 //! let wavelengths: Vec<f64> = vec![0.567];
 //!
 //! // Create a sequential model from the gaps, surfaces, and wavelengths.
-//! let sequential_model = SequentialModel::new(&gaps, &surfaces, &wavelengths, None).unwrap();
+//! let sequential_model = SequentialModel::from_surface_specs(&gaps, &surfaces, &wavelengths, None).unwrap();
 //!
 //! // Define a user-defined system aperture.
 //! let aperture_spec = ApertureSpec::EntrancePupil { semi_diameter: 5.0 };
@@ -134,15 +134,14 @@ pub mod gui;
 
 // API
 pub mod examples;
+#[cfg(feature = "serde")]
+pub use core::surfaces::{SurfaceConstructor, SurfaceRegistry};
 pub use core::{
     math::linalg::rotations::{EulerAngles, Rotation3D},
     math::vec3::Vec3,
     placement::Placement,
     sequential_model::{SequentialModel, SequentialSubModel, Step},
-    surfaces::{
-        Conic, Image, Iris, Object, Probe, Surface, SurfaceConstructor, SurfaceKind,
-        SurfaceRegistry,
-    },
+    surfaces::{Conic, Image, Iris, Object, Probe, Surface, SurfaceKind},
 };
 pub use specs::{
     aperture::ApertureSpec,

--- a/crates/cherry-rs/src/specs/aperture.rs
+++ b/crates/cherry-rs/src/specs/aperture.rs
@@ -1,9 +1,11 @@
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::core::Float;
 
 /// Specifies the system aperture.
-#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ApertureSpec {
     EntrancePupil { semi_diameter: Float },
 }

--- a/crates/cherry-rs/src/specs/fields.rs
+++ b/crates/cherry-rs/src/specs/fields.rs
@@ -1,10 +1,12 @@
 use anyhow::Result;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::core::{Float, PI, math::vec3::Vec3};
 
 /// Specifies a pupil sampling method.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum PupilSampling {
     /// A pupil consisting of only a chief ray that pierces the pupil center.
     ChiefRay,
@@ -30,7 +32,8 @@ pub enum PupilSampling {
 }
 
 /// Specifies an object field.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum FieldSpec {
     /// The 2D direction of the field, specified in spherical coordinates.
     ///

--- a/crates/cherry-rs/src/specs/gaps.rs
+++ b/crates/cherry-rs/src/specs/gaps.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use anyhow::Result;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::core::Float;
@@ -50,7 +51,8 @@ pub trait RefractiveIndexSpec: std::fmt::Debug {
     fn k(&self, wavelength: Float) -> Result<Float>;
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ConstantRefractiveIndex {
     n: Float,
     k: Float,

--- a/crates/cherry-rs/src/specs/surfaces.rs
+++ b/crates/cherry-rs/src/specs/surfaces.rs
@@ -1,9 +1,11 @@
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::core::{Float, math::linalg::rotations::Rotation3D, math::vec3::Vec3};
 
 /// Specifies the type of interaction of light with a sequential model surface.
-#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum BoundaryType {
     Refracting,
     Reflecting,
@@ -27,7 +29,8 @@ pub enum Mask {
 ///
 /// Rotations are optional and specify the active rotation sequence to orient
 /// the surface in 3D.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum SurfaceSpec {
     Conic {
         semi_diameter: Float,
@@ -44,6 +47,7 @@ pub enum SurfaceSpec {
     ///
     /// [`SurfaceRegistry`]: crate::core::surfaces::SurfaceRegistry
     /// [`SurfaceRegistry::register`]: crate::core::surfaces::SurfaceRegistry::register
+    #[cfg(feature = "serde")]
     Custom {
         type_id: String,
         params: serde_json::Value,

--- a/crates/cherry-rs/src/views/components/mod.rs
+++ b/crates/cherry-rs/src/views/components/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::rc::Rc;
 
 use anyhow::{Result, anyhow};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -20,7 +21,8 @@ const TOL: Float = 1e-6;
 ///
 /// To avoid copying data, only indexes are stored from the surface models are
 /// stored.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Component {
     Element { surf_idxs: (usize, usize) },
     Iris { stop_idx: usize },
@@ -158,7 +160,7 @@ mod tests {
         let gaps = vec![gap_0];
         let wavelengths = vec![0.567];
 
-        SequentialModel::new(&gaps, &surfaces, &wavelengths, None).unwrap()
+        SequentialModel::from_surface_specs(&gaps, &surfaces, &wavelengths, None).unwrap()
     }
 
     pub fn silly_unpaired_surface() -> SequentialModel {
@@ -212,7 +214,7 @@ mod tests {
         let gaps = vec![gap_0, gap_1, gap_2, gap_3];
         let wavelengths = vec![0.567];
 
-        SequentialModel::new(&gaps, &surfaces, &wavelengths, None).unwrap()
+        SequentialModel::from_surface_specs(&gaps, &surfaces, &wavelengths, None).unwrap()
     }
 
     pub fn silly_single_surface_and_stop() -> SequentialModel {
@@ -252,7 +254,7 @@ mod tests {
         let gaps = vec![gap_0, gap_1, gap_2];
         let wavelengths = vec![0.567];
 
-        SequentialModel::new(&gaps, &surfaces, &wavelengths, None).unwrap()
+        SequentialModel::from_surface_specs(&gaps, &surfaces, &wavelengths, None).unwrap()
     }
 
     pub fn wollaston_landscape_lens() -> SequentialModel {
@@ -305,7 +307,7 @@ mod tests {
         let gaps = vec![gap_0, gap_1, gap_2, gap_3];
         let wavelengths = vec![0.5876];
 
-        SequentialModel::new(&gaps, &surfaces, &wavelengths, None).unwrap()
+        SequentialModel::from_surface_specs(&gaps, &surfaces, &wavelengths, None).unwrap()
     }
 
     // pub fn petzval_lens() -> SequentialModel {
@@ -378,8 +380,8 @@ mod tests {
     // 87179, 1.0),     ];
     //     let wavelengths = vec![0.5876];
 
-    //     SequentialModel::new(&gaps, &surfaces, &wavelengths, None).unwrap()
-    // }
+    //     SequentialModel::from_surface_specs(&gaps, &surfaces, &wavelengths,
+    // None).unwrap() }
 
     #[test]
     fn test_concave_mirror() {
@@ -479,7 +481,7 @@ mod tests {
                 refractive_index: air.clone(),
             },
         ];
-        SequentialModel::new(&gaps, &surfaces, &[0.5876], None).unwrap()
+        SequentialModel::from_surface_specs(&gaps, &surfaces, &[0.5876], None).unwrap()
     }
 
     #[test]

--- a/crates/cherry-rs/src/views/paraxial.rs
+++ b/crates/cherry-rs/src/views/paraxial.rs
@@ -8,6 +8,7 @@
 /// system, such as the entrance and exit pupils, the back and front focal
 /// distances, and the effective focal length.
 use anyhow::{Result, anyhow};
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -36,7 +37,8 @@ const DEFAULT_THICKNESS: Float = 0.0;
 type TangentialVector = Vec3;
 
 /// A single paraxial ray with height and angle components.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ParaxialRay {
     pub height: Float,
     pub angle: Float,
@@ -48,7 +50,8 @@ pub struct ParaxialRay {
 /// laid out as `[surf_0_ray_0, …, surf_0_ray_N, surf_1_ray_0, …]`. The number
 /// of rays per surface is `rays.len() / num_surfaces`. Access rays at a given
 /// surface with [`ParaxialRayBundle::rays_at_surface`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ParaxialRayBundle {
     rays: Vec<ParaxialRay>,
     num_surfaces: usize,
@@ -105,7 +108,8 @@ pub struct ParaxialView {
 /// A description of a paraxial optical system.
 ///
 /// This is used primarily for serialization of data for export.
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct ParaxialViewDescription {
     subviews: Vec<ParaxialSubViewDescription>,
     /// Indexed by tangential_vec_id (index into the tangential-vector table).
@@ -139,7 +143,8 @@ pub struct ParaxialSubView {
 /// A paraxial description of a submodel of an optical system.
 ///
 /// This is used primarily for serialization of data for export.
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct ParaxialSubViewDescription {
     wavelength_id: usize,
     tangential_vec_id: usize,
@@ -162,7 +167,8 @@ pub struct ParaxialSubViewDescription {
 /// * `location` - The location of the pupil relative to the first non-object
 ///   surface.
 /// * `semi_diameter` - The semi-diameter of the pupil.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Pupil {
     pub location: Float,
     pub semi_diameter: Float,
@@ -174,7 +180,8 @@ pub struct Pupil {
 /// * `location` - The location of the image plane relative to the first
 ///   physical surface
 /// * `semi_diameter` - The semi-diameter of the image plane
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ImagePlane {
     pub location: Float,
     pub semi_diameter: Float,
@@ -1385,7 +1392,8 @@ mod test {
             },
         ];
 
-        let sequential_model = SequentialModel::new(&gaps, &surfaces, &wavelengths, None).unwrap();
+        let sequential_model =
+            SequentialModel::from_surface_specs(&gaps, &surfaces, &wavelengths, None).unwrap();
         let seq_sub_model = sequential_model.submodel(0).expect("Submodel not found.");
         let field_specs = vec![crate::FieldSpec::PointSource { x: 0.0, y: 0.0 }];
 
@@ -1444,7 +1452,8 @@ mod test {
                 rotation: Rotation3D::None,
             },
         ];
-        let seq = SequentialModel::new(&gaps, &surfaces, &[0.5876], Some(2)).unwrap();
+        let seq =
+            SequentialModel::from_surface_specs(&gaps, &surfaces, &[0.5876], Some(2)).unwrap();
         let field = vec![FieldSpec::Angle {
             chi: 0.0,
             phi: 90.0,

--- a/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
@@ -4,6 +4,7 @@ mod trace;
 
 use anyhow::{Result, anyhow};
 use rayon::prelude::*;
+#[cfg(feature = "serde")]
 use serde::Serialize;
 use tracing::trace;
 
@@ -54,7 +55,8 @@ const LAUNCH_POINT_BEFORE_PUPIL: Float = 10.0;
 /// results are stored internally as a Vec and not a HashMap because the O(1)
 /// lookup time is not likely to outweigth the overhead of the HashMap in these
 /// conditions.
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct TraceResultsCollection {
     results: Vec<TraceResults>,
 }
@@ -64,7 +66,8 @@ pub struct TraceResultsCollection {
 /// This represents the results of a 3D ray trace for a single set of values of
 /// 1. wavelength ID and
 /// 2. field ID.
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct TraceResults {
     wavelength_id: usize,
     field_id: usize,

--- a/crates/cherry-rs/src/views/ray_trace_3d/trace.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/trace.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+#[cfg(feature = "serde")]
 use serde::Serialize;
 use tracing::{error, trace_span, warn};
 
@@ -17,7 +18,8 @@ const MAX_INTERSECTION_ITER: usize = 100;
 ///   any rays have terminated. `0` means the ray has not terminated.
 /// - *reason_for_termination*: A hashmap containing the reason for termination.
 /// - *num_surfaces*: The number of surfaces in the optical system.
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct RayBundle {
     rays: Vec<Ray>,
     terminated: Vec<usize>,

--- a/crates/cherry-rs/tests/custom_surface_registry.rs
+++ b/crates/cherry-rs/tests/custom_surface_registry.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "serde")]
+
 use cherry_rs::{
     BoundaryType, GapSpec, Mask, Rotation3D, SequentialModel, Surface, SurfaceRegistry,
     SurfaceSpec, Vec3, n,
@@ -98,7 +100,7 @@ fn new_without_registry_rejects_custom_spec() {
     let gaps = vec![air_gap(f64::INFINITY), air_gap(10.0)];
     let wavelengths = vec![0.587];
 
-    let result = SequentialModel::new(&gaps, &surface_specs, &wavelengths, None);
+    let result = SequentialModel::from_surface_specs(&gaps, &surface_specs, &wavelengths, None);
     assert!(result.is_err());
 }
 


### PR DESCRIPTION
This is a quality-of-life refactoring for Rust library users who do not need serde.

The existing `gui` and `ri-info` feature flags continue to imply `serde`.