### PR TITLE
feat: Add optical axis annotation to cross section window

### DIFF
--- a/crates/cherry-rs/src/core/sequential_model/mod.rs
+++ b/crates/cherry-rs/src/core/sequential_model/mod.rs
@@ -23,7 +23,18 @@ use crate::specs::{
     surfaces::{BoundaryKind, SurfaceSpec},
 };
 
-type SurfsPlacementsDirs = (Vec<Box<dyn Surface>>, Vec<Placement>, Vec<Vec3>);
+/// Cursor forward direction at each surface.
+type AxisDirections = Vec<Vec3>;
+/// Nominal on-axis cursor position at each surface, before any decenter is
+/// applied.
+type CursorPositions = Vec<Vec3>;
+
+type SurfsPlacementsDirs = (
+    Vec<Box<dyn Surface>>,
+    Vec<Placement>,
+    AxisDirections,
+    CursorPositions,
+);
 
 /// A gap between two surfaces in a sequential system.
 #[derive(Debug)]
@@ -49,6 +60,12 @@ pub struct SequentialModel {
 
     // The cursor forward direction at each surface vertex.
     axis_directions: Vec<Vec3>,
+
+    /// Cursor position at each surface, captured before the surface's decenter
+    /// is applied. Unlike `placements[i].position`, these are unaffected by
+    /// lens group tilts and decenters — they represent the nominal optical
+    /// axis.
+    cursor_positions: Vec<Vec3>,
 
     /// User-specified aperture stop surface index, or `None` for auto-derived.
     stop_surface: Option<usize>,
@@ -293,7 +310,7 @@ impl SequentialModel {
         #[cfg(not(feature = "serde"))]
         {
             Self::validate_specs(gap_specs, wavelengths)?;
-            let (surfaces, placements, axis_directions) =
+            let (surfaces, placements, axis_directions, cursor_positions) =
                 Self::surf_specs_to_surfs(surface_specs, gap_specs)?;
             if let Some(i) = stop_surface {
                 Self::validate_stop_surface(&surfaces, i)?;
@@ -309,6 +326,7 @@ impl SequentialModel {
                 submodels: models,
                 wavelengths: wavelengths.to_vec(),
                 axis_directions,
+                cursor_positions,
                 stop_surface,
             })
         }
@@ -327,7 +345,7 @@ impl SequentialModel {
         registry: Option<&SurfaceRegistry>,
     ) -> Result<Self> {
         Self::validate_specs(gap_specs, wavelengths)?;
-        let (surfaces, placements, axis_directions) =
+        let (surfaces, placements, axis_directions, cursor_positions) =
             Self::surf_specs_to_surfs(surface_specs, gap_specs, registry)?;
         if let Some(i) = stop_surface {
             Self::validate_stop_surface(&surfaces, i)?;
@@ -343,6 +361,7 @@ impl SequentialModel {
             submodels: models,
             wavelengths: wavelengths.to_vec(),
             axis_directions,
+            cursor_positions,
             stop_surface,
         })
     }
@@ -376,7 +395,7 @@ impl SequentialModel {
         Self::validate_specs(gap_specs, wavelengths)?;
 
         let (surfs, surface_placements): (Vec<_>, Vec<_>) = surfaces.into_iter().unzip();
-        let (placements, axis_directions) =
+        let (placements, axis_directions, cursor_positions) =
             Self::build_placements_and_directions(&surfs, &surface_placements, gap_specs);
 
         if let Some(i) = stop_surface {
@@ -395,6 +414,7 @@ impl SequentialModel {
             submodels: models,
             wavelengths: wavelengths.to_vec(),
             axis_directions,
+            cursor_positions,
             stop_surface,
         })
     }
@@ -483,6 +503,10 @@ impl SequentialModel {
         &self.axis_directions
     }
 
+    pub fn cursor_positions(&self) -> &[Vec3] {
+        &self.cursor_positions
+    }
+
     fn gap_specs_to_gaps(gap_specs: &[GapSpec], wavelength: Float) -> Result<Vec<Gap>> {
         let mut gaps = Vec::new();
         for gap_spec in gap_specs.iter() {
@@ -515,9 +539,10 @@ impl SequentialModel {
         surfaces: &[Box<dyn Surface>],
         surface_placements: &[SurfacePlacement],
         gap_specs: &[GapSpec],
-    ) -> (Vec<Placement>, Vec<Vec3>) {
+    ) -> (Vec<Placement>, Vec<Vec3>, Vec<Vec3>) {
         let mut placements = Vec::new();
         let mut axis_directions = Vec::new();
+        let mut cursor_positions = Vec::new();
         let mut cursor = Cursor::new(-gap_specs[0].thickness);
 
         // Surfaces 0 to N-2 (each paired with a gap that follows it).
@@ -527,6 +552,7 @@ impl SequentialModel {
             .zip(gap_specs.iter())
         {
             axis_directions.push(cursor.forward());
+            cursor_positions.push(cursor.pos());
 
             let nominal_rot = sp.rotation.rotation_matrix();
             let actual_rot = sp.rotation_offset.rotation_matrix() * nominal_rot;
@@ -552,6 +578,7 @@ impl SequentialModel {
 
         // Last surface - no gap after it.
         axis_directions.push(cursor.forward());
+        cursor_positions.push(cursor.pos());
         let sp = surface_placements.last().expect("at least one surface");
         let nominal_rot = sp.rotation.rotation_matrix();
         let actual_rot = sp.rotation_offset.rotation_matrix() * nominal_rot;
@@ -562,7 +589,7 @@ impl SequentialModel {
             &cursor,
         ));
 
-        (placements, axis_directions)
+        (placements, axis_directions, cursor_positions)
     }
 
     #[cfg(feature = "serde")]
@@ -583,9 +610,9 @@ impl SequentialModel {
                 rotation_offset: spec.rotation_offset(),
             })
             .collect();
-        let (placements, axis_directions) =
+        let (placements, axis_directions, cursor_positions) =
             Self::build_placements_and_directions(&surfaces, &surface_placements, gap_specs);
-        Ok((surfaces, placements, axis_directions))
+        Ok((surfaces, placements, axis_directions, cursor_positions))
     }
 
     #[cfg(not(feature = "serde"))]
@@ -605,9 +632,9 @@ impl SequentialModel {
                 rotation_offset: spec.rotation_offset(),
             })
             .collect();
-        let (placements, axis_directions) =
+        let (placements, axis_directions, cursor_positions) =
             Self::build_placements_and_directions(&surfaces, &surface_placements, gap_specs);
-        Ok((surfaces, placements, axis_directions))
+        Ok((surfaces, placements, axis_directions, cursor_positions))
     }
 
     fn validate_gaps(gaps: &[GapSpec]) -> Result<()> {

--- a/crates/cherry-rs/src/gui/windows/cross_section.rs
+++ b/crates/cherry-rs/src/gui/windows/cross_section.rs
@@ -26,18 +26,37 @@ pub enum CuttingPlane {
     XZ,
 }
 
+// ── Annotation settings
+// ──────────────────────────────────────────────────────
+
+struct AnnotationSettings {
+    show_axis: bool,
+    show_scalebar: bool,
+}
+
+impl Default for AnnotationSettings {
+    fn default() -> Self {
+        Self {
+            show_axis: true,
+            show_scalebar: true,
+        }
+    }
+}
+
 // ── Window struct
 // ─────────────────────────────────────────────────────────────
 
 /// Cross-section output window.
 pub struct CrossSectionWindow {
     cutting_plane: CuttingPlane,
+    annotations: AnnotationSettings,
 }
 
 impl Default for CrossSectionWindow {
     fn default() -> Self {
         Self {
             cutting_plane: CuttingPlane::YZ,
+            annotations: AnnotationSettings::default(),
         }
     }
 }
@@ -132,6 +151,11 @@ impl CrossSectionWindow {
             if resp.changed() {
                 changed = true;
             }
+            ui.separator();
+            ui.menu_button("Annotations \u{25be}", |ui| {
+                ui.checkbox(&mut self.annotations.show_axis, "Optical axis");
+                ui.checkbox(&mut self.annotations.show_scalebar, "Scale bar");
+            });
         });
         changed
     }
@@ -174,8 +198,13 @@ impl CrossSectionWindow {
             draw_rays(&painter, paths, &w2s, color);
         }
 
-        // Draw scale bar.
-        draw_scalebar(&painter, rect, &geom.bounding_box);
+        // Draw annotations.
+        if self.annotations.show_axis {
+            draw_axis(&painter, &geom.axis_path, &w2s);
+        }
+        if self.annotations.show_scalebar {
+            draw_scalebar(&painter, rect, &geom.bounding_box);
+        }
     }
 
     fn show_invalid_plane_message(&self, ui: &mut egui::Ui) {
@@ -485,6 +514,18 @@ fn draw_rays(
     }
 }
 
