### PR TITLE
feat: Expose Solve system to the GUI

### DIFF
--- a/crates/cherry-rs/src/core/sequential_model/builder.rs
+++ b/crates/cherry-rs/src/core/sequential_model/builder.rs
@@ -8,6 +8,17 @@ use crate::specs::{gaps::GapSpec, surfaces::SurfaceSpec};
 use super::SequentialModel;
 use super::solves::Solve;
 
+/// The output of a successful [`SequentialModelBuilder::build()`] call.
+/// Carries the model and the post-solve specs so callers can extract
+/// solved parameter values.
+pub struct BuildResult {
+    pub model: SequentialModel,
+    /// Gap specs after all solves have been applied.
+    pub gap_specs: Vec<GapSpec>,
+    /// Surface specs after all solves have been applied.
+    pub surface_specs: Vec<SurfaceSpec>,
+}
+
 /// Specs-based construction of [`SequentialModel`]s with optional extensions.
 ///
 /// Use this when you need solves or a custom surface registry. For simple
@@ -43,7 +54,7 @@ impl SequentialModelBuilder {
         }
     }
 
-    pub fn build(self) -> Result<SequentialModel> {
+    pub fn build(self) -> Result<BuildResult> {
         self.validate()?;
 
         // Destructure all fields before any partial moves.
@@ -76,13 +87,17 @@ impl SequentialModelBuilder {
         let mut model = build(&gap_specs, &surface_specs)?;
 
         let mut solves = solves;
-        solves.sort_by_key(|s| s.surface_index());
+        solves.sort_by_key(|s| (s.surface_index(), s.parameter_kind()));
         for solve in &solves {
             solve.apply(&model, &mut gap_specs, &mut surface_specs)?;
             model = build(&gap_specs, &surface_specs)?;
         }
 
-        Ok(model)
+        Ok(BuildResult {
+            model,
+            gap_specs,
+            surface_specs,
+        })
     }
 
     pub fn gap_specs(mut self, gap_specs: Vec<GapSpec>) -> Self {
@@ -141,7 +156,7 @@ mod tests {
     use crate::{
         core::Float,
         core::math::linalg::rotations::Rotation3D,
-        core::sequential_model::SequentialSubModel,
+        core::sequential_model::{SequentialSubModel, solves::SolveKind},
         n,
         specs::gaps::GapSpec,
         specs::surfaces::{BoundaryType, SurfaceSpec},
@@ -216,6 +231,76 @@ mod tests {
         fn surface_index(&self) -> usize {
             self.surface_index
         }
+    }
+
+    /// Sets thickness only if the surface's RoC already matches `roc_sentinel`.
+    /// Used to verify that a RoC solve ran before this thickness solve.
+    struct SetThicknessIfRoc {
+        gap_index: usize,
+        surface_index: usize,
+        roc_sentinel: f64,
+        value_if_match: f64,
+        value_if_no_match: f64,
+    }
+
+    impl Solve for SetThicknessIfRoc {
+        fn apply(
+            &self,
+            _model: &SequentialModel,
+            gap_specs: &mut Vec<GapSpec>,
+            surface_specs: &mut Vec<SurfaceSpec>,
+        ) -> Result<()> {
+            let roc = match &surface_specs[self.surface_index] {
+                SurfaceSpec::Sphere {
+                    radius_of_curvature,
+                    ..
+                } => *radius_of_curvature,
+                _ => f64::NAN,
+            };
+            gap_specs[self.gap_index].thickness = if (roc - self.roc_sentinel).abs() < 1e-9 {
+                self.value_if_match
+            } else {
+                self.value_if_no_match
+            };
+            Ok(())
+        }
+
+        fn surface_index(&self) -> usize {
+            self.surface_index
+        }
+
+        fn parameter_kind(&self) -> SolveKind {
+            SolveKind::Thickness
+        }
+    }
+
+    /// Sets `surface_specs[surface_index]` RoC to `value` unconditionally.
+    struct SetRoc {
+        surface_index: usize,
+        value: f64,
+    }
+
+    impl Solve for SetRoc {
+        fn apply(
+            &self,
+            _model: &SequentialModel,
+            _gap_specs: &mut Vec<GapSpec>,
+            surface_specs: &mut Vec<SurfaceSpec>,
+        ) -> Result<()> {
+            if let SurfaceSpec::Sphere {
+                radius_of_curvature,
+                ..
+            } = &mut surface_specs[self.surface_index]
+            {
+                *radius_of_curvature = self.value;
+            }
+            Ok(())
+        }
+
+        fn surface_index(&self) -> usize {
+            self.surface_index
+        }
+        // parameter_kind defaults to Curvature — runs before Thickness
     }
 
     // --- Validation tests ---
@@ -296,7 +381,8 @@ mod tests {
             .wavelengths(vec![0.587])
             .stop_surface(1)
             .build()
-            .expect("build should succeed");
+            .expect("build should succeed")
+            .model;
         assert_eq!(model.stop_surface(), Some(1));
     }
 
@@ -314,7 +400,8 @@ mod tests {
                 value: 99.0,
             })])
             .build()
-            .expect("build should succeed");
+            .expect("build should succeed")
+            .model;
 
         // Gap index 1 in the submodel corresponds to gap_specs[1].
         let thickness = model.submodel(0).unwrap().gaps()[1].thickness;
@@ -382,10 +469,42 @@ mod tests {
                 }),
             ])
             .build()
-            .expect("build should succeed");
+            .expect("build should succeed")
+            .model;
 
         assert_eq!(model.submodel(0).unwrap().gaps()[1].thickness, 33.0);
         assert_eq!(model.submodel(0).unwrap().gaps()[2].thickness, 55.0);
+    }
+
+    #[test]
+    fn roc_solve_runs_before_thickness_solve_on_same_surface() {
+        // Supply the thickness solve first, then the RoC solve, in reverse
+        // priority order. The builder must apply the RoC solve first (priority
+        // 0) so the thickness solve sees the updated RoC (sentinel 99.0).
+        let sentinel_roc = 99.0;
+        let model = SequentialModelBuilder::new()
+            .gap_specs(lens_gaps())
+            .surface_specs(lens_surfaces())
+            .wavelengths(vec![0.587])
+            .solves(vec![
+                Box::new(SetThicknessIfRoc {
+                    gap_index: 1,
+                    surface_index: 1,
+                    roc_sentinel: sentinel_roc,
+                    value_if_match: 42.0,
+                    value_if_no_match: 0.0,
+                }),
+                Box::new(SetRoc {
+                    surface_index: 1,
+                    value: sentinel_roc,
+                }),
+            ])
+            .build()
+            .expect("build should succeed")
+            .model;
+
+        // If RoC solve ran first, thickness is 42.0; if order was wrong, it's 0.0.
+        assert_eq!(model.submodel(0).unwrap().gaps()[1].thickness, 42.0);
     }
 
     #[test]
@@ -408,7 +527,8 @@ mod tests {
                 }),
             ])
             .build()
-            .expect("build should succeed");
+            .expect("build should succeed")
+            .model;
 
         let thickness = model.submodel(0).unwrap().gaps()[1].thickness;
         assert_eq!(thickness, 77.0);

