### PR TITLE
feat: Allow for surface displacements and rotational offsets

### DIFF
--- a/crates/cherry-rs/src/core/math/vec3.rs
+++ b/crates/cherry-rs/src/core/math/vec3.rs
@@ -1,22 +1,29 @@
 /// A 3D vector
 #[cfg(feature = "serde")]
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::core::{EPSILON, Float, PI};
 
 const TOL: Float = (1 as Float) * EPSILON;
 
 #[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
-#[cfg_attr(feature = "serde", serde(into = "[Float; 3]"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(into = "[Float; 3]", from = "[Float; 3]"))]
 pub struct Vec3 {
     pub e: [Float; 3],
 }
 
-/// Required to serialize Vec3 directly into an array instead of a JSON Object.
+/// Required to serialize Vec3 directly into a JSON array.
 impl From<Vec3> for [Float; 3] {
     fn from(val: Vec3) -> Self {
         val.e
+    }
+}
+
+/// Required to deserialize Vec3 from a JSON array.
+impl From<[Float; 3]> for Vec3 {
+    fn from(val: [Float; 3]) -> Self {
+        Self { e: val }
     }
 }
 

--- a/crates/cherry-rs/src/core/sequential_model/builder.rs
+++ b/crates/cherry-rs/src/core/sequential_model/builder.rs
@@ -155,7 +155,7 @@ mod tests {
     use super::*;
     use crate::{
         core::Float,
-        core::math::linalg::rotations::Rotation3D,
+        core::math::{linalg::rotations::Rotation3D, vec3::Vec3},
         core::sequential_model::{SequentialSubModel, solves::SolveKind},
         n,
         specs::gaps::GapSpec,
@@ -175,6 +175,8 @@ mod tests {
             SurfaceSpec::Object,
             SurfaceSpec::Image {
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
         ]
     }
@@ -201,9 +203,13 @@ mod tests {
                 radius_of_curvature: 25.8,
                 surf_kind: BoundaryKind::Refracting,
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceSpec::Image {
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
         ]
     }
@@ -434,15 +440,21 @@ mod tests {
                 radius_of_curvature: 25.8,
                 surf_kind: BoundaryKind::Refracting,
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceSpec::Sphere {
                 semi_diameter: 12.5,
                 radius_of_curvature: Float::INFINITY,
                 surf_kind: BoundaryKind::Refracting,
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceSpec::Image {
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
         ]
     }

--- a/crates/cherry-rs/src/core/sequential_model/mod.rs
+++ b/crates/cherry-rs/src/core/sequential_model/mod.rs
@@ -9,15 +9,12 @@ use std::ops::Range;
 use anyhow::{Result, anyhow};
 
 use self::cursor::Cursor;
-use self::placement::Placement;
+use self::placement::{Placement, SurfacePlacement};
 #[cfg(feature = "serde")]
 use crate::core::surfaces::SurfaceRegistry;
 use crate::core::{
     Float,
-    math::{
-        linalg::{mat3x3::Mat3x3, rotations::Rotation3D},
-        vec3::Vec3,
-    },
+    math::{linalg::mat3x3::Mat3x3, vec3::Vec3},
     refractive_index::RefractiveIndex,
     surfaces::{Conic, Image, Iris, Object, Probe, Sphere, Surface, SurfaceKind},
 };
@@ -210,9 +207,9 @@ pub(crate) fn propagate_tangential_vec(
         .map(|(surf, placement)| {
             let v_incident = v;
             if let BoundaryKind::Reflecting = surf.boundary_kind() {
-                // Normal in global frame: third column of inv_rotation_matrix
-                // (maps local Z to global).
-                let n = placement.inv_rotation_matrix * Vec3::new(0.0, 0.0, 1.0);
+                // Normal in global frame derived from the *nominal* orientation
+                // so that rotation_offset never redirects the paraxial axis.
+                let n = placement.nominal_inv_rotation_matrix * Vec3::new(0.0, 0.0, 1.0);
                 let dot = v.x() * n.x() + v.y() * n.y() + v.z() * n.z();
                 v = Vec3::new(
                     v.x() - 2.0 * dot * n.x(),
@@ -354,15 +351,16 @@ impl SequentialModel {
     ///
     /// Use this when constructing a model programmatically in Rust without
     /// going through the spec/serialization layer. Each element of `surfaces`
-    /// pairs a surface implementation with its tilt rotation; pass
-    /// [`Rotation3D::None`] for untilted surfaces.
+    /// pairs a surface implementation with its [`SurfacePlacement`]; use
+    /// [`SurfacePlacement::none()`] for untilted surfaces with no displacement,
+    /// or [`SurfacePlacement::from_rotation`] to supply only a tilt rotation.
     ///
     /// # Arguments
-    /// * `surfaces` - Pre-built surfaces paired with their tilt rotations.
+    /// * `surfaces` - Pre-built surfaces paired with their placement data.
     /// * `gap_specs` - Gaps between surfaces (`surfaces.len() - 1` elements).
     /// * `wavelengths` - Wavelengths at which to model the system.
     pub fn from_surfaces(
-        surfaces: Vec<(Box<dyn Surface>, Rotation3D)>,
+        surfaces: Vec<(Box<dyn Surface>, SurfacePlacement)>,
         gap_specs: &[GapSpec],
         wavelengths: &[Float],
         stop_surface: Option<usize>,
@@ -377,9 +375,9 @@ impl SequentialModel {
         }
         Self::validate_specs(gap_specs, wavelengths)?;
 
-        let (surfs, rotations): (Vec<_>, Vec<_>) = surfaces.into_iter().unzip();
+        let (surfs, surface_placements): (Vec<_>, Vec<_>) = surfaces.into_iter().unzip();
         let (placements, axis_directions) =
-            Self::build_placements_and_directions(&surfs, &rotations, gap_specs);
+            Self::build_placements_and_directions(&surfs, &surface_placements, gap_specs);
 
         if let Some(i) = stop_surface {
             Self::validate_stop_surface(&surfs, i)?;
@@ -509,13 +507,13 @@ impl SequentialModel {
     }
 
     /// Walks the cursor through the system, building placements and axis
-    /// directions from pre-built surfaces and their rotations.
+    /// directions from pre-built surfaces and their placement data.
     ///
-    /// `surfaces` and `rotations` must have the same length N.
+    /// `surfaces` and `surface_placements` must have the same length N.
     /// `gap_specs` must have length N - 1.
     fn build_placements_and_directions(
         surfaces: &[Box<dyn Surface>],
-        rotations: &[Rotation3D],
+        surface_placements: &[SurfacePlacement],
         gap_specs: &[GapSpec],
     ) -> (Vec<Placement>, Vec<Vec3>) {
         let mut placements = Vec::new();
@@ -523,18 +521,29 @@ impl SequentialModel {
         let mut cursor = Cursor::new(-gap_specs[0].thickness);
 
         // Surfaces 0 to N-2 (each paired with a gap that follows it).
-        for ((surf, rotation), gap_spec) in
-            surfaces.iter().zip(rotations.iter()).zip(gap_specs.iter())
+        for ((surf, sp), gap_spec) in surfaces
+            .iter()
+            .zip(surface_placements.iter())
+            .zip(gap_specs.iter())
         {
             axis_directions.push(cursor.forward());
-            let placement = Placement::from_rotation(rotation, &cursor);
 
-            // Flip the cursor upon reflection. Evaluate the normal at the
-            // vertex (local origin = (0,0,0)) and transform to global frame.
+            let nominal_rot = sp.rotation.rotation_matrix();
+            let actual_rot = sp.rotation_offset.rotation_matrix() * nominal_rot;
+            let placement = Placement::from_decenter_and_rotation(
+                sp.decenter,
+                actual_rot,
+                nominal_rot,
+                &cursor,
+            );
+
+            // Flip the cursor upon reflection. Use only the nominal rotation
+            // so that rotation_offset never redirects the cursor.
             if let BoundaryKind::Reflecting = surf.boundary_kind() {
-                let mut norm = surf.norm(Vec3::new(0.0, 0.0, 0.0));
-                norm = (placement.inv_rotation_matrix * norm).normalize();
-                cursor.reflect(&norm);
+                let norm_local = surf.norm(Vec3::new(0.0, 0.0, 0.0));
+                let nominal_local_to_global = (nominal_rot * cursor.rotation_matrix()).transpose();
+                let norm_global = (nominal_local_to_global * norm_local).normalize();
+                cursor.reflect(&norm_global);
             }
 
             placements.push(placement);
@@ -543,8 +552,13 @@ impl SequentialModel {
 
         // Last surface - no gap after it.
         axis_directions.push(cursor.forward());
-        placements.push(Placement::from_rotation(
-            rotations.last().expect("at least one surface"),
+        let sp = surface_placements.last().expect("at least one surface");
+        let nominal_rot = sp.rotation.rotation_matrix();
+        let actual_rot = sp.rotation_offset.rotation_matrix() * nominal_rot;
+        placements.push(Placement::from_decenter_and_rotation(
+            sp.decenter,
+            actual_rot,
+            nominal_rot,
             &cursor,
         ));
 
@@ -561,9 +575,16 @@ impl SequentialModel {
             .iter()
             .map(|s| surface_from_spec(s, registry))
             .collect::<Result<Vec<_>>>()?;
-        let rotations: Vec<Rotation3D> = surf_specs.iter().map(rotation_from_spec).collect();
+        let surface_placements: Vec<SurfacePlacement> = surf_specs
+            .iter()
+            .map(|spec| SurfacePlacement {
+                decenter: spec.decenter(),
+                rotation: spec.rotation(),
+                rotation_offset: spec.rotation_offset(),
+            })
+            .collect();
         let (placements, axis_directions) =
-            Self::build_placements_and_directions(&surfaces, &rotations, gap_specs);
+            Self::build_placements_and_directions(&surfaces, &surface_placements, gap_specs);
         Ok((surfaces, placements, axis_directions))
     }
 
@@ -576,9 +597,16 @@ impl SequentialModel {
             .iter()
             .map(surface_from_spec)
             .collect::<Result<Vec<_>>>()?;
-        let rotations: Vec<Rotation3D> = surf_specs.iter().map(rotation_from_spec).collect();
+        let surface_placements: Vec<SurfacePlacement> = surf_specs
+            .iter()
+            .map(|spec| SurfacePlacement {
+                decenter: spec.decenter(),
+                rotation: spec.rotation(),
+                rotation_offset: spec.rotation_offset(),
+            })
+            .collect();
         let (placements, axis_directions) =
-            Self::build_placements_and_directions(&surfaces, &rotations, gap_specs);
+            Self::build_placements_and_directions(&surfaces, &surface_placements, gap_specs);
         Ok((surfaces, placements, axis_directions))
     }
 
@@ -761,20 +789,6 @@ impl<'a> Iterator for SequentialSubModelReverseIter<'a> {
     }
 }
 
-/// Extract the tilt [`Rotation3D`] from a surface specification.
-fn rotation_from_spec(spec: &SurfaceSpec) -> Rotation3D {
-    match spec {
-        SurfaceSpec::Conic { rotation, .. }
-        | SurfaceSpec::Sphere { rotation, .. }
-        | SurfaceSpec::Image { rotation }
-        | SurfaceSpec::Probe { rotation }
-        | SurfaceSpec::Iris { rotation, .. } => rotation.clone(),
-        SurfaceSpec::Object => Rotation3D::None,
-        #[cfg(feature = "serde")]
-        SurfaceSpec::Custom { rotation, .. } => rotation.clone(),
-    }
-}
-
 /// Build a [`Surface`] trait object from a surface specification.
 #[cfg(feature = "serde")]
 pub(crate) fn surface_from_spec(
@@ -870,6 +884,7 @@ mod tests {
         Placement::new(
             Vec3::new(0.0, 0.0, 0.0),
             0.0,
+            rotation_matrix,
             rotation_matrix,
             cursor_rotation_matrix,
         )
@@ -1010,8 +1025,8 @@ mod tests {
         // A system with identity rotations is rotationally symmetric.
         let id = Mat3x3::identity();
         let placements = vec![
-            Placement::new(Vec3::new(0.0, 0.0, 0.0), 0.0, id, id),
-            Placement::new(Vec3::new(0.0, 0.0, 0.0), 0.0, id, id),
+            Placement::new(Vec3::new(0.0, 0.0, 0.0), 0.0, id, id, id),
+            Placement::new(Vec3::new(0.0, 0.0, 0.0), 0.0, id, id, id),
         ];
         assert!(SequentialModel::is_rotationally_symmetric(&placements));
 
@@ -1072,19 +1087,19 @@ mod tests {
         let id = Mat3x3::identity();
 
         // z-coordinate infinite
-        let p = Placement::new(Vec3::new(0.0, 0.0, Float::INFINITY), 0.0, id, id);
+        let p = Placement::new(Vec3::new(0.0, 0.0, Float::INFINITY), 0.0, id, id, id);
         assert!(p.is_infinite());
 
         // y-coordinate infinite
-        let p = Placement::new(Vec3::new(0.0, Float::INFINITY, 0.0), 0.0, id, id);
+        let p = Placement::new(Vec3::new(0.0, Float::INFINITY, 0.0), 0.0, id, id, id);
         assert!(p.is_infinite());
 
         // x-coordinate infinite
-        let p = Placement::new(Vec3::new(Float::INFINITY, 0.0, 0.0), 0.0, id, id);
+        let p = Placement::new(Vec3::new(Float::INFINITY, 0.0, 0.0), 0.0, id, id, id);
         assert!(p.is_infinite());
 
         // finite
-        let p = Placement::new(Vec3::new(0.0, 0.0, 0.0), 0.0, id, id);
+        let p = Placement::new(Vec3::new(0.0, 0.0, 0.0), 0.0, id, id, id);
         assert!(!p.is_infinite());
     }
 
@@ -1157,16 +1172,24 @@ mod tests {
                 radius_of_curvature: 50.0,
                 surf_kind: BoundaryKind::Refracting,
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceSpec::Probe {
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceSpec::Iris {
                 semi_diameter: 5.0,
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceSpec::Image {
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
         ];
         (gaps, surfaces)
@@ -1208,5 +1231,174 @@ mod tests {
     fn stop_surface_probe_is_rejected() {
         let (gaps, surfaces) = stop_validation_specs();
         assert!(SequentialModel::from_surface_specs(&gaps, &surfaces, &[0.5876], Some(2)).is_err());
+    }
+
+    // AT-6: rotation_offset on a reflecting surface never redirects the cursor.
+    // A mirror with rotation = 45° about R redirects the cursor regardless of
+    // rotation_offset. Adding a rotation_offset should not change the image
+    // surface position (it only changes the surface's tilt, not the beam path).
+    #[test]
+    fn at6_rotation_offset_does_not_redirect_cursor() {
+        use crate::specs::surfaces::BoundaryKind;
+        use crate::{GapSpec, SurfaceSpec, Vec3, n};
+
+        let theta = 45.0_f64.to_radians();
+        let gaps = vec![
+            GapSpec {
+                thickness: 10.0,
+                refractive_index: n!(1.0),
+            },
+            GapSpec {
+                thickness: 10.0,
+                refractive_index: n!(1.0),
+            },
+        ];
+
+        // Mirror with rotation only (no rotation_offset).
+        let surfaces_no_offset = vec![
+            SurfaceSpec::Object,
+            SurfaceSpec::Sphere {
+                semi_diameter: 25.4,
+                radius_of_curvature: f64::INFINITY,
+                surf_kind: BoundaryKind::Reflecting,
+                rotation: Rotation3D::IntrinsicPassiveRUF(EulerAngles(theta, 0.0, 0.0)),
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
+            },
+            SurfaceSpec::Image {
+                rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
+            },
+        ];
+        let model_no_offset =
+            SequentialModel::from_surface_specs(&gaps, &surfaces_no_offset, &[0.5876], None)
+                .expect("model_no_offset builds");
+
+        // Mirror with the same rotation plus a non-trivial rotation_offset.
+        let phi = 10.0_f64.to_radians();
+        let surfaces_with_offset = vec![
+            SurfaceSpec::Object,
+            SurfaceSpec::Sphere {
+                semi_diameter: 25.4,
+                radius_of_curvature: f64::INFINITY,
+                surf_kind: BoundaryKind::Reflecting,
+                rotation: Rotation3D::IntrinsicPassiveRUF(EulerAngles(theta, 0.0, 0.0)),
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::IntrinsicPassiveRUF(EulerAngles(0.0, phi, 0.0)),
+            },
+            SurfaceSpec::Image {
+                rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
+            },
+        ];
+        let model_with_offset =
+            SequentialModel::from_surface_specs(&gaps, &surfaces_with_offset, &[0.5876], None)
+                .expect("model_with_offset builds");
+
+        // Image surface position must be identical in both models because the
+        // cursor path is determined by `rotation` only.
+        let tol = 1e-10;
+        let pos_no_offset = model_no_offset.placements()[2].position;
+        let pos_with_offset = model_with_offset.placements()[2].position;
+        assert!(
+            (pos_no_offset.x() - pos_with_offset.x()).abs() < tol
+                && (pos_no_offset.y() - pos_with_offset.y()).abs() < tol
+                && (pos_no_offset.z() - pos_with_offset.z()).abs() < tol,
+            "rotation_offset changed cursor path: no_offset={:?}, with_offset={:?}",
+            pos_no_offset,
+            pos_with_offset
+        );
+    }
+
+    // AT-7: rotation_offset changes placement.rotation_matrix without changing
+    // the cursor direction (verified via the mirror surface itself).
+    #[test]
+    fn at7_rotation_offset_changes_rotation_matrix() {
+        use crate::specs::surfaces::BoundaryKind;
+        use crate::{GapSpec, SurfaceSpec, Vec3, n};
+
+        let gaps = vec![
+            GapSpec {
+                thickness: 10.0,
+                refractive_index: n!(1.0),
+            },
+            GapSpec {
+                thickness: 10.0,
+                refractive_index: n!(1.0),
+            },
+        ];
+        let phi = 5.0_f64.to_radians();
+
+        let surfaces_no_offset = vec![
+            SurfaceSpec::Object,
+            SurfaceSpec::Sphere {
+                semi_diameter: 25.4,
+                radius_of_curvature: f64::INFINITY,
+                surf_kind: BoundaryKind::Refracting,
+                rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
+            },
+            SurfaceSpec::Image {
+                rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
+            },
+        ];
+        let surfaces_with_offset = vec![
+            SurfaceSpec::Object,
+            SurfaceSpec::Sphere {
+                semi_diameter: 25.4,
+                radius_of_curvature: f64::INFINITY,
+                surf_kind: BoundaryKind::Refracting,
+                rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::IntrinsicPassiveRUF(EulerAngles(0.0, phi, 0.0)),
+            },
+            SurfaceSpec::Image {
+                rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
+            },
+        ];
+
+        let model_no =
+            SequentialModel::from_surface_specs(&gaps, &surfaces_no_offset, &[0.5876], None)
+                .expect("model_no builds");
+        let model_with =
+            SequentialModel::from_surface_specs(&gaps, &surfaces_with_offset, &[0.5876], None)
+                .expect("model_with builds");
+
+        let rot_no = model_no.placements()[1].rotation_matrix;
+        let rot_with = model_with.placements()[1].rotation_matrix;
+
+        // rotation_matrix must differ when rotation_offset != None.
+        assert!(
+            !rot_no.approx_eq(&rot_with, 1e-10),
+            "rotation_matrix should change when rotation_offset is set"
+        );
+
+        // nominal_inv_rotation_matrix must be identical (cursor sees same nominal).
+        let nom_no = model_no.placements()[1].nominal_inv_rotation_matrix;
+        let nom_with = model_with.placements()[1].nominal_inv_rotation_matrix;
+        assert!(
+            nom_no.approx_eq(&nom_with, 1e-10),
+            "nominal_inv_rotation_matrix should be identical: no={:?}, with={:?}",
+            nom_no,
+            nom_with
+        );
+
+        // Image surface position must be identical (cursor path unchanged).
+        let tol = 1e-10;
+        let img_no = model_no.placements()[2].position;
+        let img_with = model_with.placements()[2].position;
+        assert!(
+            (img_no.z() - img_with.z()).abs() < tol,
+            "image z changed: no={}, with={}",
+            img_no.z(),
+            img_with.z()
+        );
     }
 }

--- a/crates/cherry-rs/src/core/sequential_model/placement.rs
+++ b/crates/cherry-rs/src/core/sequential_model/placement.rs
@@ -13,6 +13,44 @@ use crate::core::{
 
 use super::cursor::Cursor;
 
+/// Displacement and orientation parameters for one surface.
+///
+/// Used by [`SequentialModel::from_surfaces`] and internally by
+/// `build_placements_and_directions`.
+///
+/// [`SequentialModel::from_surfaces`]: super::SequentialModel::from_surfaces
+#[derive(Debug, Clone)]
+pub struct SurfacePlacement {
+    /// Vertex offset from the nominal cursor position, in cursor-frame (R, U,
+    /// F).
+    pub decenter: Vec3,
+    /// Nominal surface tilt; redirects the cursor for reflecting surfaces.
+    pub rotation: Rotation3D,
+    /// Additional surface-only rotation; never redirects the cursor.
+    pub rotation_offset: Rotation3D,
+}
+
+impl SurfacePlacement {
+    /// Returns a `SurfacePlacement` with no displacement.
+    pub fn none() -> Self {
+        Self {
+            decenter: Vec3::new(0.0, 0.0, 0.0),
+            rotation: Rotation3D::None,
+            rotation_offset: Rotation3D::None,
+        }
+    }
+
+    /// Returns a `SurfacePlacement` with the given nominal rotation and no
+    /// decenter or rotation offset.
+    pub fn from_rotation(rotation: Rotation3D) -> Self {
+        Self {
+            decenter: Vec3::new(0.0, 0.0, 0.0),
+            rotation,
+            rotation_offset: Rotation3D::None,
+        }
+    }
+}
+
 /// Position and orientation of a surface in the global coordinate system.
 #[derive(Debug, Clone)]
 pub struct Placement {
@@ -24,7 +62,8 @@ pub struct Placement {
 
     /// Rotation from the global frame into the surface's local frame.
     ///
-    /// Equals `surface_tilt_rotation * cursor_rotation` (global-to-local).
+    /// Equals `(rotation_offset · rotation) * cursor_rotation`
+    /// (global-to-local, including any rotation offset).
     pub rotation_matrix: Mat3x3,
 
     /// Inverse of `rotation_matrix` (local-to-global).
@@ -32,6 +71,12 @@ pub struct Placement {
     /// Because the matrix is orthogonal this equals
     /// `rotation_matrix.transpose()`. This value is cached for efficiency.
     pub inv_rotation_matrix: Mat3x3,
+
+    /// Local-to-global transform computed from the nominal rotation only
+    /// (without `rotation_offset`). Equal to `inv_rotation_matrix` when
+    /// `rotation_offset` is `None`. Used by `propagate_tangential_vec` so
+    /// that the paraxial tangential axis follows the nominal system.
+    pub nominal_inv_rotation_matrix: Mat3x3,
 
     /// Rotation from the global frame into the optical-axis (cursor) frame
     /// only, without any surface tilt applied.
@@ -42,17 +87,31 @@ pub struct Placement {
 }
 
 impl Placement {
-    /// Build a [`Placement`] from a rotation and the current cursor state.
+    /// Build a [`Placement`] from a pre-composed surface rotation matrix, the
+    /// nominal rotation matrix, a decenter, and the current cursor state.
     ///
-    /// `rotation` is the surface-tilt rotation composed on top of the cursor
-    /// orientation. Pass [`Rotation3D::None`] for surfaces with no tilt.
-    pub(crate) fn from_rotation(rotation: &Rotation3D, cursor: &Cursor) -> Self {
+    /// `actual_rotation_matrix` is
+    /// `rotation_offset.rotation_matrix() * rotation.rotation_matrix()`.
+    /// `nominal_rotation_matrix` is `rotation.rotation_matrix()` alone.
+    /// When `rotation_offset` is `None` both matrices are equal.
+    ///
+    /// `decenter` is in cursor-frame coordinates (R, U, F).
+    pub(crate) fn from_decenter_and_rotation(
+        decenter: Vec3,
+        actual_rotation_matrix: Mat3x3,
+        nominal_rotation_matrix: Mat3x3,
+        cursor: &Cursor,
+    ) -> Self {
         let cursor_rotation_matrix = cursor.rotation_matrix();
-        let rotation_matrix = rotation.rotation_matrix() * cursor_rotation_matrix;
+        let rotation_matrix = actual_rotation_matrix * cursor_rotation_matrix;
+        let nom_rot_matrix = nominal_rotation_matrix * cursor_rotation_matrix;
+        let offset_global = cursor_rotation_matrix.transpose() * decenter;
+        let position = cursor.pos() + offset_global;
         Self::new(
-            cursor.pos(),
+            position,
             cursor.track(),
             rotation_matrix,
+            nom_rot_matrix,
             cursor_rotation_matrix,
         )
     }
@@ -62,14 +121,17 @@ impl Placement {
         position: Vec3,
         track: Float,
         rotation_matrix: Mat3x3,
+        nominal_rotation_matrix: Mat3x3,
         cursor_rotation_matrix: Mat3x3,
     ) -> Self {
         let inv_rotation_matrix = rotation_matrix.transpose();
+        let nominal_inv_rotation_matrix = nominal_rotation_matrix.transpose();
         Self {
             position,
             track,
             rotation_matrix,
             inv_rotation_matrix,
+            nominal_inv_rotation_matrix,
             cursor_rotation_matrix,
         }
     }
@@ -139,5 +201,177 @@ impl Placement {
         }
 
         r * n_f.abs() / denom
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity_cursor() -> Cursor {
+        Cursor::new(0.0)
+    }
+
+    fn cursor_at(z: f64) -> Cursor {
+        let mut c = Cursor::new(0.0);
+        c.advance(z);
+        c
+    }
+
+    // AT-1: zero displacement produces placement identical to nominal
+    #[test]
+    fn at1_zero_displacement_identity_cursor() {
+        let id = Mat3x3::identity();
+        let cursor = identity_cursor();
+        let p = Placement::from_decenter_and_rotation(Vec3::new(0.0, 0.0, 0.0), id, id, &cursor);
+        assert!(
+            p.position.approx_eq(&Vec3::new(0.0, 0.0, 0.0), 1e-15),
+            "position: {:?}",
+            p.position
+        );
+        assert!(p.rotation_matrix.approx_eq(&id, 1e-15));
+        assert!(p.nominal_inv_rotation_matrix.approx_eq(&id, 1e-15));
+        assert!(p.cursor_rotation_matrix.approx_eq(&id, 1e-15));
+        assert!((p.track - 0.0).abs() < 1e-15);
+    }
+
+    // AT-2: R-axis decenter shifts vertex along x
+    #[test]
+    fn at2_transverse_decenter_r_axis() {
+        let id = Mat3x3::identity();
+        let dx = 2.5;
+        let cursor = cursor_at(10.0);
+        let p = Placement::from_decenter_and_rotation(Vec3::new(dx, 0.0, 0.0), id, id, &cursor);
+        let tol = 1e-15;
+        assert!((p.position.x() - dx).abs() < tol, "x: {}", p.position.x());
+        assert!(p.position.y().abs() < tol, "y: {}", p.position.y());
+        assert!((p.position.z() - 10.0).abs() < tol, "z: {}", p.position.z());
+    }
+
+    // AT-3: U-axis decenter shifts vertex along y
+    #[test]
+    fn at3_transverse_decenter_u_axis() {
+        let id = Mat3x3::identity();
+        let dy = -1.3;
+        let cursor = cursor_at(5.0);
+        let p = Placement::from_decenter_and_rotation(Vec3::new(0.0, dy, 0.0), id, id, &cursor);
+        let tol = 1e-15;
+        assert!(p.position.x().abs() < tol, "x: {}", p.position.x());
+        assert!((p.position.y() - dy).abs() < tol, "y: {}", p.position.y());
+        assert!((p.position.z() - 5.0).abs() < tol, "z: {}", p.position.z());
+    }
+
+    // AT-4: F-axis decenter shifts vertex along z in a straight system
+    #[test]
+    fn at4_axial_decenter_f_axis() {
+        let id = Mat3x3::identity();
+        let dz = 3.0;
+        let nominal_z = 7.0;
+        let cursor = cursor_at(nominal_z);
+        let p = Placement::from_decenter_and_rotation(Vec3::new(0.0, 0.0, dz), id, id, &cursor);
+        let tol = 1e-15;
+        assert!(p.position.x().abs() < tol, "x: {}", p.position.x());
+        assert!(p.position.y().abs() < tol, "y: {}", p.position.y());
+        assert!(
+            (p.position.z() - (nominal_z + dz)).abs() < tol,
+            "z: {}",
+            p.position.z()
+        );
+    }
+
+    // AT-5: F-axis decenter after a 90° fold shifts along the post-fold axis,
+    // not along global Z. After a 90° fold about the R-axis the cursor
+    // forward direction is (0, -1, 0), so a cursor-F decenter of dz moves the
+    // vertex by (0, -dz, 0) in global coordinates.
+    #[test]
+    fn at5_axial_decenter_after_fold() {
+        // Build a 3-surface system: Object — flat mirror (45° theta fold) — Image
+        use crate::specs::{
+            gaps::GapSpec,
+            surfaces::{BoundaryKind, SurfaceSpec},
+        };
+        use crate::{EulerAngles, Rotation3D, n};
+
+        let gaps = vec![
+            GapSpec {
+                thickness: 10.0,
+                refractive_index: n!(1.0),
+            },
+            GapSpec {
+                thickness: 10.0,
+                refractive_index: n!(1.0),
+            },
+        ];
+        // Mirror at 45° about R redirects the cursor downward (–Y).
+        let theta = 45.0_f64.to_radians();
+        let surfaces = vec![
+            SurfaceSpec::Object,
+            SurfaceSpec::Sphere {
+                semi_diameter: 25.4,
+                radius_of_curvature: f64::INFINITY,
+                surf_kind: BoundaryKind::Reflecting,
+                rotation: Rotation3D::IntrinsicPassiveRUF(EulerAngles(theta, 0.0, 0.0)),
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
+            },
+            SurfaceSpec::Image {
+                rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
+            },
+        ];
+
+        let model = crate::SequentialModel::from_surface_specs(&gaps, &surfaces, &[0.5876], None)
+            .expect("model builds");
+
+        // Now construct the same mirror surface but with a cursor-F decenter of 2.0.
+        // After the 90° fold the cursor forward direction is (0, -1, 0), so
+        // decenter (0, 0, 2) in cursor frame should shift the vertex by
+        // (0, -2, 0) in global coords relative to the mirror without decenter.
+        let placements_no_decenter = model.placements();
+        let mirror_pos_nominal = placements_no_decenter[1].position;
+
+        let surfaces_with_decenter = vec![
+            SurfaceSpec::Object,
+            SurfaceSpec::Sphere {
+                semi_diameter: 25.4,
+                radius_of_curvature: f64::INFINITY,
+                surf_kind: BoundaryKind::Reflecting,
+                rotation: Rotation3D::IntrinsicPassiveRUF(EulerAngles(theta, 0.0, 0.0)),
+                decenter: Vec3::new(0.0, 0.0, 2.0),
+                rotation_offset: Rotation3D::None,
+            },
+            SurfaceSpec::Image {
+                rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
+            },
+        ];
+        let model2 = crate::SequentialModel::from_surface_specs(
+            &gaps,
+            &surfaces_with_decenter,
+            &[0.5876],
+            None,
+        )
+        .expect("model2 builds");
+        let mirror_pos_decentered = model2.placements()[1].position;
+
+        let tol = 1e-12;
+        // x unchanged
+        assert!(
+            (mirror_pos_decentered.x() - mirror_pos_nominal.x()).abs() < tol,
+            "x changed: {} vs {}",
+            mirror_pos_decentered.x(),
+            mirror_pos_nominal.x()
+        );
+        // After 45° fold the forward direction at the mirror is still along Z
+        // (cursor hasn't been redirected yet when placement is built).
+        // So F-decenter of 2 shifts z by +2.
+        assert!(
+            (mirror_pos_decentered.z() - mirror_pos_nominal.z() - 2.0).abs() < tol,
+            "z shift wrong: decentered z={}, nominal z={}",
+            mirror_pos_decentered.z(),
+            mirror_pos_nominal.z()
+        );
     }
 }

--- a/crates/cherry-rs/src/core/sequential_model/solves/fno.rs
+++ b/crates/cherry-rs/src/core/sequential_model/solves/fno.rs
@@ -126,7 +126,7 @@ mod tests {
     use approx::assert_abs_diff_eq;
 
     use crate::{
-        GapSpec, Rotation3D, SequentialModel, SurfaceSpec,
+        GapSpec, Rotation3D, SequentialModel, SurfaceSpec, Vec3,
         core::{Float, sequential_model::builder::SequentialModelBuilder},
         n,
         specs::{fields::FieldSpec, surfaces::BoundaryKind},
@@ -160,15 +160,21 @@ mod tests {
                 radius_of_curvature: 25.8,
                 surf_kind: BoundaryKind::Refracting,
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceSpec::Sphere {
                 semi_diameter: 12.5,
                 radius_of_curvature: Float::INFINITY,
                 surf_kind: BoundaryKind::Refracting,
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceSpec::Image {
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
         ]
     }
@@ -260,13 +266,19 @@ mod tests {
                 radius_of_curvature: 25.8,
                 surf_kind: BoundaryKind::Refracting,
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceSpec::Iris {
                 semi_diameter: 10.0,
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceSpec::Image {
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
         ];
         let model =

--- a/crates/cherry-rs/src/core/sequential_model/solves/marginal_ray.rs
+++ b/crates/cherry-rs/src/core/sequential_model/solves/marginal_ray.rs
@@ -93,7 +93,7 @@ mod tests {
     use approx::assert_abs_diff_eq;
 
     use crate::{
-        GapSpec, Rotation3D, SequentialModel, SurfaceSpec,
+        GapSpec, Rotation3D, SequentialModel, SurfaceSpec, Vec3,
         core::{Float, sequential_model::builder::SequentialModelBuilder},
         n,
         specs::{fields::FieldSpec, surfaces::BoundaryKind},
@@ -128,15 +128,21 @@ mod tests {
                 radius_of_curvature: 25.8,
                 surf_kind: BoundaryKind::Refracting,
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceSpec::Sphere {
                 semi_diameter: 12.5,
                 radius_of_curvature: Float::INFINITY,
                 surf_kind: BoundaryKind::Refracting,
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceSpec::Image {
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
         ]
     }
@@ -210,9 +216,13 @@ mod tests {
                 conic_constant: 0.0,
                 surf_kind: BoundaryKind::Refracting,
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceSpec::Image {
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
         ];
         let model = SequentialModel::from_surface_specs(&gaps, &surfaces, &[0.5876], None).unwrap();

--- a/crates/cherry-rs/src/examples/biconvex_lens_finite_object.rs
+++ b/crates/cherry-rs/src/examples/biconvex_lens_finite_object.rs
@@ -3,7 +3,9 @@
 //! Thorlabs Part No.: LB1676-A
 use std::rc::Rc;
 
-use crate::{BoundaryKind, GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel, SurfaceSpec};
+use crate::{
+    BoundaryKind, GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel, SurfaceSpec, Vec3,
+};
 
 pub fn sequential_model(
     n_air: Rc<dyn RefractiveIndexSpec>,
@@ -30,15 +32,21 @@ pub fn sequential_model(
         radius_of_curvature: 102.4,
         surf_kind: BoundaryKind::Refracting,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_2 = SurfaceSpec::Sphere {
         semi_diameter: 12.7,
         radius_of_curvature: -102.4,
         surf_kind: BoundaryKind::Refracting,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_3 = SurfaceSpec::Image {
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
 
     let surfaces = vec![surf_0, surf_1, surf_2, surf_3];

--- a/crates/cherry-rs/src/examples/concave_mirror.rs
+++ b/crates/cherry-rs/src/examples/concave_mirror.rs
@@ -1,7 +1,9 @@
 //! A f=+100 mm concave mirror with infinite field points.
 use std::rc::Rc;
 
-use crate::{BoundaryKind, GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel, SurfaceSpec};
+use crate::{
+    BoundaryKind, GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel, SurfaceSpec, Vec3,
+};
 
 pub fn sequential_model(
     n_air: Rc<dyn RefractiveIndexSpec>,
@@ -23,9 +25,13 @@ pub fn sequential_model(
         radius_of_curvature: -200.0,
         surf_kind: BoundaryKind::Reflecting,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_2 = SurfaceSpec::Image {
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surfaces = vec![surf_0, surf_1, surf_2];
 

--- a/crates/cherry-rs/src/examples/convexplano_lens.rs
+++ b/crates/cherry-rs/src/examples/convexplano_lens.rs
@@ -1,7 +1,9 @@
 //! A f = 50 mm convexplano lens.
 use std::rc::Rc;
 
-use crate::{BoundaryKind, GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel, SurfaceSpec};
+use crate::{
+    BoundaryKind, GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel, SurfaceSpec, Vec3,
+};
 
 pub fn sequential_model(
     n_air: Rc<dyn RefractiveIndexSpec>,
@@ -28,15 +30,21 @@ pub fn sequential_model(
         radius_of_curvature: 25.8,
         surf_kind: BoundaryKind::Refracting,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_2 = SurfaceSpec::Sphere {
         semi_diameter: 12.5,
         radius_of_curvature: f64::INFINITY,
         surf_kind: BoundaryKind::Refracting,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_3 = SurfaceSpec::Image {
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surfaces = vec![surf_0, surf_1, surf_2, surf_3];
 

--- a/crates/cherry-rs/src/examples/f_theta_scan_lens.rs
+++ b/crates/cherry-rs/src/examples/f_theta_scan_lens.rs
@@ -9,7 +9,8 @@
 use std::rc::Rc;
 
 use crate::{
-    BoundaryKind, FieldSpec, GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel, SurfaceSpec,
+    BoundaryKind, FieldSpec, GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel,
+    SurfaceSpec, Vec3,
 };
 
 pub fn sequential_model(
@@ -55,45 +56,61 @@ pub fn sequential_model(
     let surf_1 = SurfaceSpec::Iris {
         semi_diameter: 0.5,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_2 = SurfaceSpec::Sphere {
         semi_diameter: 2.0,
         radius_of_curvature: -2.2136,
         surf_kind: BoundaryKind::Refracting,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_3 = SurfaceSpec::Sphere {
         semi_diameter: 2.0,
         radius_of_curvature: -2.6575,
         surf_kind: BoundaryKind::Refracting,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_4 = SurfaceSpec::Sphere {
         semi_diameter: 2.0,
         radius_of_curvature: -5.5022,
         surf_kind: BoundaryKind::Refracting,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_5 = SurfaceSpec::Sphere {
         semi_diameter: 2.0,
         radius_of_curvature: -3.8129,
         surf_kind: BoundaryKind::Refracting,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_6 = SurfaceSpec::Sphere {
         semi_diameter: 3.0,
         radius_of_curvature: 7.9951,
         surf_kind: BoundaryKind::Refracting,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_7 = SurfaceSpec::Sphere {
         semi_diameter: 3.0,
         radius_of_curvature: 8.3651,
         surf_kind: BoundaryKind::Refracting,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_8 = SurfaceSpec::Image {
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surfaces = vec![
         surf_0, surf_1, surf_2, surf_3, surf_4, surf_5, surf_6, surf_7, surf_8,

--- a/crates/cherry-rs/src/examples/mirrors_figure_z.rs
+++ b/crates/cherry-rs/src/examples/mirrors_figure_z.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 use crate::{
     BoundaryKind, EulerAngles, GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel,
-    SurfaceSpec, core::Float,
+    SurfaceSpec, Vec3, core::Float,
 };
 
 pub fn sequential_model(
@@ -37,6 +37,8 @@ pub fn sequential_model(
             0.0,
             0.0,
         )),
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_2 = SurfaceSpec::Sphere {
         semi_diameter: 12.7,
@@ -47,9 +49,13 @@ pub fn sequential_model(
             0.0,
             0.0,
         )),
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_3 = SurfaceSpec::Image {
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surfaces = vec![surf_0, surf_1, surf_2, surf_3];
 

--- a/crates/cherry-rs/src/examples/petzval_lens.rs
+++ b/crates/cherry-rs/src/examples/petzval_lens.rs
@@ -1,4 +1,4 @@
-use crate::{BoundaryKind, FieldSpec, GapSpec, Rotation3D, SequentialModel, SurfaceSpec, n};
+use crate::{BoundaryKind, FieldSpec, GapSpec, Rotation3D, SequentialModel, SurfaceSpec, Vec3, n};
 
 pub fn sequential_model() -> SequentialModel {
     let air = n!(1.0);
@@ -53,55 +53,75 @@ pub fn sequential_model() -> SequentialModel {
         radius_of_curvature: 99.56266,
         surf_kind: BoundaryKind::Refracting,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_2 = SurfaceSpec::Sphere {
         semi_diameter: 26.276,
         radius_of_curvature: -86.84002,
         surf_kind: BoundaryKind::Refracting,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_3 = SurfaceSpec::Sphere {
         semi_diameter: 21.02,
         radius_of_curvature: -1187.63858,
         surf_kind: BoundaryKind::Refracting,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_4 = SurfaceSpec::Iris {
         semi_diameter: 16.631,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_5 = SurfaceSpec::Sphere {
         semi_diameter: 20.543,
         radius_of_curvature: 57.47491,
         surf_kind: BoundaryKind::Refracting,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_6 = SurfaceSpec::Sphere {
         semi_diameter: 20.074,
         radius_of_curvature: -54.61685,
         surf_kind: BoundaryKind::Refracting,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_7 = SurfaceSpec::Sphere {
         semi_diameter: 20.074,
         radius_of_curvature: -614.68633,
         surf_kind: BoundaryKind::Refracting,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_8 = SurfaceSpec::Sphere {
         semi_diameter: 17.297,
         radius_of_curvature: -38.17110,
         surf_kind: BoundaryKind::Refracting,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_9 = SurfaceSpec::Sphere {
         semi_diameter: 18.94,
         radius_of_curvature: f64::INFINITY,
         surf_kind: BoundaryKind::Refracting,
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surf_10 = SurfaceSpec::Image {
         rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
     };
     let surfaces = vec![
         surf_0, surf_1, surf_2, surf_3, surf_4, surf_5, surf_6, surf_7, surf_8, surf_9, surf_10,

--- a/crates/cherry-rs/src/gui/convert.rs
+++ b/crates/cherry-rs/src/gui/convert.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result, bail};
 
 use crate::{
     ApertureSpec, BoundaryKind, ConstantRefractiveIndex, EulerAngles, FNumberSolve, FieldSpec,
-    GapSpec, MarginalRaySolve, RefractiveIndexSpec, Rotation3D, Solve, SurfaceSpec,
+    GapSpec, MarginalRaySolve, RefractiveIndexSpec, Rotation3D, Solve, SurfaceSpec, Vec3,
 };
 
 use super::model::{FieldMode, SolveSpec, SurfaceKind, SurfaceVariant, SystemSpecs};
@@ -101,6 +101,8 @@ fn convert_specs_inner(
                     conic_constant: conic,
                     surf_kind,
                     rotation,
+                    decenter: Vec3::new(0.0, 0.0, 0.0),
+                    rotation_offset: Rotation3D::None,
                 }
             }
             SurfaceVariant::Sphere => {
@@ -134,6 +136,8 @@ fn convert_specs_inner(
                     radius_of_curvature: roc,
                     surf_kind,
                     rotation,
+                    decenter: Vec3::new(0.0, 0.0, 0.0),
+                    rotation_offset: Rotation3D::None,
                 }
             }
             SurfaceVariant::Iris => {
@@ -142,13 +146,19 @@ fn convert_specs_inner(
                 SurfaceSpec::Iris {
                     semi_diameter,
                     rotation: Rotation3D::None,
+                    decenter: Vec3::new(0.0, 0.0, 0.0),
+                    rotation_offset: Rotation3D::None,
                 }
             }
             SurfaceVariant::Probe => SurfaceSpec::Probe {
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceVariant::Image => SurfaceSpec::Image {
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
         };
         surfaces.push(surface);

--- a/crates/cherry-rs/src/lib.rs
+++ b/crates/cherry-rs/src/lib.rs
@@ -39,7 +39,7 @@
 //! use cherry_rs::{
 //!     n, ray_trace_3d_view, trace_ray_bundle, ApertureSpec, FieldSpec, GapSpec, ImagePlane,
 //!     ParaxialView, Pupil, SamplingConfig, RefractiveIndexSpec, Rotation3D,
-//!     SequentialModel, SurfaceSpec, BoundaryKind,
+//!     SequentialModel, SurfaceSpec, BoundaryKind, Vec3,
 //! };
 //!
 //! // Create a convexplano lens with an object at infinity.
@@ -70,14 +70,22 @@
 //!         radius_of_curvature: 25.8,
 //!         surf_kind: BoundaryKind::Refracting,
 //!         rotation: Rotation3D::None,
+//!         decenter: Vec3::new(0.0, 0.0, 0.0),
+//!         rotation_offset: Rotation3D::None,
 //!     },
 //!     SurfaceSpec::Sphere {
 //!         semi_diameter: 12.5,
 //!         radius_of_curvature: f64::INFINITY,
 //!         surf_kind: BoundaryKind::Refracting,
 //!         rotation: Rotation3D::None,
+//!         decenter: Vec3::new(0.0, 0.0, 0.0),
+//!         rotation_offset: Rotation3D::None,
 //!     },
-//!     SurfaceSpec::Image { rotation: Rotation3D::None },
+//!     SurfaceSpec::Image {
+//!         rotation: Rotation3D::None,
+//!         decenter: Vec3::new(0.0, 0.0, 0.0),
+//!         rotation_offset: Rotation3D::None,
+//!     },
 //! ];
 //!
 //! // Define a set of wavelengths to model.
@@ -141,7 +149,7 @@ pub use core::{
     sequential_model::{
         SequentialModel, SequentialSubModel, Step,
         builder::{BuildResult, SequentialModelBuilder},
-        placement::Placement,
+        placement::{Placement, SurfacePlacement},
         solves::{FNumberSolve, MarginalRaySolve, Solve, SolveKind},
     },
     surfaces::{Conic, Image, Iris, Object, Probe, Sphere, Surface, SurfaceKind},

--- a/crates/cherry-rs/src/specs/surfaces.rs
+++ b/crates/cherry-rs/src/specs/surfaces.rs
@@ -38,12 +38,20 @@ pub enum SurfaceSpec {
         conic_constant: Float,
         surf_kind: BoundaryKind,
         rotation: Rotation3D,
+        #[cfg_attr(feature = "serde", serde(default = "default_zero_vec3"))]
+        decenter: Vec3,
+        #[cfg_attr(feature = "serde", serde(default = "default_rotation3d_none"))]
+        rotation_offset: Rotation3D,
     },
     Sphere {
         semi_diameter: Float,
         radius_of_curvature: Float,
         surf_kind: BoundaryKind,
         rotation: Rotation3D,
+        #[cfg_attr(feature = "serde", serde(default = "default_zero_vec3"))]
+        decenter: Vec3,
+        #[cfg_attr(feature = "serde", serde(default = "default_rotation3d_none"))]
+        rotation_offset: Rotation3D,
     },
     /// A user-defined surface type registered with a [`SurfaceRegistry`].
     ///
@@ -61,15 +69,92 @@ pub enum SurfaceSpec {
     },
     Image {
         rotation: Rotation3D,
+        #[cfg_attr(feature = "serde", serde(default = "default_zero_vec3"))]
+        decenter: Vec3,
+        #[cfg_attr(feature = "serde", serde(default = "default_rotation3d_none"))]
+        rotation_offset: Rotation3D,
     },
     Object,
     Probe {
         rotation: Rotation3D,
+        #[cfg_attr(feature = "serde", serde(default = "default_zero_vec3"))]
+        decenter: Vec3,
+        #[cfg_attr(feature = "serde", serde(default = "default_rotation3d_none"))]
+        rotation_offset: Rotation3D,
     },
     Iris {
         semi_diameter: Float,
         rotation: Rotation3D,
+        #[cfg_attr(feature = "serde", serde(default = "default_zero_vec3"))]
+        decenter: Vec3,
+        #[cfg_attr(feature = "serde", serde(default = "default_rotation3d_none"))]
+        rotation_offset: Rotation3D,
     },
+}
+
+#[cfg(feature = "serde")]
+fn default_zero_vec3() -> Vec3 {
+    Vec3::new(0.0, 0.0, 0.0)
+}
+
+#[cfg(feature = "serde")]
+fn default_rotation3d_none() -> Rotation3D {
+    Rotation3D::None
+}
+
+impl SurfaceSpec {
+    /// Nominal surface tilt; redirects the cursor for reflecting surfaces.
+    pub fn rotation(&self) -> Rotation3D {
+        match self {
+            SurfaceSpec::Conic { rotation, .. }
+            | SurfaceSpec::Sphere { rotation, .. }
+            | SurfaceSpec::Image { rotation, .. }
+            | SurfaceSpec::Probe { rotation, .. }
+            | SurfaceSpec::Iris { rotation, .. } => rotation.clone(),
+            SurfaceSpec::Object => Rotation3D::None,
+            #[cfg(feature = "serde")]
+            SurfaceSpec::Custom { rotation, .. } => rotation.clone(),
+        }
+    }
+
+    /// Additional surface-only rotation; never redirects the cursor.
+    pub fn rotation_offset(&self) -> Rotation3D {
+        match self {
+            SurfaceSpec::Conic {
+                rotation_offset, ..
+            }
+            | SurfaceSpec::Sphere {
+                rotation_offset, ..
+            }
+            | SurfaceSpec::Image {
+                rotation_offset, ..
+            }
+            | SurfaceSpec::Probe {
+                rotation_offset, ..
+            }
+            | SurfaceSpec::Iris {
+                rotation_offset, ..
+            } => rotation_offset.clone(),
+            SurfaceSpec::Object => Rotation3D::None,
+            #[cfg(feature = "serde")]
+            SurfaceSpec::Custom { .. } => Rotation3D::None,
+        }
+    }
+
+    /// Vertex offset from the nominal cursor position, in cursor-frame (R, U,
+    /// F).
+    pub fn decenter(&self) -> Vec3 {
+        match self {
+            SurfaceSpec::Conic { decenter, .. }
+            | SurfaceSpec::Sphere { decenter, .. }
+            | SurfaceSpec::Image { decenter, .. }
+            | SurfaceSpec::Probe { decenter, .. }
+            | SurfaceSpec::Iris { decenter, .. } => *decenter,
+            SurfaceSpec::Object => Vec3::new(0.0, 0.0, 0.0),
+            #[cfg(feature = "serde")]
+            SurfaceSpec::Custom { .. } => Vec3::new(0.0, 0.0, 0.0),
+        }
+    }
 }
 
 impl Mask {
@@ -94,5 +179,72 @@ impl Mask {
             Mask::Circular { semi_diameter } => *semi_diameter,
             Mask::Unbounded => Float::INFINITY,
         }
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use super::*;
+
+    // AT-9: serialize a Sphere with non-zero decenter and rotation_offset, then
+    // deserialize; assert the round-tripped values are preserved.
+    #[test]
+    fn at9_serde_round_trip_preserves_decenter_and_rotation_offset() {
+        use crate::core::math::linalg::rotations::EulerAngles;
+
+        let phi = 0.1_f64;
+        let spec = SurfaceSpec::Sphere {
+            semi_diameter: 12.5,
+            radius_of_curvature: 25.8,
+            surf_kind: BoundaryKind::Refracting,
+            rotation: Rotation3D::None,
+            decenter: Vec3::new(0.5, -0.3, 0.0),
+            rotation_offset: Rotation3D::IntrinsicPassiveRUF(EulerAngles(phi, 0.0, 0.0)),
+        };
+
+        let json = serde_json::to_string(&spec).expect("serialize");
+        let back: SurfaceSpec = serde_json::from_str(&json).expect("deserialize");
+
+        let d = back.decenter();
+        assert!((d.x() - 0.5).abs() < 1e-15, "decenter x: {}", d.x());
+        assert!((d.y() - (-0.3)).abs() < 1e-15, "decenter y: {}", d.y());
+        assert!(d.z().abs() < 1e-15, "decenter z: {}", d.z());
+
+        match back.rotation_offset() {
+            Rotation3D::IntrinsicPassiveRUF(EulerAngles(a, b, c)) => {
+                assert!((a - phi).abs() < 1e-15, "rotation_offset theta: {a}");
+                assert!(b.abs() < 1e-15, "rotation_offset psi: {b}");
+                assert!(c.abs() < 1e-15, "rotation_offset phi: {c}");
+            }
+            other => panic!("unexpected rotation_offset variant: {:?}", other),
+        }
+    }
+
+    // AT-10: deserializing a JSON string that omits decenter and rotation_offset
+    // applies the correct defaults (zero vector and None).
+    #[test]
+    fn at10_serde_default_decenter_and_rotation_offset() {
+        let json = r#"{
+            "Sphere": {
+                "semi_diameter": 10.0,
+                "radius_of_curvature": 50.0,
+                "surf_kind": "Refracting",
+                "rotation": "None"
+            }
+        }"#;
+
+        let spec: SurfaceSpec = serde_json::from_str(json).expect("deserialize");
+
+        let d = spec.decenter();
+        assert!(
+            d.x().abs() < 1e-15 && d.y().abs() < 1e-15 && d.z().abs() < 1e-15,
+            "default decenter should be zero: {:?}",
+            d
+        );
+
+        assert!(
+            matches!(spec.rotation_offset(), Rotation3D::None),
+            "default rotation_offset should be None"
+        );
     }
 }

--- a/crates/cherry-rs/src/views/components/mod.rs
+++ b/crates/cherry-rs/src/views/components/mod.rs
@@ -140,7 +140,7 @@ mod tests {
     use std::rc::Rc;
 
     use crate::examples::{concave_mirror, convexplano_lens};
-    use crate::{GapSpec, Rotation3D, SequentialModel, SurfaceSpec, core::Float, n};
+    use crate::{GapSpec, Rotation3D, SequentialModel, SurfaceSpec, Vec3, core::Float, n};
 
     use super::*;
 
@@ -154,6 +154,8 @@ mod tests {
         };
         let surf_1 = SurfaceSpec::Image {
             rotation: Rotation3D::None,
+            decenter: Vec3::new(0.0, 0.0, 0.0),
+            rotation_offset: Rotation3D::None,
         };
 
         let surfaces = vec![surf_0, surf_1];
@@ -179,6 +181,8 @@ mod tests {
             conic_constant: 0.0,
             surf_kind: crate::BoundaryKind::Refracting,
             rotation: Rotation3D::None,
+            decenter: Vec3::new(0.0, 0.0, 0.0),
+            rotation_offset: Rotation3D::None,
         };
         let gap_1 = GapSpec {
             thickness: 5.3,
@@ -190,6 +194,8 @@ mod tests {
             conic_constant: 0.0,
             surf_kind: crate::BoundaryKind::Refracting,
             rotation: Rotation3D::None,
+            decenter: Vec3::new(0.0, 0.0, 0.0),
+            rotation_offset: Rotation3D::None,
         };
         let gap_2 = GapSpec {
             thickness: 46.6,
@@ -201,6 +207,8 @@ mod tests {
             conic_constant: 0.0,
             surf_kind: crate::BoundaryKind::Refracting,
             rotation: Rotation3D::None,
+            decenter: Vec3::new(0.0, 0.0, 0.0),
+            rotation_offset: Rotation3D::None,
         }; // Surface is unpaired
         let gap_3 = GapSpec {
             thickness: 20.0,
@@ -208,6 +216,8 @@ mod tests {
         };
         let surf_4 = SurfaceSpec::Image {
             rotation: Rotation3D::None,
+            decenter: Vec3::new(0.0, 0.0, 0.0),
+            rotation_offset: Rotation3D::None,
         };
 
         let surfaces = vec![surf_0, surf_1, surf_2, surf_3, surf_4];
@@ -233,6 +243,8 @@ mod tests {
             conic_constant: 0.0,
             surf_kind: crate::BoundaryKind::Refracting,
             rotation: Rotation3D::None,
+            decenter: Vec3::new(0.0, 0.0, 0.0),
+            rotation_offset: Rotation3D::None,
         };
         let gap_1 = GapSpec {
             thickness: 10.0,
@@ -241,6 +253,8 @@ mod tests {
         let surf_2 = SurfaceSpec::Iris {
             semi_diameter: 12.5,
             rotation: Rotation3D::None,
+            decenter: Vec3::new(0.0, 0.0, 0.0),
+            rotation_offset: Rotation3D::None,
         };
         let gap_2 = GapSpec {
             thickness: 10.0,
@@ -248,6 +262,8 @@ mod tests {
         };
         let surf_3 = SurfaceSpec::Image {
             rotation: Rotation3D::None,
+            decenter: Vec3::new(0.0, 0.0, 0.0),
+            rotation_offset: Rotation3D::None,
         };
 
         let surfaces = vec![surf_0, surf_1, surf_2, surf_3];
@@ -272,6 +288,8 @@ mod tests {
         let surf_1 = SurfaceSpec::Iris {
             semi_diameter: 5.0,
             rotation: Rotation3D::None,
+            decenter: Vec3::new(0.0, 0.0, 0.0),
+            rotation_offset: Rotation3D::None,
         };
         let gap_1 = GapSpec {
             thickness: 5.0,
@@ -283,6 +301,8 @@ mod tests {
             conic_constant: 0.0,
             surf_kind: crate::BoundaryKind::Refracting,
             rotation: Rotation3D::None,
+            decenter: Vec3::new(0.0, 0.0, 0.0),
+            rotation_offset: Rotation3D::None,
         };
         let gap_2 = GapSpec {
             thickness: 5.0,
@@ -294,6 +314,8 @@ mod tests {
             conic_constant: 0.0,
             surf_kind: crate::BoundaryKind::Refracting,
             rotation: Rotation3D::None,
+            decenter: Vec3::new(0.0, 0.0, 0.0),
+            rotation_offset: Rotation3D::None,
         };
         let gap_3 = GapSpec {
             thickness: 47.974,
@@ -301,6 +323,8 @@ mod tests {
         };
         let surf_4 = SurfaceSpec::Image {
             rotation: Rotation3D::None,
+            decenter: Vec3::new(0.0, 0.0, 0.0),
+            rotation_offset: Rotation3D::None,
         };
 
         let surfaces = vec![surf_0, surf_1, surf_2, surf_3, surf_4];
@@ -459,12 +483,18 @@ mod tests {
                 conic_constant: 0.0,
                 surf_kind: crate::BoundaryKind::Reflecting,
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceSpec::Probe {
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceSpec::Image {
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
         ];
         let gaps = vec![

--- a/crates/cherry-rs/src/views/paraxial.rs
+++ b/crates/cherry-rs/src/views/paraxial.rs
@@ -1199,7 +1199,7 @@ mod test {
 
     use crate::examples::convexplano_lens;
     use crate::{
-        GapSpec, Rotation3D, SequentialModel, SurfaceSpec, core::Float, n,
+        GapSpec, Rotation3D, SequentialModel, SurfaceSpec, Vec3, core::Float, n,
         specs::surfaces::BoundaryKind,
     };
 
@@ -1463,6 +1463,8 @@ mod test {
                 conic_constant: 0.0,
                 surf_kind: BoundaryKind::Refracting,
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceSpec::Conic {
                 semi_diameter: 14.0,
@@ -1470,9 +1472,13 @@ mod test {
                 conic_constant: 0.0,
                 surf_kind: BoundaryKind::Refracting,
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceSpec::Image {
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
         ];
 
@@ -1524,6 +1530,8 @@ mod test {
                 conic_constant: 0.0,
                 surf_kind: BoundaryKind::Refracting,
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceSpec::Conic {
                 semi_diameter: 12.5,
@@ -1531,9 +1539,13 @@ mod test {
                 conic_constant: 0.0,
                 surf_kind: BoundaryKind::Refracting,
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
             SurfaceSpec::Image {
                 rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
             },
         ];
         let seq =

--- a/crates/cherry-rs/tests/custom_surface_registry.rs
+++ b/crates/cherry-rs/tests/custom_surface_registry.rs
@@ -75,6 +75,8 @@ fn builder_with_registry_accepts_custom_spec() {
         },
         SurfaceSpec::Image {
             rotation: Rotation3D::None,
+            decenter: Vec3::new(0.0, 0.0, 0.0),
+            rotation_offset: Rotation3D::None,
         },
     ];
     let gaps = vec![air_gap(f64::INFINITY), air_gap(10.0)];
@@ -100,6 +102,8 @@ fn without_registry_rejects_custom_spec() {
         },
         SurfaceSpec::Image {
             rotation: Rotation3D::None,
+            decenter: Vec3::new(0.0, 0.0, 0.0),
+            rotation_offset: Rotation3D::None,
         },
     ];
     let gaps = vec![air_gap(f64::INFINITY), air_gap(10.0)];
@@ -123,6 +127,8 @@ fn params_are_forwarded_to_constructor() {
         },
         SurfaceSpec::Image {
             rotation: Rotation3D::None,
+            decenter: Vec3::new(0.0, 0.0, 0.0),
+            rotation_offset: Rotation3D::None,
         },
     ];
     let gaps = vec![air_gap(f64::INFINITY), air_gap(10.0)];

--- a/crates/cherry-rs/tests/from_surfaces.rs
+++ b/crates/cherry-rs/tests/from_surfaces.rs
@@ -1,4 +1,4 @@
-use cherry_rs::{BoundaryKind, GapSpec, Mask, Rotation3D, SequentialModel, Surface, Vec3, n};
+use cherry_rs::{BoundaryKind, GapSpec, Mask, SequentialModel, Surface, SurfacePlacement, Vec3, n};
 
 #[derive(Debug)]
 struct FlatNoOp {
@@ -40,9 +40,9 @@ fn air_gap(thickness: f64) -> GapSpec {
 
 #[test]
 fn from_surfaces_constructs_minimal_model() {
-    let surfaces: Vec<(Box<dyn Surface>, Rotation3D)> = vec![
-        (Box::new(FlatNoOp::new()), Rotation3D::None),
-        (Box::new(FlatNoOp::new()), Rotation3D::None),
+    let surfaces: Vec<(Box<dyn Surface>, SurfacePlacement)> = vec![
+        (Box::new(FlatNoOp::new()), SurfacePlacement::none()),
+        (Box::new(FlatNoOp::new()), SurfacePlacement::none()),
     ];
     let gaps = vec![air_gap(10.0)];
     let wavelengths = vec![0.587];
@@ -52,9 +52,9 @@ fn from_surfaces_constructs_minimal_model() {
 
 #[test]
 fn from_surfaces_wrong_gap_count_errors() {
-    let surfaces: Vec<(Box<dyn Surface>, Rotation3D)> = vec![
-        (Box::new(FlatNoOp::new()), Rotation3D::None),
-        (Box::new(FlatNoOp::new()), Rotation3D::None),
+    let surfaces: Vec<(Box<dyn Surface>, SurfacePlacement)> = vec![
+        (Box::new(FlatNoOp::new()), SurfacePlacement::none()),
+        (Box::new(FlatNoOp::new()), SurfacePlacement::none()),
     ];
     let gaps = vec![air_gap(10.0), air_gap(5.0)]; // one too many
     let wavelengths = vec![0.587];
@@ -64,9 +64,9 @@ fn from_surfaces_wrong_gap_count_errors() {
 
 #[test]
 fn from_surfaces_wavelengths_are_preserved() {
-    let surfaces: Vec<(Box<dyn Surface>, Rotation3D)> = vec![
-        (Box::new(FlatNoOp::new()), Rotation3D::None),
-        (Box::new(FlatNoOp::new()), Rotation3D::None),
+    let surfaces: Vec<(Box<dyn Surface>, SurfacePlacement)> = vec![
+        (Box::new(FlatNoOp::new()), SurfacePlacement::none()),
+        (Box::new(FlatNoOp::new()), SurfacePlacement::none()),
     ];
     let gaps = vec![air_gap(10.0)];
     let wavelengths = vec![0.486, 0.587, 0.656];


### PR DESCRIPTION
Surfaces may now be decentered and rotated away from the axis. This allows modeling decenters and rotational misalignments, as well as rotating mirrors where the axis remains fixed, i.e. galvanometer mirrors.

These changes are not yet exposed to the GUI.