### PR TITLE
feat: Add analytical solver for flat surfaces

### DIFF
--- a/crates/cherry-rs/src/core/surfaces/image.rs
+++ b/crates/cherry-rs/src/core/surfaces/image.rs
@@ -1,9 +1,11 @@
+use anyhow::Result;
+
 use crate::{
-    core::{Float, math::vec3::Vec3},
+    core::{Float, math::vec3::Vec3, ray::Ray},
     specs::surfaces::{BoundaryType, Mask},
 };
 
-use super::{Surface, SurfaceKind};
+use super::{Surface, SurfaceKind, solvers::flat_surface};
 
 /// The image plane — a flat surface with no optical effect on rays.
 #[derive(Debug, Clone)]
@@ -26,6 +28,10 @@ impl Default for Image {
 }
 
 impl Surface for Image {
+    fn intersect(&self, ray: &Ray, _max_iter: usize) -> Result<(Vec3, Vec3)> {
+        flat_surface(ray, self, 0)
+    }
+
     fn sag(&self, _pos: Vec3) -> Float {
         0.0
     }

--- a/crates/cherry-rs/src/core/surfaces/iris.rs
+++ b/crates/cherry-rs/src/core/surfaces/iris.rs
@@ -1,9 +1,11 @@
+use anyhow::Result;
+
 use crate::{
-    core::{Float, math::vec3::Vec3},
+    core::{Float, math::vec3::Vec3, ray::Ray},
     specs::surfaces::{BoundaryType, Mask},
 };
 
-use super::{Surface, SurfaceKind};
+use super::{Surface, SurfaceKind, solvers::flat_surface};
 
 /// A physical iris — a flat surface that clips rays by a circular aperture.
 #[derive(Debug, Clone)]
@@ -20,20 +22,24 @@ impl Iris {
 }
 
 impl Surface for Iris {
-    fn sag(&self, _pos: Vec3) -> Float {
-        0.0
+    fn boundary_type(&self) -> BoundaryType {
+        BoundaryType::NoOp
     }
 
-    fn norm(&self, _pos: Vec3) -> Vec3 {
-        Vec3::new(0.0, 0.0, 1.0)
+    fn intersect(&self, ray: &Ray, _max_iter: usize) -> Result<(Vec3, Vec3)> {
+        flat_surface(ray, self, 0)
     }
 
     fn mask(&self) -> &Mask {
         &self.mask
     }
 
-    fn boundary_type(&self) -> BoundaryType {
-        BoundaryType::NoOp
+    fn norm(&self, _pos: Vec3) -> Vec3 {
+        Vec3::new(0.0, 0.0, 1.0)
+    }
+
+    fn sag(&self, _pos: Vec3) -> Float {
+        0.0
     }
 
     fn surface_kind(&self) -> SurfaceKind {

--- a/crates/cherry-rs/src/core/surfaces/object.rs
+++ b/crates/cherry-rs/src/core/surfaces/object.rs
@@ -1,9 +1,11 @@
+use anyhow::Result;
+
 use crate::{
-    core::{Float, math::vec3::Vec3},
+    core::{Float, math::vec3::Vec3, ray::Ray},
     specs::surfaces::{BoundaryType, Mask},
 };
 
-use super::{Surface, SurfaceKind};
+use super::{Surface, SurfaceKind, solvers::flat_surface};
 
 /// The object plane — a flat surface with no optical effect on rays.
 #[derive(Debug, Clone)]
@@ -26,6 +28,10 @@ impl Default for Object {
 }
 
 impl Surface for Object {
+    fn intersect(&self, ray: &Ray, _max_iter: usize) -> Result<(Vec3, Vec3)> {
+        flat_surface(ray, self, 0)
+    }
+
     fn sag(&self, _pos: Vec3) -> Float {
         0.0
     }

--- a/crates/cherry-rs/src/core/surfaces/probe.rs
+++ b/crates/cherry-rs/src/core/surfaces/probe.rs
@@ -1,9 +1,11 @@
+use anyhow::Result;
+
 use crate::{
-    core::{Float, math::vec3::Vec3},
+    core::{Float, math::vec3::Vec3, ray::Ray},
     specs::surfaces::{BoundaryType, Mask},
 };
 
-use super::{Surface, SurfaceKind};
+use super::{Surface, SurfaceKind, solvers::flat_surface};
 
 /// A probe surface — a flat, non-optical surface used to measure ray positions.
 #[derive(Debug, Clone)]
@@ -26,20 +28,24 @@ impl Default for Probe {
 }
 
 impl Surface for Probe {
-    fn sag(&self, _pos: Vec3) -> Float {
-        0.0
+    fn boundary_type(&self) -> BoundaryType {
+        BoundaryType::NoOp
     }
 
-    fn norm(&self, _pos: Vec3) -> Vec3 {
-        Vec3::new(0.0, 0.0, 1.0)
+    fn intersect(&self, ray: &Ray, _max_iter: usize) -> Result<(Vec3, Vec3)> {
+        flat_surface(ray, self, 0)
     }
 
     fn mask(&self) -> &Mask {
         &self.mask
     }
 
-    fn boundary_type(&self) -> BoundaryType {
-        BoundaryType::NoOp
+    fn norm(&self, _pos: Vec3) -> Vec3 {
+        Vec3::new(0.0, 0.0, 1.0)
+    }
+
+    fn sag(&self, _pos: Vec3) -> Float {
+        0.0
     }
 
     fn surface_kind(&self) -> SurfaceKind {

--- a/crates/cherry-rs/src/core/surfaces/solvers.rs
+++ b/crates/cherry-rs/src/core/surfaces/solvers.rs
@@ -11,6 +11,24 @@ pub(crate) const TOL: Float = 10.0 * Float::EPSILON;
 /// during ray intersection
 pub(crate) const MAX_BISECT: usize = 64;
 
+/// Finds the intersection of a ray with a flat surface.
+///
+/// By convention, a flat surface lies in the z=0 plane of the surface's local
+/// coordinate system. Its normal vector points in the positive z-direction.
+///
+/// Returns the intersection point and the surface normal at that point, both in
+/// the surface's local coordinate system.
+pub fn flat_surface<S: Surface + ?Sized>(
+    ray: &Ray,
+    surf: &S,
+    _max_iter: usize,
+) -> Result<(Vec3, Vec3)> {
+    let s = -ray.z() / ray.n();
+    let r = ray.pos_at(s);
+    let norm = surf.norm(r);
+    Ok((r, norm))
+}
+
 /// Finds the intersection of a ray with a surface using Newton-Raphson
 /// iteration.
 ///
@@ -129,13 +147,32 @@ pub fn newton_raphson<S: Surface + ?Sized>(
 
 #[cfg(test)]
 mod tests {
-    use crate::core::{Float, math::vec3::Vec3, ray::Ray, surfaces::Conic};
+    use crate::core::{
+        Float,
+        math::vec3::Vec3,
+        ray::Ray,
+        surfaces::{Conic, Probe},
+    };
     use crate::specs::surfaces::BoundaryType;
 
     use super::*;
 
     #[test]
-    fn flat_surface() {
+    fn analytical_flat_surface() {
+        let ray = Ray::new(
+            Vec3::new(0.0, 0.0, -10.0),
+            Vec3::new(0.0, Float::sqrt(2.0) / 2.0, Float::sqrt(2.0) / 2.0),
+        );
+        let surf = Probe::new();
+
+        let (p, norm) = flat_surface(&ray, &surf, 0).unwrap();
+
+        assert_eq!(p, Vec3::new(0.0, 10.0, 0.0));
+        assert_eq!(norm, Vec3::new(0.0, 0.0, 1.0));
+    }
+
+    #[test]
+    fn newton_raphson_flat_surface() {
         let ray = Ray::new(Vec3::new(0.0, 0.0, -1.0), Vec3::new(0.0, 0.0, 1.0));
         let surf = Conic::new(4.0, Float::INFINITY, 0.0, BoundaryType::Refracting);
 

--- a/crates/cherry-rs/src/lib.rs
+++ b/crates/cherry-rs/src/lib.rs
@@ -140,6 +140,7 @@ pub use core::{
     math::linalg::rotations::{EulerAngles, Rotation3D},
     math::vec3::Vec3,
     placement::Placement,
+    ray::Ray,
     sequential_model::{SequentialModel, SequentialSubModel, Step},
     surfaces::{Conic, Image, Iris, Object, Probe, Surface, SurfaceKind},
 };
@@ -159,7 +160,7 @@ pub use views::{
         ParaxialView, ParaxialViewDescription, Pupil,
     },
     ray_trace_3d::{
-        Ray, RayBundle, SamplingConfig, TraceResults, TraceResultsCollection, ray_trace_3d_view,
+        RayBundle, SamplingConfig, TraceResults, TraceResultsCollection, ray_trace_3d_view,
         trace_ray_bundle,
     },
 };

--- a/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
@@ -1,5 +1,4 @@
 /// Performs a 3D ray trace on the system.
-mod rays;
 mod trace;
 
 use anyhow::{Result, anyhow};
@@ -14,6 +13,7 @@ use crate::{
         Float, PI,
         math::vec3::Vec3,
         placement::Placement,
+        ray::Ray,
         sequential_model::{SequentialModel, SequentialSubModel},
         surfaces::Surface,
     },
@@ -25,7 +25,6 @@ use crate::{
 
 use trace::trace;
 
-pub use rays::Ray;
 pub use trace::RayBundle;
 
 use super::paraxial::{ParaxialSubView, ParaxialView};

--- a/crates/cherry-rs/src/views/ray_trace_3d/rays.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/rays.rs
@@ -1,1 +1,0 @@
-pub use crate::core::ray::Ray;

--- a/crates/cherry-rs/src/views/ray_trace_3d/trace.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/trace.rs
@@ -4,8 +4,7 @@ use std::collections::HashMap;
 use serde::Serialize;
 use tracing::{error, trace_span, warn};
 
-use super::rays::Ray;
-use crate::core::sequential_model::SequentialSubModelIter;
+use crate::core::{ray::Ray, sequential_model::SequentialSubModelIter};
 
 const MAX_INTERSECTION_ITER: usize = 100;
 


### PR DESCRIPTION
This skips the Newton-Raphson solver entirely for flat surfaces and computes the analytical solution of the ray-surface intersection.

The f-theta scan lens benchmark improved by about 5%.