--- a/crates/cherry-rs/src/core/sequential_model/solves/fno.rs
+++ b/crates/cherry-rs/src/core/sequential_model/solves/fno.rs
@@ -188,7 +188,8 @@ mod tests {
             .wavelengths(vec![0.5876])
             .solves(vec![Box::new(FNumberSolve::new(2, target_fno, 0))])
             .build()
-            .expect("build should succeed");
+            .expect("build should succeed")
+            .model;
         let pv = ParaxialView::new(&model, &field_specs(), false).unwrap();
         (model, pv)
     }
@@ -295,7 +296,8 @@ mod tests {
                 Box::new(MarginalRaySolve::new(2, 0.0, 0)),
             ])
             .build()
-            .expect("build should succeed");
+            .expect("build should succeed")
+            .model;
 
         let pv = ParaxialView::new(&model, &field_specs(), false).unwrap();
         let sub = pv.get(0, 0).unwrap();

--- a/crates/cherry-rs/src/core/sequential_model/solves/marginal_ray.rs
+++ b/crates/cherry-rs/src/core/sequential_model/solves/marginal_ray.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 use super::super::SequentialModel;
-use super::Solve;
+use super::{Solve, SolveKind};
 
 /// Adjusts a gap thickness so that the paraxial marginal ray height at the
 /// following surface equals a target value.