+fn draw_axis(painter: &egui::Painter, path: &[[f64; 2]], w2s: &WorldToScreen) {
+    if path.len() < 2 {
+        return;
+    }
+    let stroke = egui::Stroke::new(1.0, egui::Color32::from_gray(110));
+    let screen: Vec<egui::Pos2> = path
+        .iter()
+        .map(|&[z, t]| w2s.map(z as f32, t as f32))
+        .collect();
+    painter.add(egui::Shape::line(screen, stroke));
+}
+
 fn draw_scalebar(painter: &egui::Painter, rect: egui::Rect, bb: &Bounds2D) {
     let world_width = (bb.z.1 - bb.z.0) as f32;
     if world_width <= 0.0 {
@@ -610,6 +651,8 @@ fn render_svg(geom: &PlaneGeometry, wavelengths: &[f64], dark_mode: bool) -> Str
         r#"<rect width="{w}" height="{h}" fill="none" stroke="{border}" stroke-width="1"/>"#
     ));
 
+    svg_axis(&mut s, &geom.axis_path, &w2s, scalebar_color);
+
     for elem in &geom.elements {
         match elem {
             DrawElement::LensGroup {
@@ -687,6 +730,23 @@ fn svg_lens_group(
         .join(" ");
     s.push_str(&format!(
         r#"<polygon points="{pts}" fill="{fill}" stroke="{stroke}" stroke-width="1.5" stroke-linejoin="round"/>"#
+    ));
+}
+
+fn svg_axis(s: &mut String, path: &[[f64; 2]], w2s: &WorldToSvg, color: &str) {
+    if path.len() < 2 {
+        return;
+    }
+    let pts: String = path
+        .iter()
+        .map(|&[z, t]| {
+            let (x, y) = w2s.map(z, t);
+            format!("{x:.2},{y:.2}")
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    s.push_str(&format!(
+        r#"<polyline points="{pts}" fill="none" stroke="{color}" stroke-width="1" stroke-dasharray="4 3"/>"#
     ));
 }
 
@@ -872,6 +932,7 @@ mod tests {
                 },
                 elements: Vec::new(),
                 ray_paths: Vec::new(),
+                axis_path: Vec::new(),
             },
             xz: PlaneGeometry {
                 bounding_box: Bounds2D {
@@ -880,6 +941,7 @@ mod tests {
                 },
                 elements: Vec::new(),
                 ray_paths: Vec::new(),
+                axis_path: Vec::new(),
             },
         };
         let result = ResultPackage {

--- a/crates/cherry-rs/src/views/cross_section.rs
+++ b/crates/cherry-rs/src/views/cross_section.rs
@@ -35,6 +35,11 @@ pub struct PlaneGeometry {
     pub elements: Vec<DrawElement>,
     /// ray_paths[wavelength_idx][path_idx] = Vec<[z, transverse]>
     pub ray_paths: Vec<Vec<Vec<[f64; 2]>>>,
+    /// On-axis positions [z, transverse] from the first finite surface to the
+    /// image surface. Starts at the object surface for finite-conjugate
+    /// systems, or at the first lens surface for infinite-conjugate systems
+    /// (where the object placement is infinite).
+    pub axis_path: Vec<[f64; 2]>,
 }
 
 /// Axis-aligned bounding box in the (z, transverse) 2D coordinate system.
@@ -293,12 +298,26 @@ fn build_plane_geometry(
         }
     }
 
+    let axis_path: Vec<[f64; 2]> = model
+        .cursor_positions()
+        .iter()
+        .filter(|p| p.x().is_finite() && p.y().is_finite() && p.z().is_finite())
+        .map(|p| {
+            let t = match axis {
+                GlobalAxis::Y => p.y(),
+                GlobalAxis::X => p.x(),
+            };
+            [p.z(), t]
+        })
+        .collect();
+
     let bounding_box = compute_bounds(&elements, &ray_paths);
 
     PlaneGeometry {
         bounding_box,
         elements,
         ray_paths,
+        axis_path,
     }
 }
 
@@ -739,6 +758,144 @@ mod tests {
         assert!(
             fwd_t.abs() > 0.99,
             "after fold, iris fwd_t should be ~±1, got {fwd_t}"
+        );
+    }
+
+    #[test]
+    fn axis_path_starts_at_first_lens_for_infinite_object() {
+        // convexplano_lens uses INFINITY for the first gap, so the object
+        // surface is infinite and must be excluded from axis_path.
+        let air = n!(1.0);
+        let nbk7 = n!(1.515);
+        let wavelengths: [Float; 1] = [0.5876];
+        let model = convexplano_lens::sequential_model(air.clone(), nbk7, &wavelengths);
+        let components = components_view(&model, air).unwrap();
+        let cs = cross_section_view(&model, None, &components);
+
+        // Object is infinite → axis_path must not contain an infinite coordinate.
+        assert!(
+            cs.yz
+                .axis_path
+                .iter()
+                .all(|&[z, t]| z.is_finite() && t.is_finite()),
+            "axis_path must not contain infinite coordinates"
+        );
+        // For a straight system every on-axis transverse coordinate is zero.
+        for &[_z, t] in &cs.yz.axis_path {
+            assert!(t.abs() < EPS, "expected on-axis transverse ≈ 0, got {t}");
+        }
+        // The path should include the two lens surfaces plus the image surface
+        // (3 finite surfaces: front lens, back lens, image).
+        assert_eq!(cs.yz.axis_path.len(), 3, "expected 3 points in axis_path");
+    }
+
+    #[test]
+    fn axis_path_starts_at_object_for_finite_object() {
+        // straight_sphere_model uses thickness=100.0 for the first gap, so the
+        // object surface is at a finite z position and must be included.
+        let model = straight_sphere_model(Vec3::new(0.0, 0.0, 0.0), Rotation3D::None);
+        let components = components_view(&model, n!(1.0)).unwrap();
+        let cs = cross_section_view(&model, None, &components);
+
+        // Object(finite) + Sphere + Image = 3 surfaces.
+        assert_eq!(
+            cs.yz.axis_path.len(),
+            3,
+            "expected 3 points: object, sphere, image; got {}",
+            cs.yz.axis_path.len()
+        );
+        // All coordinates must be finite.
+        assert!(
+            cs.yz
+                .axis_path
+                .iter()
+                .all(|&[z, t]| z.is_finite() && t.is_finite()),
+            "axis_path must not contain infinite coordinates"
+        );
+    }
+
+    #[test]
+    fn axis_path_unaffected_by_lens_decenter() {
+        // A 2 mm U-decenter shifts the surface vertex to t = 2, but the cursor
+        // (optical axis) must remain at t = 0.
+        let model = straight_sphere_model(Vec3::new(0.0, 2.0, 0.0), Rotation3D::None);
+        let components = components_view(&model, n!(1.0)).unwrap();
+        let cs = cross_section_view(&model, None, &components);
+
+        for &[_z, t] in &cs.yz.axis_path {
+            assert!(
+                t.abs() < EPS,
+                "axis_path must stay on-axis despite decenter, got t={t}"
+            );
+        }
+    }
+
+    #[test]
+    fn axis_path_nonzero_transverse_after_fold() {
+        // After a 45° fold mirror, the axis has a non-zero transverse component
+        // in the YZ plane. At least one axis_path point must have |t| > 0.
+        let air = n!(1.0);
+        let gaps = vec![
+            GapSpec {
+                thickness: 100.0,
+                refractive_index: air.clone(),
+            },
+            GapSpec {
+                thickness: 50.0,
+                refractive_index: air.clone(),
+            },
+            GapSpec {
+                thickness: 25.0,
+                refractive_index: air.clone(),
+            },
+            GapSpec {
+                thickness: 50.0,
+                refractive_index: air.clone(),
+            },
+        ];
+        let mirror_rotation =
+            Rotation3D::IntrinsicPassiveRUF(EulerAngles(45.0_f64.to_radians(), 0.0, 0.0));
+        let surfs = vec![
+            SurfaceSpec::Object,
+            SurfaceSpec::Sphere {
+                semi_diameter: 12.7,
+                radius_of_curvature: 102.4,
+                surf_kind: BoundaryKind::Refracting,
+                rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
+            },
+            SurfaceSpec::Sphere {
+                semi_diameter: 10.0,
+                radius_of_curvature: Float::INFINITY,
+                surf_kind: BoundaryKind::Reflecting,
+                rotation: mirror_rotation,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
+            },
+            SurfaceSpec::Iris {
+                semi_diameter: 7.1,
+                rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
+            },
+            SurfaceSpec::Image {
+                rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
+            },
+        ];
+        let model = SequentialModel::from_surface_specs(&gaps, &surfs, &[0.5876], None)
+            .expect("build folded model");
+        let components = components_view(&model, air).unwrap();
+        let cs = cross_section_view(&model, None, &components);
+
+        // After the fold, at least one point in axis_path must have non-zero
+        // transverse.
+        let has_nonzero_t = cs.yz.axis_path.iter().any(|&[_z, t]| t.abs() > 0.1);
+        assert!(
+            has_nonzero_t,
+            "expected non-zero transverse in axis_path after 45° fold"
         );
     }
 }


### PR DESCRIPTION
Additionally, this and the scale bar annotations can now be toggled on/off.

<img width="1399" height="774" alt="image" src="https://github.com/user-attachments/assets/c152032f-8586-4fb8-b9ac-d5cae78934f5" />
