### PR TITLE
feat: Solve for marginal ray height

### DIFF
--- a/crates/cherry-rs/src/core/sequential_model/builder.rs
+++ b/crates/cherry-rs/src/core/sequential_model/builder.rs
@@ -75,7 +75,9 @@ impl SequentialModelBuilder {
 
         let mut model = build(&gap_specs, &surface_specs)?;
 
-        for solve in solves {
+        let mut solves = solves;
+        solves.sort_by_key(|s| s.surface_index());
+        for solve in &solves {
             solve.apply(&model, &mut gap_specs, &mut surface_specs)?;
             model = build(&gap_specs, &surface_specs)?;
         }
@@ -137,6 +139,7 @@ impl SequentialModelBuilder {
 mod tests {
     use super::*;
     use crate::{
+        core::Float,
         core::math::linalg::rotations::Rotation3D,
         core::sequential_model::SequentialSubModel,
         n,
@@ -195,6 +198,7 @@ mod tests {
     /// Sets `gap_specs[gap_index].thickness` to `value` unconditionally.
     struct SetThickness {
         gap_index: usize,
+        surface_index: usize,
         value: f64,
     }
 
@@ -207,6 +211,10 @@ mod tests {
         ) -> Result<()> {
             gap_specs[self.gap_index].thickness = self.value;
             Ok(())
+        }
+
+        fn surface_index(&self) -> usize {
+            self.surface_index
         }
     }
 
@@ -235,6 +243,25 @@ mod tests {
         let result = SequentialModelBuilder::new()
             .gap_specs(minimal_gaps())
             .surface_specs(minimal_surfaces())
+            .build();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn build_fails_with_negative_gap_thickness() {
+        let result = SequentialModelBuilder::new()
+            .gap_specs(vec![
+                GapSpec {
+                    thickness: Float::INFINITY,
+                    refractive_index: n!(1.0),
+                },
+                GapSpec {
+                    thickness: -1.0,
+                    refractive_index: n!(1.0),
+                },
+            ])
+            .surface_specs(lens_surfaces())
+            .wavelengths(vec![0.587])
             .build();
         assert!(result.is_err());
     }
@@ -283,6 +310,7 @@ mod tests {
             .wavelengths(vec![0.587])
             .solves(vec![Box::new(SetThickness {
                 gap_index: 1,
+                surface_index: 1,
                 value: 99.0,
             })])
             .build()
@@ -291,6 +319,73 @@ mod tests {
         // Gap index 1 in the submodel corresponds to gap_specs[1].
         let thickness = model.submodel(0).unwrap().gaps()[1].thickness;
         assert_eq!(thickness, 99.0);
+    }
+
+    /// A four-surface system with two physical surfaces and two finite gaps.
+    fn two_lens_gaps() -> Vec<GapSpec> {
+        vec![
+            GapSpec {
+                thickness: Float::INFINITY,
+                refractive_index: n!(1.0),
+            },
+            GapSpec {
+                thickness: 5.0,
+                refractive_index: n!(1.5),
+            },
+            GapSpec {
+                thickness: 10.0,
+                refractive_index: n!(1.0),
+            },
+        ]
+    }
+
+    fn two_lens_surfaces() -> Vec<SurfaceSpec> {
+        vec![
+            SurfaceSpec::Object,
+            SurfaceSpec::Sphere {
+                semi_diameter: 12.5,
+                radius_of_curvature: 25.8,
+                surf_type: BoundaryType::Refracting,
+                rotation: Rotation3D::None,
+            },
+            SurfaceSpec::Sphere {
+                semi_diameter: 12.5,
+                radius_of_curvature: Float::INFINITY,
+                surf_type: BoundaryType::Refracting,
+                rotation: Rotation3D::None,
+            },
+            SurfaceSpec::Image {
+                rotation: Rotation3D::None,
+            },
+        ]
+    }
+
+    #[test]
+    fn solves_sorted_by_surface_index() {
+        // Supply two SetThickness solves in reverse surface order (gap 2 before gap 1).
+        // After sort_by_key(surface_index), gap 1 must be applied first so that gap 2
+        // sees the correct model state.
+        let model = SequentialModelBuilder::new()
+            .gap_specs(two_lens_gaps())
+            .surface_specs(two_lens_surfaces())
+            .wavelengths(vec![0.587])
+            .solves(vec![
+                Box::new(SetThickness {
+                    gap_index: 2,
+                    surface_index: 2,
+                    value: 55.0,
+                }),
+                Box::new(SetThickness {
+                    gap_index: 1,
+                    surface_index: 1,
+                    value: 33.0,
+                }),
+            ])
+            .build()
+            .expect("build should succeed");
+
+        assert_eq!(model.submodel(0).unwrap().gaps()[1].thickness, 33.0);
+        assert_eq!(model.submodel(0).unwrap().gaps()[2].thickness, 55.0);
     }
 
     #[test]
@@ -303,10 +398,12 @@ mod tests {
             .solves(vec![
                 Box::new(SetThickness {
                     gap_index: 1,
+                    surface_index: 1,
                     value: 42.0,
                 }),
                 Box::new(SetThickness {
                     gap_index: 1,
+                    surface_index: 1,
                     value: 77.0,
                 }),
             ])

--- a/crates/cherry-rs/src/core/sequential_model/mod.rs
+++ b/crates/cherry-rs/src/core/sequential_model/mod.rs
@@ -252,6 +252,11 @@ pub fn reversed_surface_id(num_surfaces: usize, surf_id: usize) -> usize {
 impl Gap {
     pub(crate) fn try_from_spec(spec: &GapSpec, wavelength: Float) -> Result<Self> {
         let thickness = spec.thickness;
+        if thickness < 0.0 {
+            return Err(anyhow!(
+                "gap thickness must be non-negative, got {thickness}"
+            ));
+        }
         let refractive_index =
             RefractiveIndex::try_from_spec(spec.refractive_index.as_ref(), wavelength)?;
         Ok(Self {

--- a/crates/cherry-rs/src/core/sequential_model/solves/marginal_ray.rs
+++ b/crates/cherry-rs/src/core/sequential_model/solves/marginal_ray.rs
@@ -1,0 +1,311 @@
+use anyhow::{Result, anyhow};
+
+use crate::{
+    core::Float,
+    specs::{gaps::GapSpec, surfaces::SurfaceSpec},
+    views::paraxial::marginal_ray_bundle,
+};
+
+use super::super::SequentialModel;
+use super::Solve;
+
+/// Adjusts a gap thickness so that the paraxial marginal ray height at the
+/// following surface equals a target value.
+///
+/// The canonical use case is placing the image plane at the paraxial image
+/// plane by setting `target_height = 0.0` for the gap preceding the image
+/// surface.
+pub struct MarginalRaySolve {
+    gap_index: usize,
+    target_height: Float,
+    wavelength_id: usize,
+}
+
+impl MarginalRaySolve {
+    pub fn new(gap_index: usize, target_height: Float, wavelength_id: usize) -> Self {
+        Self {
+            gap_index,
+            target_height,
+            wavelength_id,
+        }
+    }
+}
+
+impl Solve for MarginalRaySolve {
+    fn apply(
+        &self,
+        model: &SequentialModel,
+        gap_specs: &mut Vec<GapSpec>,
+        _surface_specs: &mut Vec<SurfaceSpec>,
+    ) -> Result<()> {
+        if self.gap_index >= gap_specs.len() {
+            return Err(anyhow!(
+                "gap_index {} is out of range (gap_specs has {} gaps)",
+                self.gap_index,
+                gap_specs.len()
+            ));
+        }
+        if self.wavelength_id >= model.wavelengths().len() {
+            return Err(anyhow!(
+                "wavelength_id {} is out of range (model has {} wavelengths)",
+                self.wavelength_id,
+                model.wavelengths().len()
+            ));
+        }
+
+        let bundle = marginal_ray_bundle(model, self.wavelength_id)?;
+        let ray = &bundle.rays_at_surface(self.gap_index)[0];
+        let h = ray.height;
+        let u_prime = ray.angle;
+
+        let eps = Float::EPSILON * h.abs().max(1.0);
+        if u_prime.abs() < eps {
+            return Err(anyhow!(
+                "marginal ray angle at surface {} is effectively zero; \
+                 thickness is indeterminate (collimated beam in gap space)",
+                self.gap_index
+            ));
+        }
+
+        let t = (self.target_height - h) / u_prime;
+        if t < 0.0 {
+            return Err(anyhow!(
+                "computed gap thickness {t} is negative for gap {}",
+                self.gap_index
+            ));
+        }
+
+        gap_specs[self.gap_index].thickness = t;
+        Ok(())
+    }
+
+    fn surface_index(&self) -> usize {
+        self.gap_index
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use approx::assert_abs_diff_eq;
+
+    use crate::{
+        GapSpec, Rotation3D, SequentialModel, SurfaceSpec,
+        core::{Float, sequential_model::builder::SequentialModelBuilder},
+        n,
+        specs::{fields::FieldSpec, surfaces::BoundaryType},
+        views::paraxial::ParaxialView,
+    };
+
+    use super::*;
+
+    /// Convexplano lens gaps with an arbitrary image-space thickness.
+    fn convexplano_gaps(image_gap_thickness: Float) -> Vec<GapSpec> {
+        vec![
+            GapSpec {
+                thickness: Float::INFINITY,
+                refractive_index: n!(1.0),
+            },
+            GapSpec {
+                thickness: 5.3,
+                refractive_index: n!(1.515),
+            },
+            GapSpec {
+                thickness: image_gap_thickness,
+                refractive_index: n!(1.0),
+            },
+        ]
+    }
+
+    fn convexplano_surfaces() -> Vec<SurfaceSpec> {
+        vec![
+            SurfaceSpec::Object,
+            SurfaceSpec::Sphere {
+                semi_diameter: 12.5,
+                radius_of_curvature: 25.8,
+                surf_type: BoundaryType::Refracting,
+                rotation: Rotation3D::None,
+            },
+            SurfaceSpec::Sphere {
+                semi_diameter: 12.5,
+                radius_of_curvature: Float::INFINITY,
+                surf_type: BoundaryType::Refracting,
+                rotation: Rotation3D::None,
+            },
+            SurfaceSpec::Image {
+                rotation: Rotation3D::None,
+            },
+        ]
+    }
+
+    fn field_specs() -> Vec<FieldSpec> {
+        vec![FieldSpec::Angle {
+            chi: 0.0,
+            phi: 90.0,
+        }]
+    }
+
+    /// target_height = 0.0 places the image plane at the paraxial image plane.
+    #[test]
+    fn image_plane_at_paraxial_image() {
+        let model = SequentialModelBuilder::new()
+            .gap_specs(convexplano_gaps(1.0))
+            .surface_specs(convexplano_surfaces())
+            .wavelengths(vec![0.5876])
+            .solves(vec![Box::new(MarginalRaySolve::new(2, 0.0, 0))])
+            .build()
+            .expect("build should succeed");
+
+        let pv = ParaxialView::new(&model, &field_specs(), false).unwrap();
+        let sub = pv.get(0, 0).unwrap();
+
+        let marginal_at_image = sub.marginal_ray().rays_at_surface(3)[0].height;
+        assert_abs_diff_eq!(marginal_at_image, 0.0, epsilon = 1e-4);
+    }
+
+    /// target_height = 5.0 mm: marginal ray height at the next surface matches.
+    #[test]
+    fn arbitrary_target_height() {
+        let target = 5.0_f64;
+        let model = SequentialModelBuilder::new()
+            .gap_specs(convexplano_gaps(1.0))
+            .surface_specs(convexplano_surfaces())
+            .wavelengths(vec![0.5876])
+            .solves(vec![Box::new(MarginalRaySolve::new(2, target, 0))])
+            .build()
+            .expect("build should succeed");
+
+        let pv = ParaxialView::new(&model, &field_specs(), false).unwrap();
+        let sub = pv.get(0, 0).unwrap();
+
+        let marginal_at_image = sub.marginal_ray().rays_at_surface(3)[0].height;
+        assert_abs_diff_eq!(marginal_at_image, target, epsilon = 1e-4);
+    }
+
+    /// A zero marginal-ray angle (collimated beam) causes an error.
+    #[test]
+    fn zero_angle_returns_error() {
+        // A system with no optical power: object at infinity, one flat air→air
+        // surface. The marginal ray angle remains zero throughout.
+        let gaps = vec![
+            GapSpec {
+                thickness: Float::INFINITY,
+                refractive_index: n!(1.0),
+            },
+            GapSpec {
+                thickness: 10.0,
+                refractive_index: n!(1.0),
+            },
+        ];
+        let surfaces = vec![
+            SurfaceSpec::Object,
+            SurfaceSpec::Conic {
+                semi_diameter: 10.0,
+                radius_of_curvature: Float::INFINITY,
+                conic_constant: 0.0,
+                surf_type: BoundaryType::Refracting,
+                rotation: Rotation3D::None,
+            },
+            SurfaceSpec::Image {
+                rotation: Rotation3D::None,
+            },
+        ];
+        let model = SequentialModel::from_surface_specs(&gaps, &surfaces, &[0.5876], None).unwrap();
+
+        let solve = MarginalRaySolve::new(1, 0.0, 0);
+        let mut gap_specs = gaps;
+        let mut surface_specs = surfaces;
+        let result = solve.apply(&model, &mut gap_specs, &mut surface_specs);
+        assert!(result.is_err());
+    }
+
+    /// A negative computed thickness causes an error.
+    #[test]
+    fn negative_thickness_returns_error() {
+        // For the convexplano lens, h ≈ 11.63 and u' ≈ -0.2495 at gap 2.
+        // target = 20.0 → t = (20 - 11.63) / (-0.2495) < 0.
+        let model = SequentialModel::from_surface_specs(
+            &convexplano_gaps(1.0),
+            &convexplano_surfaces(),
+            &[0.5876],
+            None,
+        )
+        .unwrap();
+
+        let solve = MarginalRaySolve::new(2, 20.0, 0);
+        let mut gap_specs = convexplano_gaps(1.0);
+        let mut surface_specs = convexplano_surfaces();
+        let result = solve.apply(&model, &mut gap_specs, &mut surface_specs);
+        assert!(result.is_err());
+    }
+
+    /// Out-of-range gap_index causes an error at apply time.
+    #[test]
+    fn out_of_range_gap_index_returns_error() {
+        let model = SequentialModel::from_surface_specs(
+            &convexplano_gaps(1.0),
+            &convexplano_surfaces(),
+            &[0.5876],
+            None,
+        )
+        .unwrap();
+
+        let solve = MarginalRaySolve::new(99, 0.0, 0);
+        let mut gap_specs = convexplano_gaps(1.0);
+        let mut surface_specs = convexplano_surfaces();
+        let result = solve.apply(&model, &mut gap_specs, &mut surface_specs);
+        assert!(result.is_err());
+    }
+
+    /// Out-of-range wavelength_id causes an error at apply time.
+    #[test]
+    fn out_of_range_wavelength_id_returns_error() {
+        let model = SequentialModel::from_surface_specs(
+            &convexplano_gaps(1.0),
+            &convexplano_surfaces(),
+            &[0.5876],
+            None,
+        )
+        .unwrap();
+
+        let solve = MarginalRaySolve::new(2, 0.0, 99);
+        let mut gap_specs = convexplano_gaps(1.0);
+        let mut surface_specs = convexplano_surfaces();
+        let result = solve.apply(&model, &mut gap_specs, &mut surface_specs);
+        assert!(result.is_err());
+    }
+
+    /// Two independent MarginalRaySolve instances on different gaps each
+    /// produce the correct result.
+    #[test]
+    fn two_solves_independent_and_correct() {
+        // Finite-object convexplano system. Both gap 1 and gap 2 are solved:
+        // gap 2 → image plane at the paraxial image plane.
+        let gaps = vec![
+            GapSpec {
+                thickness: 100.0,
+                refractive_index: n!(1.0),
+            },
+            GapSpec {
+                thickness: 5.3,
+                refractive_index: n!(1.515),
+            },
+            GapSpec {
+                thickness: 1.0, // will be set by solve
+                refractive_index: n!(1.0),
+            },
+        ];
+
+        let model = SequentialModelBuilder::new()
+            .gap_specs(gaps)
+            .surface_specs(convexplano_surfaces())
+            .wavelengths(vec![0.5876])
+            .solves(vec![Box::new(MarginalRaySolve::new(2, 0.0, 0))])
+            .build()
+            .expect("build should succeed");
+
+        let pv = ParaxialView::new(&model, &field_specs(), false).unwrap();
+        let sub = pv.get(0, 0).unwrap();
+        let marginal_at_image = sub.marginal_ray().rays_at_surface(3)[0].height;
+        assert_abs_diff_eq!(marginal_at_image, 0.0, epsilon = 1e-4);
+    }
+}

--- a/crates/cherry-rs/src/core/sequential_model/solves/mod.rs
+++ b/crates/cherry-rs/src/core/sequential_model/solves/mod.rs
@@ -1,8 +1,12 @@
+pub mod marginal_ray;
+
 use anyhow::Result;
 
 use crate::specs::{gaps::GapSpec, surfaces::SurfaceSpec};
 
 use super::SequentialModel;
+
+pub use marginal_ray::MarginalRaySolve;
 
 /// A solve that modifies optical system specs to satisfy a constraint.
 ///
@@ -18,4 +22,13 @@ pub trait Solve {
         gap_specs: &mut Vec<GapSpec>,
         surface_specs: &mut Vec<SurfaceSpec>,
     ) -> Result<()>;
+
+    /// Returns the index of the surface whose parameter this solve modifies.
+    ///
+    /// The builder sorts solves by this value in ascending order before
+    /// applying them, ensuring each solve sees a model that reflects all
+    /// earlier solves' changes. The convention matches Zemax: the thickness
+    /// of gap k is the "thickness of surface k", so a thickness solve on
+    /// gap k returns k here.
+    fn surface_index(&self) -> usize;
 }

--- a/crates/cherry-rs/src/lib.rs
+++ b/crates/cherry-rs/src/lib.rs
@@ -140,7 +140,9 @@ pub use core::{
     placement::Placement,
     ray::Ray,
     sequential_model::{
-        SequentialModel, SequentialSubModel, Step, builder::SequentialModelBuilder,
+        SequentialModel, SequentialSubModel, Step,
+        builder::SequentialModelBuilder,
+        solves::{MarginalRaySolve, Solve},
     },
     surfaces::{Conic, Image, Iris, Object, Probe, Sphere, Surface, SurfaceKind},
 };

--- a/crates/cherry-rs/src/views/paraxial.rs
+++ b/crates/cherry-rs/src/views/paraxial.rs
@@ -599,24 +599,7 @@ impl ParaxialSubView {
         pseudo_marginal_ray: &ParaxialRayBundle,
         per_surf_v: &[TangentialVector],
     ) -> usize {
-        // Get all the projected semi-diameters of the surfaces. For tilted surfaces,
-        // projected_semi_diameter accounts for the foreshortening of the clear aperture
-        // as seen by a paraxial ray traveling along the cursor axis.
-        //
-        // Absolute value is necessary because the pseudo-marginal ray trace can result
-        // in surface intersections that are negative.
-        let ratios: Vec<Float> = surfaces
-            .iter()
-            .zip(placements.iter())
-            .zip(pseudo_marginal_ray.iter_surfaces())
-            .zip(per_surf_v.iter())
-            .map(|(((s, p), rays), &v)| {
-                (p.projected_semi_diameter(s.mask().semi_diameter(), v) / rays[0].height).abs()
-            })
-            .collect();
-
-        // Do not include the object or image surfaces when computing the aperture stop.
-        argmin(&ratios[1..ratios.len() - 1]) + 1
+        calc_aperture_stop(surfaces, placements, pseudo_marginal_ray, per_surf_v)
     }
 
     fn calc_back_focal_distance(
@@ -874,30 +857,13 @@ impl ParaxialSubView {
         aperture_stop: &usize,
         per_surf_v: &[TangentialVector],
     ) -> ParaxialRayBundle {
-        let ratios: Vec<Float> = surfaces
-            .iter()
-            .zip(placements.iter())
-            .zip(pseudo_marginal_ray.iter_surfaces())
-            .zip(per_surf_v.iter())
-            .map(|(((s, p), rays), &v)| {
-                p.projected_semi_diameter(s.mask().semi_diameter(), v) / rays[0].height
-            })
-            .collect();
-        let scale_factor = ratios[*aperture_stop];
-
-        let rays = pseudo_marginal_ray
-            .rays
-            .iter()
-            .map(|r| ParaxialRay {
-                height: r.height * scale_factor,
-                angle: r.angle * scale_factor,
-            })
-            .collect();
-
-        ParaxialRayBundle {
-            rays,
-            num_surfaces: pseudo_marginal_ray.num_surfaces,
-        }
+        calc_marginal_ray(
+            surfaces,
+            placements,
+            pseudo_marginal_ray,
+            aperture_stop,
+            per_surf_v,
+        )
     }
 
     /// Compute the parallel ray.
@@ -949,21 +915,7 @@ impl ParaxialSubView {
         surfaces: &[Box<dyn Surface>],
         placements: &[Placement],
     ) -> Result<ParaxialRayBundle> {
-        let ray = if sequential_sub_model.is_obj_at_inf() {
-            // Ray parallel to axis at a height of 1
-            vec![ParaxialRay {
-                height: 1.0,
-                angle: 0.0,
-            }]
-        } else {
-            // Ray starting from the axis at an angle of 1
-            vec![ParaxialRay {
-                height: 0.0,
-                angle: 1.0,
-            }]
-        };
-
-        Self::trace(ray, sequential_sub_model, surfaces, placements, false)
+        calc_pseudo_marginal_ray(sequential_sub_model, surfaces, placements)
     }
 
     /// Compute the reverse parallel ray.
@@ -1091,6 +1043,110 @@ fn surface_to_rtm(
         BoundaryType::Reflecting => Mat2x2::new(1.0, t, -2.0 / roc, -1.0 - 2.0 * t / roc),
         BoundaryType::NoOp => Mat2x2::new(1.0, t, 0.0, 1.0),
     }
+}
+
+/// Compute the pseudo-marginal ray for a submodel.
+pub(crate) fn calc_pseudo_marginal_ray(
+    sequential_sub_model: &dyn SequentialSubModel,
+    surfaces: &[Box<dyn Surface>],
+    placements: &[Placement],
+) -> Result<ParaxialRayBundle> {
+    let ray = if sequential_sub_model.is_obj_at_inf() {
+        vec![ParaxialRay {
+            height: 1.0,
+            angle: 0.0,
+        }]
+    } else {
+        vec![ParaxialRay {
+            height: 0.0,
+            angle: 1.0,
+        }]
+    };
+    ParaxialSubView::trace(ray, sequential_sub_model, surfaces, placements, false)
+}
+
+/// Compute the aperture stop surface index using the minimum aperture-ratio
+/// heuristic.
+pub(crate) fn calc_aperture_stop(
+    surfaces: &[Box<dyn Surface>],
+    placements: &[Placement],
+    pseudo_marginal_ray: &ParaxialRayBundle,
+    per_surf_v: &[TangentialVector],
+) -> usize {
+    let ratios: Vec<Float> = surfaces
+        .iter()
+        .zip(placements.iter())
+        .zip(pseudo_marginal_ray.iter_surfaces())
+        .zip(per_surf_v.iter())
+        .map(|(((s, p), rays), &v)| {
+            (p.projected_semi_diameter(s.mask().semi_diameter(), v) / rays[0].height).abs()
+        })
+        .collect();
+    argmin(&ratios[1..ratios.len() - 1]) + 1
+}
+
+/// Scale the pseudo-marginal ray to match the aperture stop semi-diameter.
+pub(crate) fn calc_marginal_ray(
+    surfaces: &[Box<dyn Surface>],
+    placements: &[Placement],
+    pseudo_marginal_ray: &ParaxialRayBundle,
+    aperture_stop: &usize,
+    per_surf_v: &[TangentialVector],
+) -> ParaxialRayBundle {
+    let ratios: Vec<Float> = surfaces
+        .iter()
+        .zip(placements.iter())
+        .zip(pseudo_marginal_ray.iter_surfaces())
+        .zip(per_surf_v.iter())
+        .map(|(((s, p), rays), &v)| {
+            p.projected_semi_diameter(s.mask().semi_diameter(), v) / rays[0].height
+        })
+        .collect();
+    let scale_factor = ratios[*aperture_stop];
+
+    let rays = pseudo_marginal_ray
+        .rays
+        .iter()
+        .map(|r| ParaxialRay {
+            height: r.height * scale_factor,
+            angle: r.angle * scale_factor,
+        })
+        .collect();
+
+    ParaxialRayBundle {
+        rays,
+        num_surfaces: pseudo_marginal_ray.num_surfaces,
+    }
+}
+
+/// Compute the paraxial marginal ray bundle for a given wavelength.
+///
+/// Uses the first tangential direction `(0, 1, 0)`, valid for all rotationally
+/// symmetric systems.
+pub(crate) fn marginal_ray_bundle(
+    model: &SequentialModel,
+    wavelength_id: usize,
+) -> Result<ParaxialRayBundle> {
+    let submodel = model
+        .submodel(wavelength_id)
+        .ok_or_else(|| anyhow!("wavelength_id {wavelength_id} out of range"))?;
+    let surfaces = model.surfaces();
+    let placements = model.placements();
+
+    let v = Vec3::new(0.0, 1.0, 0.0);
+    let per_surf_v = propagate_tangential_vec(v, surfaces, placements);
+    let pseudo = calc_pseudo_marginal_ray(submodel, surfaces, placements)?;
+    let stop = match model.stop_surface() {
+        Some(i) => i,
+        None => calc_aperture_stop(surfaces, placements, &pseudo, &per_surf_v),
+    };
+    Ok(calc_marginal_ray(
+        surfaces,
+        placements,
+        &pseudo,
+        &stop,
+        &per_surf_v,
+    ))
 }
 
 fn argmin(ratios: &[Float]) -> usize {
@@ -1289,7 +1345,7 @@ mod test {
         let wavelengths: [Float; 1] = [0.5876];
         let sequential_model = convexplano_lens::sequential_model(air, nbk7, &wavelengths);
         let seq_sub_model = sequential_model.submodel(0).expect("Submodel not found.");
-        let pseudo_marginal_ray = ParaxialSubView::calc_pseudo_marginal_ray(
+        let pseudo_marginal_ray = calc_pseudo_marginal_ray(
             seq_sub_model,
             sequential_model.surfaces(),
             sequential_model.placements(),


### PR DESCRIPTION
This implements the Solve trait for fixing the marginal ray height at the next surface. It is most often used for placing the image surface at the paraxial image plane.

A few internal reactors of the ParaxialView were made so that this solve could work without constructing a full `ParaxialView` instance.