@@ -32,6 +32,10 @@ impl MarginalRaySolve {
 }
 
 impl Solve for MarginalRaySolve {
+    fn parameter_kind(&self) -> SolveKind {
+        SolveKind::Thickness
+    }
+
     fn apply(
         &self,
         model: &SequentialModel,
@@ -153,7 +157,8 @@ mod tests {
             .wavelengths(vec![0.5876])
             .solves(vec![Box::new(MarginalRaySolve::new(2, 0.0, 0))])
             .build()
-            .expect("build should succeed");
+            .expect("build should succeed")
+            .model;
 
         let pv = ParaxialView::new(&model, &field_specs(), false).unwrap();
         let sub = pv.get(0, 0).unwrap();
@@ -172,7 +177,8 @@ mod tests {
             .wavelengths(vec![0.5876])
             .solves(vec![Box::new(MarginalRaySolve::new(2, target, 0))])
             .build()
-            .expect("build should succeed");
+            .expect("build should succeed")
+            .model;
 
         let pv = ParaxialView::new(&model, &field_specs(), false).unwrap();
         let sub = pv.get(0, 0).unwrap();
@@ -301,7 +307,8 @@ mod tests {
             .wavelengths(vec![0.5876])
             .solves(vec![Box::new(MarginalRaySolve::new(2, 0.0, 0))])
             .build()
-            .expect("build should succeed");
+            .expect("build should succeed")
+            .model;
 
         let pv = ParaxialView::new(&model, &field_specs(), false).unwrap();
         let sub = pv.get(0, 0).unwrap();

--- a/crates/cherry-rs/src/core/sequential_model/solves/mod.rs
+++ b/crates/cherry-rs/src/core/sequential_model/solves/mod.rs
@@ -10,6 +10,18 @@ use super::SequentialModel;
 pub use fno::FNumberSolve;
 pub use marginal_ray::MarginalRaySolve;
 
+/// Which optical parameter a solve modifies.
+///
+/// Declaration order defines execution order within the same surface index:
+/// earlier variants run first. Shape parameters (`Curvature`) precede
+/// positional parameters (`Thickness`), matching the convention used by Zemax
+/// OpticStudio and CODE V.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SolveKind {
+    Curvature,
+    Thickness,
+}
+
 /// A solve that modifies optical system specs to satisfy a constraint.
 ///
 /// Solves are applied sequentially during model building. Each solve receives
@@ -34,4 +46,16 @@ pub trait Solve {
     /// gap k returns k here. For curvature solves (e.g. [`FNumberSolve`]),
     /// this is the index of the surface whose radius of curvature is modified.
     fn surface_index(&self) -> usize;
+
+    /// Secondary sort key used when two solves share the same `surface_index`.
+    ///
+    /// The builder sorts by `(surface_index, parameter_kind)`. Since
+    /// [`SolveKind`] derives `Ord` in declaration order,
+    /// [`SolveKind::Curvature`] runs before
+    /// [`SolveKind::Thickness`] at the same surface index. Implementations
+    /// that modify a parameter not yet represented here should add a new
+    /// variant to [`SolveKind`] in the appropriate position.
+    fn parameter_kind(&self) -> SolveKind {
+        SolveKind::Curvature
+    }
 }

--- a/crates/cherry-rs/src/gui/app.rs
+++ b/crates/cherry-rs/src/gui/app.rs
@@ -545,9 +545,12 @@ impl eframe::App for CherryApp {
 
         // Floating windows
         if self.windows.specs {
-            let changed = self
-                .specs_window
-                .show(ctx, &mut self.windows.specs, &mut self.specs);
+            let changed = self.specs_window.show(
+                ctx,
+                &mut self.windows.specs,
+                &mut self.specs,
+                self.latest_result.as_ref(),
+            );
             if changed {
                 self.bump_input_id();
             }

--- a/crates/cherry-rs/src/gui/compute.rs
+++ b/crates/cherry-rs/src/gui/compute.rs
@@ -4,14 +4,17 @@ use std::sync::mpsc::{Receiver, Sender};
 use std::{collections::HashMap, rc::Rc};
 
 use crate::{
-    ParaxialView, SequentialModel, components_view, cross_section_view, ray_trace_3d_view,
-    specs::fields::PupilSampling, trace_ray_bundle, views::ray_trace_3d::SamplingConfig,
+    ParaxialView, SequentialModel, SequentialModelBuilder, components_view, cross_section_view,
+    ray_trace_3d_view,
+    specs::{fields::PupilSampling, gaps::GapSpec, surfaces::SurfaceSpec},
+    trace_ray_bundle,
+    views::ray_trace_3d::SamplingConfig,
 };
 
 use super::{
     convert,
-    model::SystemSpecs,
-    result_package::{ResultPackage, SurfaceDesc},
+    model::{SolveSpec, SystemSpecs},
+    result_package::{ResultPackage, SolvedValues, SurfaceDesc},
 };
 
 pub struct ComputeRequest {
@@ -120,15 +123,28 @@ fn run_compute(
         Err(e) => return ResultPackage::error(req.id, format!("Specs error: {e}")),
     };
 
-    let seq = match SequentialModel::from_surface_specs(
-        &parsed.gaps,
-        &parsed.surfaces,
-        &parsed.wavelengths,
-        req.specs.stop_surface,
-    ) {
-        Ok(s) => s,
-        Err(e) => return ResultPackage::error(req.id, format!("Model error: {e}")),
+    let build_result = {
+        let mut builder = SequentialModelBuilder::new()
+            .gap_specs(parsed.gaps)
+            .surface_specs(parsed.surfaces)
+            .wavelengths(parsed.wavelengths.clone())
+            .solves(parsed.solves);
+        if let Some(stop) = req.specs.stop_surface {
+            builder = builder.stop_surface(stop);
+        }
+        match builder.build() {
+            Ok(r) => r,
+            Err(e) => return ResultPackage::error(req.id, format!("Model error: {e}")),
+        }
     };
+
+    let solved_values = extract_solved_values(
+        &req.specs.solves,
+        &build_result.gap_specs,
+        &build_result.surface_specs,
+    );
+
+    let seq = build_result.model;
 
     let wavelengths = seq.wavelengths().to_vec();
     let surfaces = build_surface_descs(&seq);
@@ -147,6 +163,7 @@ fn run_compute(
                 ray_trace: None,
                 cross_section: None,
                 error: Some(format!("Paraxial error: {e}")),
+                solved_values,
             };
         }
     };
@@ -197,6 +214,44 @@ fn run_compute(
         ray_trace: trace,
         cross_section,
         error: None,
+        solved_values,
+    }
+}
+
+fn extract_solved_values(
+    solves: &[SolveSpec],
+    gap_specs: &[GapSpec],
+    surface_specs: &[SurfaceSpec],
+) -> SolvedValues {
+    let mut sv = SolvedValues::default();
+    for solve in solves {
+        match solve {
+            SolveSpec::MarginalRayHeight { gap_index, .. } => {
+                if let Some(gap) = gap_specs.get(*gap_index) {
+                    sv.gap_thicknesses.insert(*gap_index, gap.thickness);
+                }
+            }
+            SolveSpec::FNumber { surface_index, .. } => {
+                if let Some(roc) = roc_from_spec(surface_specs.get(*surface_index)) {
+                    sv.surface_rocs.insert(*surface_index, roc);
+                }
+            }
+        }
+    }
+    sv
+}
+
+fn roc_from_spec(spec: Option<&SurfaceSpec>) -> Option<f64> {
+    match spec? {
+        SurfaceSpec::Conic {
+            radius_of_curvature,
+            ..
+        } => Some(*radius_of_curvature),
+        SurfaceSpec::Sphere {
+            radius_of_curvature,
+            ..
+        } => Some(*radius_of_curvature),
+        _ => None,
     }
 }
 

--- a/crates/cherry-rs/src/gui/convert.rs
+++ b/crates/cherry-rs/src/gui/convert.rs
@@ -3,11 +3,11 @@ use std::rc::Rc;
 use anyhow::{Context, Result, bail};
 
 use crate::{
-    ApertureSpec, BoundaryType, ConstantRefractiveIndex, EulerAngles, FieldSpec, GapSpec,
-    RefractiveIndexSpec, Rotation3D, SurfaceSpec,
+    ApertureSpec, BoundaryType, ConstantRefractiveIndex, EulerAngles, FNumberSolve, FieldSpec,
+    GapSpec, MarginalRaySolve, RefractiveIndexSpec, Rotation3D, Solve, SurfaceSpec,
 };
 
-use super::model::{FieldMode, SurfaceKind, SurfaceVariant, SystemSpecs};
+use super::model::{FieldMode, SolveSpec, SurfaceKind, SurfaceVariant, SystemSpecs};
 
 /// Parsed core specs ready for model construction.
 pub struct ParsedSpecs {
@@ -17,6 +17,7 @@ pub struct ParsedSpecs {
     pub aperture: ApertureSpec,
     pub wavelengths: Vec<f64>,
     pub background: std::rc::Rc<dyn RefractiveIndexSpec>,
+    pub solves: Vec<Box<dyn Solve>>,
 }
 
 /// Parse a string as f64, treating "Infinity" / "infinity" / "inf" as
@@ -214,6 +215,33 @@ fn convert_specs_inner(
         materials,
     )?;
 
+    let solves: Vec<Box<dyn Solve>> = specs
+        .solves
+        .iter()
+        .map(|s| -> Box<dyn Solve> {
+            match s {
+                SolveSpec::MarginalRayHeight {
+                    gap_index,
+                    target_height,
+                    wavelength_id,
+                } => Box::new(MarginalRaySolve::new(
+                    *gap_index,
+                    *target_height,
+                    *wavelength_id,
+                )),
+                SolveSpec::FNumber {
+                    surface_index,
+                    target_fno,
+                    wavelength_id,
+                } => Box::new(FNumberSolve::new(
+                    *surface_index,
+                    *target_fno,
+                    *wavelength_id,
+                )),
+            }
+        })
+        .collect();
+
     Ok(ParsedSpecs {
         surfaces,
         gaps,
@@ -221,6 +249,7 @@ fn convert_specs_inner(
         aperture,
         wavelengths,
         background,
+        solves,
     })
 }
 
@@ -270,4 +299,68 @@ fn resolve_refractive_index(
     let n = parse_float(&row.refractive_index)
         .with_context(|| format!("surface {surface_idx}: refractive index"))?;
     Ok(Rc::new(ConstantRefractiveIndex::new(n, 0.0)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gui::model::{SolveSpec, SurfaceRow, SystemSpecs};
+
+    fn convert(specs: &SystemSpecs) -> ParsedSpecs {
+        #[cfg(not(feature = "ri-info"))]
+        return convert_specs(specs).expect("convert should succeed");
+        #[cfg(feature = "ri-info")]
+        return convert_specs(specs, &Default::default()).expect("convert should succeed");
+    }
+
+    #[test]
+    fn empty_solves_converts_ok() {
+        let specs = SystemSpecs::default();
+        let parsed = convert(&specs);
+        assert!(parsed.solves.is_empty());
+    }
+
+    #[test]
+    fn marginal_ray_height_spec_converts_to_solve() {
+        let mut specs = SystemSpecs {
+            surfaces: vec![
+                SurfaceRow::new_object("Infinity"),
+                SurfaceRow::new_sphere("12.5", "25.8", "5.3", "1.515"),
+                SurfaceRow::new_sphere("12.5", "Infinity", "46.6", "1.0"),
+                SurfaceRow::new_image(),
+            ],
+            solves: vec![SolveSpec::MarginalRayHeight {
+                gap_index: 2,
+                target_height: 0.0,
+                wavelength_id: 0,
+            }],
+            ..Default::default()
+        };
+        specs.wavelengths = vec!["0.567".into()];
+        let parsed = convert(&specs);
+        assert_eq!(parsed.solves.len(), 1);
+        assert_eq!(parsed.solves[0].surface_index(), 2);
+    }
+
+    #[test]
+    fn fno_spec_converts_to_solve() {
+        let mut specs = SystemSpecs {
+            surfaces: vec![
+                SurfaceRow::new_object("Infinity"),
+                SurfaceRow::new_sphere("12.5", "25.8", "5.3", "1.515"),
+                SurfaceRow::new_sphere("12.5", "Infinity", "46.6", "1.0"),
+                SurfaceRow::new_image(),
+            ],
+            solves: vec![SolveSpec::FNumber {
+                surface_index: 1,
+                target_fno: 4.0,
+                wavelength_id: 0,
+            }],
+            ..Default::default()
+        };
+        specs.wavelengths = vec!["0.567".into()];
+        let parsed = convert(&specs);
+        assert_eq!(parsed.solves.len(), 1);
+        assert_eq!(parsed.solves[0].surface_index(), 1);
+    }
 }

--- a/crates/cherry-rs/src/gui/examples.rs
+++ b/crates/cherry-rs/src/gui/examples.rs
@@ -48,6 +48,7 @@ pub fn mirrors_figure_z() -> SystemSpecs {
         background_n: "1.0".into(),
         background_material_key: None,
         stop_surface: None,
+        solves: Vec::new(),
     }
 }
 
@@ -90,6 +91,7 @@ pub fn petzval_lens() -> SystemSpecs {
         background_n: "1.0".into(),
         background_material_key: None,
         stop_surface: None,
+        solves: Vec::new(),
     }
 }
 
@@ -126,6 +128,7 @@ pub fn biconvex_lens() -> SystemSpecs {
         background_n: "1.0".into(),
         background_material_key: None,
         stop_surface: None,
+        solves: Vec::new(),
     }
 }
 
@@ -195,6 +198,7 @@ pub fn convexplano_lens_with_materials() -> SystemSpecs {
         background_n: "1.0".into(),
         background_material_key: Some("other:air:Ciddor".into()),
         stop_surface: None,
+        solves: Vec::new(),
     }
 }
 
@@ -322,6 +326,7 @@ pub fn f_theta_scan_lens() -> SystemSpecs {
         background_n: "1.0".into(),
         background_material_key: Some("other:air:Ciddor".into()),
         stop_surface: None,
+        solves: Vec::new(),
     }
 }
 
@@ -367,5 +372,6 @@ pub fn concave_mirror() -> SystemSpecs {
         background_n: "1.0".into(),
         background_material_key: None,
         stop_surface: None,
+        solves: Vec::new(),
     }
 }

--- a/crates/cherry-rs/src/gui/model.rs
+++ b/crates/cherry-rs/src/gui/model.rs
@@ -1,4 +1,140 @@
+use std::fmt;
+
 use serde::{Deserialize, Serialize};
+
+/// Which table parameter a solve controls.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SolveParameter {
+    Thickness,
+    RadiusOfCurvature,
+}
+
+impl fmt::Display for SolveParameter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Thickness => write!(f, "Thickness"),
+            Self::RadiusOfCurvature => write!(f, "Curvature"),
+        }
+    }
+}
+
+/// Serializable description of one active solve on the system.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum SolveSpec {
+    MarginalRayHeight {
+        gap_index: usize,
+        target_height: f64,
+        wavelength_id: usize,
+    },
+    FNumber {
+        surface_index: usize,
+        target_fno: f64,
+        wavelength_id: usize,
+    },
+}
+
+impl SolveSpec {
+    pub(crate) fn surface_index(&self) -> usize {
+        match self {
+            Self::MarginalRayHeight { gap_index, .. } => *gap_index,
+            Self::FNumber { surface_index, .. } => *surface_index,
+        }
+    }
+
+    pub(crate) fn set_surface_index(&mut self, idx: usize) {
+        match self {
+            Self::MarginalRayHeight { gap_index, .. } => *gap_index = idx,
+            Self::FNumber { surface_index, .. } => *surface_index = idx,
+        }
+    }
+
+    pub(crate) fn parameter(&self) -> SolveParameter {
+        match self {
+            Self::MarginalRayHeight { .. } => SolveParameter::Thickness,
+            Self::FNumber { .. } => SolveParameter::RadiusOfCurvature,
+        }
+    }
+
+    pub(crate) fn is_paraxial(&self) -> bool {
+        match self {
+            Self::MarginalRayHeight { .. } | Self::FNumber { .. } => true,
+        }
+    }
+}
+
+/// Transient UI state for the solve-configuration popup. Lives in `model.rs`
+/// so both the window and panel can reference it without a circular dependency.
+#[derive(Clone, Debug)]
+pub struct SolvePopupState {
+    pub surface_index: usize,
+    pub parameter: SolveParameter,
+    pub type_str: String,
+    pub target: String,
+    pub wavelength_id: usize,
+    pub error: Option<String>,
+}
+
+impl SolvePopupState {
+    pub fn open(
+        surface_index: usize,
+        parameter: SolveParameter,
+        existing: Option<&SolveSpec>,
+    ) -> Self {
+        match existing {
+            None => Self {
+                surface_index,
+                parameter,
+                type_str: "None".to_owned(),
+                target: String::new(),
+                wavelength_id: 0,
+                error: None,
+            },
+            Some(SolveSpec::MarginalRayHeight {
+                target_height,
+                wavelength_id,
+                ..
+            }) => Self {
+                surface_index,
+                parameter,
+                type_str: "Marginal ray height".to_owned(),
+                target: target_height.to_string(),
+                wavelength_id: *wavelength_id,
+                error: None,
+            },
+            Some(SolveSpec::FNumber {
+                target_fno,
+                wavelength_id,
+                ..
+            }) => Self {
+                surface_index,
+                parameter,
+                type_str: "F/#".to_owned(),
+                target: target_fno.to_string(),
+                wavelength_id: *wavelength_id,
+                error: None,
+            },
+        }
+    }
+
+    /// Returns true if the currently selected solve type is a paraxial solve.
+    pub fn is_paraxial(&self) -> bool {
+        match self.type_str.as_str() {
+            "Marginal ray height" => SolveSpec::MarginalRayHeight {
+                gap_index: 0,
+                target_height: 0.0,
+                wavelength_id: 0,
+            }
+            .is_paraxial(),
+            "F/#" => SolveSpec::FNumber {
+                surface_index: 0,
+                target_fno: 1.0,
+                wavelength_id: 0,
+            }
+            .is_paraxial(),
+            _ => false,
+        }
+    }
+}
 
 /// Which surface variant this row represents.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -249,10 +385,14 @@ pub struct SystemSpecs {
     /// User-designated aperture stop surface index. `None` = auto-derived.
     #[serde(default)]
     pub stop_surface: Option<usize>,
+    /// Active solves on the system, serialized as part of system state.
+    #[serde(default)]
+    pub solves: Vec<SolveSpec>,
 }
 
 impl SystemSpecs {
-    /// Insert a default surface after index `idx` and adjust `stop_surface`.
+    /// Insert a default surface after index `idx` and adjust `stop_surface` and
+    /// solves.
     pub fn insert_surface_after(&mut self, idx: usize) {
         self.surfaces.insert(idx + 1, SurfaceRow::new_default());
         if let Some(stop) = self.stop_surface
@@ -260,9 +400,14 @@ impl SystemSpecs {
         {
             self.stop_surface = Some(stop + 1);
         }
+        for solve in &mut self.solves {
+            if solve.surface_index() > idx {
+                solve.set_surface_index(solve.surface_index() + 1);
+            }
+        }
     }
 
-    /// Remove the surface at index `idx` and adjust `stop_surface`.
+    /// Remove the surface at index `idx` and adjust `stop_surface` and solves.
     ///
     /// Does nothing if fewer than 3 surfaces remain (must keep object + image).
     pub fn delete_surface(&mut self, idx: usize) {
@@ -275,6 +420,19 @@ impl SystemSpecs {
             Some(stop) if idx < stop => Some(stop - 1),
             other => other,
         };
+        self.solves.retain(|s| s.surface_index() != idx);
+        for solve in &mut self.solves {
+            if solve.surface_index() > idx {
+                solve.set_surface_index(solve.surface_index() - 1);
+            }
+        }
+    }
+
+    /// Return the active solve for a given cell, if any.
+    pub fn solve_for(&self, surface_index: usize, parameter: SolveParameter) -> Option<&SolveSpec> {
+        self.solves
+            .iter()
+            .find(|s| s.surface_index() == surface_index && s.parameter() == parameter)
     }
 }
 
@@ -320,6 +478,7 @@ impl Default for SystemSpecs {
             background_n: "1.0".into(),
             background_material_key: None,
             stop_surface: None,
+            solves: Vec::new(),
         }
     }
 }
@@ -409,5 +568,111 @@ mod tests {
         specs.stop_surface = None;
         specs.delete_surface(2);
         assert_eq!(specs.stop_surface, None);
+    }
+
+    // --- SolveSpec serde ---
+
+    #[test]
+    fn solve_spec_serde_roundtrip() {
+        let specs = vec![
+            SolveSpec::MarginalRayHeight {
+                gap_index: 2,
+                target_height: 0.0,
+                wavelength_id: 0,
+            },
+            SolveSpec::FNumber {
+                surface_index: 1,
+                target_fno: 4.0,
+                wavelength_id: 1,
+            },
+        ];
+        let json = serde_json::to_string(&specs).unwrap();
+        let roundtripped: Vec<SolveSpec> = serde_json::from_str(&json).unwrap();
+        assert_eq!(specs, roundtripped);
+    }
+
+    // --- insert_surface_after renumbers solves ---
+
+    #[test]
+    fn insert_surface_after_renumbers_solves() {
+        let mut specs = five_surface_specs();
+        specs.solves = vec![SolveSpec::MarginalRayHeight {
+            gap_index: 2,
+            target_height: 0.0,
+            wavelength_id: 0,
+        }];
+        specs.insert_surface_after(1); // insert at idx 2, solve was at 2 → becomes 3
+        assert_eq!(specs.solves[0].surface_index(), 3);
+    }
+
+    #[test]
+    fn insert_surface_after_does_not_renumber_solves_at_or_before_insert() {
+        let mut specs = five_surface_specs();
+        specs.solves = vec![SolveSpec::MarginalRayHeight {
+            gap_index: 1,
+            target_height: 0.0,
+            wavelength_id: 0,
+        }];
+        specs.insert_surface_after(1); // solve at idx 1, insert after 1 → unchanged
+        assert_eq!(specs.solves[0].surface_index(), 1);
+    }
+
+    // --- delete_surface removes and renumbers solves ---
+
+    #[test]
+    fn delete_surface_removes_matching_solve() {
+        let mut specs = five_surface_specs();
+        specs.solves = vec![SolveSpec::MarginalRayHeight {
+            gap_index: 2,
+            target_height: 0.0,
+            wavelength_id: 0,
+        }];
+        specs.delete_surface(2);
+        assert!(specs.solves.is_empty());
+    }
+
+    #[test]
+    fn delete_surface_renumbers_higher_solves() {
+        let mut specs = five_surface_specs();
+        specs.solves = vec![SolveSpec::MarginalRayHeight {
+            gap_index: 3,
+            target_height: 0.0,
+            wavelength_id: 0,
+        }];
+        specs.delete_surface(2); // delete surface 2 → solve at 3 becomes 2
+        assert_eq!(specs.solves[0].surface_index(), 2);
+    }
+
+    // --- solve_for ---
+
+    #[test]
+    fn solve_for_returns_matching_solve() {
+        let mut specs = five_surface_specs();
+        specs.solves = vec![SolveSpec::MarginalRayHeight {
+            gap_index: 2,
+            target_height: 5.0,
+            wavelength_id: 0,
+        }];
+        let found = specs.solve_for(2, SolveParameter::Thickness);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().surface_index(), 2);
+    }
+
+    #[test]
+    fn solve_for_returns_none_for_unmatched() {
+        let mut specs = five_surface_specs();
+        specs.solves = vec![SolveSpec::MarginalRayHeight {
+            gap_index: 2,
+            target_height: 5.0,
+            wavelength_id: 0,
+        }];
+        // Wrong parameter type
+        assert!(
+            specs
+                .solve_for(2, SolveParameter::RadiusOfCurvature)
+                .is_none()
+        );
+        // Wrong index
+        assert!(specs.solve_for(3, SolveParameter::Thickness).is_none());
     }
 }

--- a/crates/cherry-rs/src/gui/panels/surfaces.rs
+++ b/crates/cherry-rs/src/gui/panels/surfaces.rs
@@ -1,10 +1,18 @@
 use egui_extras::{Column, TableBuilder};
 
-use super::super::model::{SurfaceKind, SurfaceVariant, SystemSpecs};
+use super::super::model::{
+    SolveParameter, SolvePopupState, SurfaceKind, SurfaceVariant, SystemSpecs,
+};
 use super::{format_display_float, inf_formatter, inf_parser, parse_display_float};
+use crate::gui::result_package::SolvedValues;
 
 /// Draw the surfaces editor panel. Returns true if any spec was modified.
-pub fn surfaces_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
+pub fn surfaces_panel(
+    ui: &mut egui::Ui,
+    specs: &mut SystemSpecs,
+    solved_values: Option<&SolvedValues>,
+    solve_popup: &mut Option<SolvePopupState>,
+) -> bool {
     let mut changed = false;
 
     // Snapshot material state before mutable table iteration.
@@ -105,6 +113,15 @@ pub fn surfaces_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
                 let mut delete_at: Option<usize> = None;
 
                 for row_idx in 0..num_surfaces {
+                    // Snapshot solve state before taking mutable borrow of surf.
+                    let roc_solve_spec = specs
+                        .solve_for(row_idx, SolveParameter::RadiusOfCurvature)
+                        .cloned();
+                    let thick_solve_spec =
+                        specs.solve_for(row_idx, SolveParameter::Thickness).cloned();
+                    let has_roc_solve = roc_solve_spec.is_some();
+                    let has_thick_solve = thick_solve_spec.is_some();
+
                     body.row(22.0, |mut row| {
                         if specs.stop_surface == Some(row_idx) {
                             row.set_selected(true);
@@ -203,14 +220,39 @@ pub fn surfaces_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
                         // Radius of Curvature
                         row.col(|ui| {
                             if is_curved {
-                                changed |= drag_inf(
-                                    ui,
-                                    &mut surf.radius_of_curvature,
-                                    row_idx,
-                                    "roc",
-                                    f64::NEG_INFINITY..=f64::INFINITY,
-                                    1.0,
-                                );
+                                if has_roc_solve {
+                                    match solved_values
+                                        .and_then(|sv| sv.surface_rocs.get(&row_idx).copied())
+                                    {
+                                        Some(val) => solved_cell(ui, val, "F"),
+                                        None => {
+                                            ui.weak("—");
+                                        }
+                                    }
+                                    if solve_button(ui, row_idx, "roc_solve", true).clicked() {
+                                        *solve_popup = Some(SolvePopupState::open(
+                                            row_idx,
+                                            SolveParameter::RadiusOfCurvature,
+                                            roc_solve_spec.as_ref(),
+                                        ));
+                                    }
+                                } else {
+                                    changed |= drag_inf(
+                                        ui,
+                                        &mut surf.radius_of_curvature,
+                                        row_idx,
+                                        "roc",
+                                        f64::NEG_INFINITY..=f64::INFINITY,
+                                        1.0,
+                                    );
+                                    if solve_button(ui, row_idx, "roc_solve", false).clicked() {
+                                        *solve_popup = Some(SolvePopupState::open(
+                                            row_idx,
+                                            SolveParameter::RadiusOfCurvature,
+                                            None,
+                                        ));
+                                    }
+                                }
                             }
                         });
 
@@ -239,14 +281,39 @@ pub fn surfaces_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
                         // Thickness
                         row.col(|ui| {
                             if !is_image {
-                                changed |= drag_inf(
-                                    ui,
-                                    &mut surf.thickness,
-                                    row_idx,
-                                    "thick",
-                                    0.0..=f64::INFINITY,
-                                    0.5,
-                                );
+                                if has_thick_solve {
+                                    match solved_values
+                                        .and_then(|sv| sv.gap_thicknesses.get(&row_idx).copied())
+                                    {
+                                        Some(val) => solved_cell(ui, val, "M"),
+                                        None => {
+                                            ui.weak("—");
+                                        }
+                                    }
+                                    if solve_button(ui, row_idx, "thick_solve", true).clicked() {
+                                        *solve_popup = Some(SolvePopupState::open(
+                                            row_idx,
+                                            SolveParameter::Thickness,
+                                            thick_solve_spec.as_ref(),
+                                        ));
+                                    }
+                                } else {
+                                    changed |= drag_inf(
+                                        ui,
+                                        &mut surf.thickness,
+                                        row_idx,
+                                        "thick",
+                                        0.0..=f64::INFINITY,
+                                        0.5,
+                                    );
+                                    if solve_button(ui, row_idx, "thick_solve", false).clicked() {
+                                        *solve_popup = Some(SolvePopupState::open(
+                                            row_idx,
+                                            SolveParameter::Thickness,
+                                            None,
+                                        ));
+                                    }
+                                }
                             }
                         });
 
@@ -357,6 +424,30 @@ pub fn surfaces_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
     changed
 }
 
+/// Renders a read-only label for a solved cell with a type badge.
+fn solved_cell(ui: &mut egui::Ui, val: f64, badge: &str) {
+    ui.horizontal(|ui| {
+        ui.label(format!("{val:.4}"));
+        ui.weak(format!("[{badge}]"));
+    });
+}
+
+/// Renders a small solve indicator button. Returns the egui Response.
+/// `active` = a solve is currently set on this cell.
+fn solve_button(ui: &mut egui::Ui, row: usize, col: &str, active: bool) -> egui::Response {
+    let label = if active { "●" } else { "○" };
+    let id = egui::Id::new(format!("solve_btn_{row}_{col}"));
+    ui.push_id(id, |ui| {
+        let btn = ui.small_button(label);
+        btn.on_hover_text(if active {
+            "Solve active"
+        } else {
+            "Configure solve"
+        })
+    })
+    .inner
+}
+
 /// DragValue cell without special infinity handling.
 fn drag_value(
     ui: &mut egui::Ui,
@@ -412,7 +503,7 @@ mod tests {
     use super::*;
     use egui_kittest::{Harness, kittest::Queryable};
 
-    use crate::gui::model::{SurfaceKind, SurfaceRow, SurfaceVariant, SystemSpecs};
+    use crate::gui::model::{SolveSpec, SurfaceKind, SurfaceRow, SurfaceVariant, SystemSpecs};
 
     fn specs_with_reflecting_surface() -> SystemSpecs {
         let mut mirror = SurfaceRow::new_sphere("12.7", "Infinity", "100.0", "1.0");
@@ -434,13 +525,17 @@ mod tests {
         }
     }
 
+    fn default_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
+        surfaces_panel(ui, specs, None, &mut None)
+    }
+
     /// The object row must have a + button so users can insert surfaces after
     /// it.
     #[test]
     fn object_row_has_add_button() {
         let mut specs = minimal_specs();
         let mut harness = Harness::new_ui(|ui| {
-            surfaces_panel(ui, &mut specs);
+            default_panel(ui, &mut specs);
         });
         harness.run();
         // Panics if no + button is found — that is the red state.
@@ -453,7 +548,7 @@ mod tests {
         let mut specs = minimal_specs();
         {
             let mut harness = Harness::new_ui(|ui| {
-                surfaces_panel(ui, &mut specs);
+                default_panel(ui, &mut specs);
             });
             harness.run();
             harness.get_by_label("+").click();
@@ -473,7 +568,7 @@ mod tests {
     fn actions_column_is_rightmost_with_reflecting_surfaces() {
         let mut specs = specs_with_reflecting_surface();
         let mut harness = Harness::new_ui(|ui| {
-            surfaces_panel(ui, &mut specs);
+            default_panel(ui, &mut specs);
         });
         harness.run();
 
@@ -489,6 +584,84 @@ mod tests {
              + button at x={:.1}, θ header at x={:.1}",
             add_button.rect().center().x,
             theta_header.rect().center().x,
+        );
+    }
+
+    fn lens_specs() -> SystemSpecs {
+        SystemSpecs {
+            surfaces: vec![
+                SurfaceRow::new_object("Infinity"),
+                SurfaceRow::new_sphere("12.5", "25.8", "5.3", "1.515"),
+                SurfaceRow::new_sphere("12.5", "Infinity", "46.6", "1.0"),
+                SurfaceRow::new_image(),
+            ],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn solve_button_present_on_roc_cell_for_sphere() {
+        let mut specs = lens_specs();
+        let mut harness = Harness::new_ui(|ui| {
+            default_panel(ui, &mut specs);
+        });
+        harness.run();
+        // The ○ solve button must appear (at least one, since we have curved surfaces).
+        harness
+            .get_all_by_label("○")
+            .next()
+            .expect("solve button should exist on RoC cell");
+    }
+
+    #[test]
+    fn solved_roc_cell_shows_badge() {
+        use crate::gui::result_package::SolvedValues;
+        let mut specs = lens_specs();
+        specs.solves = vec![SolveSpec::FNumber {
+            surface_index: 1,
+            target_fno: 4.0,
+            wavelength_id: 0,
+        }];
+        let mut sv = SolvedValues::default();
+        sv.surface_rocs.insert(1, 12.345);
+
+        let mut harness = Harness::new_ui(|ui| {
+            surfaces_panel(ui, &mut specs, Some(&sv), &mut None);
+        });
+        harness.run();
+        harness.get_by_label("[F]");
+    }
+
+    #[test]
+    fn solved_roc_cell_shows_placeholder_before_result() {
+        let mut specs = lens_specs();
+        specs.solves = vec![SolveSpec::FNumber {
+            surface_index: 1,
+            target_fno: 4.0,
+            wavelength_id: 0,
+        }];
+
+        let mut harness = Harness::new_ui(|ui| {
+            surfaces_panel(ui, &mut specs, None, &mut None);
+        });
+        harness.run();
+        harness.get_by_label("—");
+    }
+
+    #[test]
+    fn unsolved_cell_shows_drag_value_not_badge() {
+        let mut specs = lens_specs();
+        // No solves active — DragValues should be present and solve buttons should
+        // show the inactive "○" icon, not the active "●".
+        let mut harness = Harness::new_ui(|ui| {
+            default_panel(ui, &mut specs);
+        });
+        harness.run();
+        // Active solve indicator "●" should not appear when no solves are configured.
+        let active_buttons: Vec<_> = harness.query_all_by_label("●").collect();
+        assert!(
+            active_buttons.is_empty(),
+            "should not show active solve buttons when no solve is active"
         );
     }
 }

--- a/crates/cherry-rs/src/gui/result_package.rs
+++ b/crates/cherry-rs/src/gui/result_package.rs
@@ -1,7 +1,19 @@
+use std::collections::HashMap;
+
 use crate::{
     CrossSectionView, FieldSpec, ParaxialView, TraceResultsCollection,
     core::math::{linalg::mat3x3::Mat3x3, vec3::Vec3},
 };
+
+/// Post-solve parameter values keyed by their index in the surfaces table.
+/// Only cells with an active solve are populated.
+#[derive(Default)]
+pub struct SolvedValues {
+    /// gap_index → solved thickness (mm).
+    pub gap_thicknesses: HashMap<usize, f64>,
+    /// surface_index → solved radius of curvature (mm).
+    pub surface_rocs: HashMap<usize, f64>,
+}
 
 /// Lightweight description of a surface for display in dropdowns.
 pub struct SurfaceDesc {
@@ -32,6 +44,7 @@ pub struct ResultPackage {
     pub ray_trace: Option<TraceResultsCollection>,
     pub cross_section: Option<CrossSectionView>,
     pub error: Option<String>,
+    pub solved_values: SolvedValues,
 }
 
 impl ResultPackage {
@@ -47,6 +60,7 @@ impl ResultPackage {
             ray_trace: None,
             cross_section: None,
             error: Some(msg),
+            solved_values: SolvedValues::default(),
         }
     }
 }

--- a/crates/cherry-rs/src/gui/windows/cross_section.rs
+++ b/crates/cherry-rs/src/gui/windows/cross_section.rs
@@ -840,6 +840,7 @@ mod tests {
             ray_trace: None,
             cross_section: Some(cs),
             error: None,
+            solved_values: Default::default(),
         };
         let mut harness = Harness::new_state(
             |ctx, (w, r): &mut (CrossSectionWindow, ResultPackage)| {

--- a/crates/cherry-rs/src/gui/windows/paraxial.rs
+++ b/crates/cherry-rs/src/gui/windows/paraxial.rs
@@ -247,6 +247,7 @@ mod tests {
             ray_trace: None,
             cross_section: None,
             error: None,
+            solved_values: Default::default(),
         }
     }
 

--- a/crates/cherry-rs/src/gui/windows/ray_fan.rs
+++ b/crates/cherry-rs/src/gui/windows/ray_fan.rs
@@ -489,6 +489,7 @@ mod tests {
             ray_trace: None,
             cross_section: None,
             error: None,
+            solved_values: Default::default(),
         }
     }
 
@@ -574,6 +575,7 @@ mod tests {
             ray_trace: trace,
             cross_section: None,
             error: None,
+            solved_values: Default::default(),
         }
     }
 

--- a/crates/cherry-rs/src/gui/windows/specs.rs
+++ b/crates/cherry-rs/src/gui/windows/specs.rs
@@ -1,24 +1,33 @@
 use crate::gui::{
-    model::{SpecsTab, SystemSpecs},
+    model::{SolveParameter, SolvePopupState, SolveSpec, SpecsTab, SystemSpecs},
     panels,
+    result_package::{ResultPackage, SolvedValues},
 };
 
 /// Floating specs input window with tabbed panels.
 pub struct SpecsWindow {
     pub active_tab: SpecsTab,
+    solve_popup: Option<SolvePopupState>,
 }
 
 impl Default for SpecsWindow {
     fn default() -> Self {
         Self {
             active_tab: SpecsTab::Surfaces,
+            solve_popup: None,
         }
     }
 }
 
 impl SpecsWindow {
     /// Show the specs window. Returns true if any spec was modified.
-    pub fn show(&mut self, ctx: &egui::Context, open: &mut bool, specs: &mut SystemSpecs) -> bool {
+    pub fn show(
+        &mut self,
+        ctx: &egui::Context,
+        open: &mut bool,
+        specs: &mut SystemSpecs,
+        result: Option<&ResultPackage>,
+    ) -> bool {
         let response = egui::Window::new("Specs")
             .open(open)
             .default_width(640.0)
@@ -33,7 +42,13 @@ impl SpecsWindow {
                 ui.separator();
 
                 match self.active_tab {
-                    SpecsTab::Surfaces => panels::surfaces_panel(ui, specs),
+                    SpecsTab::Surfaces => {
+                        let solved_values = result.map(|r| &r.solved_values);
+                        let panel_changed =
+                            panels::surfaces_panel(ui, specs, solved_values, &mut self.solve_popup);
+                        let popup_committed = self.show_solve_popup(ctx, specs, solved_values);
+                        panel_changed || popup_committed
+                    }
                     SpecsTab::Fields => panels::fields_panel(ui, specs),
                     SpecsTab::Aperture => panels::aperture_panel(ui, specs),
                     SpecsTab::Wavelengths => panels::wavelengths_panel(ui, specs),
@@ -41,6 +56,197 @@ impl SpecsWindow {
             });
 
         response.and_then(|r| r.inner).unwrap_or(false)
+    }
+
+    fn show_solve_popup(
+        &mut self,
+        ctx: &egui::Context,
+        specs: &mut SystemSpecs,
+        solved_values: Option<&SolvedValues>,
+    ) -> bool {
+        let mut mutated = false;
+        let Some(state) = &mut self.solve_popup else {
+            return false;
+        };
+
+        let wavelength_count = specs.wavelengths.len();
+        let surface_index = state.surface_index;
+        let parameter = state.parameter;
+
+        let type_options: &[&str] = match parameter {
+            SolveParameter::Thickness => &["None", "Marginal ray height"],
+            SolveParameter::RadiusOfCurvature => &["None", "F/#"],
+        };
+
+        let mut open = true;
+        let mut commit = false;
+        let mut remove = false;
+
+        egui::Window::new(format!("Solve — surface {surface_index} — {parameter}"))
+            .id(egui::Id::new("solve_popup"))
+            .resizable(false)
+            .collapsible(false)
+            .open(&mut open)
+            .show(ctx, |ui| {
+                ui.label("Solve type:");
+                egui::ComboBox::from_id_salt("solve_type")
+                    .selected_text(state.type_str.as_str())
+                    .show_ui(ui, |ui| {
+                        for &opt in type_options {
+                            ui.selectable_value(&mut state.type_str, opt.to_owned(), opt);
+                        }
+                    });
+
+                if state.type_str != "None" {
+                    if state.is_paraxial() {
+                        ui.weak("Paraxial solve");
+                    }
+
+                    let target_label = match state.type_str.as_str() {
+                        "Marginal ray height" => "Target height (mm):",
+                        "F/#" => "Target F/#:",
+                        _ => "Target:",
+                    };
+                    ui.label(target_label);
+                    ui.text_edit_singleline(&mut state.target);
+                    if let Some(err) = &state.error {
+                        ui.colored_label(egui::Color32::from_rgb(200, 80, 80), err);
+                    }
+
+                    if wavelength_count > 1 {
+                        ui.label("Wavelength:");
+                        let selected_wl = specs
+                            .wavelengths
+                            .get(state.wavelength_id)
+                            .map(|wl| format!("{wl} μm ({})", state.wavelength_id))
+                            .unwrap_or_else(|| format!("{}", state.wavelength_id));
+                        egui::ComboBox::from_id_salt("solve_wl")
+                            .selected_text(selected_wl)
+                            .show_ui(ui, |ui| {
+                                for (i, wl) in specs.wavelengths.iter().enumerate() {
+                                    ui.selectable_value(
+                                        &mut state.wavelength_id,
+                                        i,
+                                        format!("{wl} μm ({i})"),
+                                    );
+                                }
+                            });
+                    }
+                }
+
+                ui.separator();
+                ui.horizontal(|ui| {
+                    if ui.button("OK").clicked() {
+                        commit = true;
+                    }
+                    let has_active = specs.solve_for(surface_index, parameter).is_some();
+                    if ui
+                        .add_enabled(has_active, egui::Button::new("Remove"))
+                        .clicked()
+                    {
+                        remove = true;
+                    }
+                });
+            });
+
+        if remove {
+            Self::write_back_solved_value(specs, surface_index, parameter, solved_values);
+            specs
+                .solves
+                .retain(|s| !(s.surface_index() == surface_index && s.parameter() == parameter));
+            self.solve_popup = None;
+            return true;
+        }
+
+        if commit {
+            if state.type_str == "None" {
+                Self::write_back_solved_value(specs, surface_index, parameter, solved_values);
+                specs.solves.retain(|s| {
+                    !(s.surface_index() == surface_index && s.parameter() == parameter)
+                });
+                self.solve_popup = None;
+                return true;
+            }
+            // Borrow state mutably for validation — clone what we need first.
+            let type_str = state.type_str.clone();
+            let target = state.target.clone();
+            let wavelength_id = state.wavelength_id;
+            if let Some(spec) =
+                Self::build_solve_spec_from(&type_str, &target, wavelength_id, surface_index, state)
+            {
+                specs.solves.retain(|s| {
+                    !(s.surface_index() == surface_index && s.parameter() == parameter)
+                });
+                specs.solves.push(spec);
+                self.solve_popup = None;
+                mutated = true;
+            }
+        }
+
+        if !open {
+            self.solve_popup = None;
+        }
+
+        mutated
+    }
+
+    fn write_back_solved_value(
+        specs: &mut SystemSpecs,
+        surface_index: usize,
+        parameter: SolveParameter,
+        solved_values: Option<&SolvedValues>,
+    ) {
+        let Some(sv) = solved_values else { return };
+        match parameter {
+            SolveParameter::Thickness => {
+                if let Some(&val) = sv.gap_thicknesses.get(&surface_index)
+                    && surface_index < specs.surfaces.len()
+                {
+                    specs.surfaces[surface_index].thickness = format!("{val:.4}");
+                }
+            }
+            SolveParameter::RadiusOfCurvature => {
+                if let Some(&val) = sv.surface_rocs.get(&surface_index)
+                    && surface_index < specs.surfaces.len()
+                {
+                    specs.surfaces[surface_index].radius_of_curvature = format!("{val:.4}");
+                }
+            }
+        }
+    }
+
+    fn build_solve_spec_from(
+        type_str: &str,
+        target: &str,
+        wavelength_id: usize,
+        surface_index: usize,
+        state: &mut SolvePopupState,
+    ) -> Option<SolveSpec> {
+        match type_str {
+            "Marginal ray height" => match target.trim().parse::<f64>() {
+                Ok(h) if h.is_finite() => Some(SolveSpec::MarginalRayHeight {
+                    gap_index: surface_index,
+                    target_height: h,
+                    wavelength_id,
+                }),
+                _ => {
+                    state.error = Some("Target height must be a finite number.".to_owned());
+                    None
+                }
+            },
+            "F/#" => match target.trim().parse::<f64>() {
+                Ok(f) if f.is_finite() && f > 0.0 => Some(SolveSpec::FNumber {
+                    surface_index,
+                    target_fno: f,
+                    wavelength_id,
+                }),
+                _ => {
+                    state.error = Some("Target F/# must be a positive number.".to_owned());
+                    None
+                }
+            },
+            _ => None,
+        }
     }
 }
 
@@ -53,7 +259,7 @@ mod tests {
 
     fn show_specs_window(window: &mut SpecsWindow, specs: &mut SystemSpecs, ctx: &egui::Context) {
         let mut open = true;
-        window.show(ctx, &mut open, specs);
+        window.show(ctx, &mut open, specs, None);
     }
 
     #[test]

--- a/crates/cherry-rs/src/gui/windows/spot_diagram.rs
+++ b/crates/cherry-rs/src/gui/windows/spot_diagram.rs
@@ -405,6 +405,7 @@ mod tests {
             ray_trace: None,
             cross_section: None,
             error: Some("trace failed".to_string()),
+            solved_values: Default::default(),
         };
 
         let window = SpotDiagramWindow::default();
@@ -486,6 +487,7 @@ mod tests {
             ray_trace: Some(trace),
             cross_section: None,
             error: None,
+            solved_values: Default::default(),
         };
 
         let window = SpotDiagramWindow::default();

--- a/crates/cherry-rs/src/lib.rs
+++ b/crates/cherry-rs/src/lib.rs
@@ -141,8 +141,8 @@ pub use core::{
     ray::Ray,
     sequential_model::{
         SequentialModel, SequentialSubModel, Step,
-        builder::SequentialModelBuilder,
-        solves::{FNumberSolve, MarginalRaySolve, Solve},
+        builder::{BuildResult, SequentialModelBuilder},
+        solves::{FNumberSolve, MarginalRaySolve, Solve, SolveKind},
     },
     surfaces::{Conic, Image, Iris, Object, Probe, Sphere, Surface, SurfaceKind},
 };

--- a/crates/cherry-rs/tests/custom_surface_registry.rs
+++ b/crates/cherry-rs/tests/custom_surface_registry.rs
@@ -134,7 +134,8 @@ fn params_are_forwarded_to_constructor() {
         .wavelengths(wavelengths)
         .registry(registry)
         .build()
-        .expect("model should build");
+        .expect("model should build")
+        .model;
 
     // The custom surface is at index 1.
     assert_eq!(model.surfaces()[1].mask().semi_diameter(), 7.5);


### PR DESCRIPTION
This exposes the new solve system to the GUI. Radius of curvature and thicknesses in the surface spec table now have small buttons allowing the user to set solves on these parameters. Curvature solves are now executed before Thickness solves.

<img width="523" height="423" alt="image" src="https://github.com/user-attachments/assets/21bc6381-866e-4697-b6fc-c880e7dfd1b8" />
