### PR TITLE
feat: Add RUF axis annotations to the cross section window

### DIFF
--- a/crates/cherry-rs/src/gui/panels/fields.rs
+++ b/crates/cherry-rs/src/gui/panels/fields.rs
@@ -34,6 +34,7 @@ pub fn fields_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
         let table = TableBuilder::new(ui)
             .striped(true)
             .resizable(true)
+            .sense(egui::Sense::click())
             .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
             .column(Column::auto().at_least(30.0)) // #
             .column(Column::initial(100.0).resizable(true)) // χ (angle) or Y (point source)

--- a/crates/cherry-rs/src/gui/panels/lens_overlay.rs
+++ b/crates/cherry-rs/src/gui/panels/lens_overlay.rs
@@ -183,9 +183,11 @@ impl LensOverlayPanel {
         let mut select_remove: Vec<usize> = Vec::new();
 
         egui::ScrollArea::horizontal().show(ui, |ui| {
+            let ctx = ui.ctx().clone();
             let table = TableBuilder::new(ui)
                 .striped(true)
                 .resizable(true)
+                .sense(egui::Sense::click())
                 .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
                 .column(Column::auto().at_least(16.0)) // select
                 .column(Column::initial(130.0).resizable(true)) // Name
@@ -243,10 +245,9 @@ impl LensOverlayPanel {
                                 }
                             });
 
-                            let group = &mut specs.lens_groups[row_idx];
-
                             // Name (editable)
                             row.col(|ui| {
+                                let group = &mut specs.lens_groups[row_idx];
                                 if ui.text_edit_singleline(&mut group.name).changed() {
                                     changed = true;
                                 }
@@ -254,7 +255,7 @@ impl LensOverlayPanel {
 
                             // Components summary (read-only)
                             row.col(|ui| {
-                                let summary: Vec<String> = group
+                                let summary: Vec<String> = specs.lens_groups[row_idx]
                                     .component_first_surfs
                                     .iter()
                                     .filter_map(|&fs| {
@@ -267,7 +268,12 @@ impl LensOverlayPanel {
                             // Decenter R / U / F
                             row.col(|ui| {
                                 if ui
-                                    .add(egui::DragValue::new(&mut group.decenter[0]).speed(0.01))
+                                    .add(
+                                        egui::DragValue::new(
+                                            &mut specs.lens_groups[row_idx].decenter[0],
+                                        )
+                                        .speed(0.01),
+                                    )
                                     .changed()
                                 {
                                     changed = true;
@@ -275,7 +281,12 @@ impl LensOverlayPanel {
                             });
                             row.col(|ui| {
                                 if ui
-                                    .add(egui::DragValue::new(&mut group.decenter[1]).speed(0.01))
+                                    .add(
+                                        egui::DragValue::new(
+                                            &mut specs.lens_groups[row_idx].decenter[1],
+                                        )
+                                        .speed(0.01),
+                                    )
                                     .changed()
                                 {
                                     changed = true;
@@ -283,7 +294,12 @@ impl LensOverlayPanel {
                             });
                             row.col(|ui| {
                                 if ui
-                                    .add(egui::DragValue::new(&mut group.decenter[2]).speed(0.01))
+                                    .add(
+                                        egui::DragValue::new(
+                                            &mut specs.lens_groups[row_idx].decenter[2],
+                                        )
+                                        .speed(0.01),
+                                    )
                                     .changed()
                                 {
                                     changed = true;
@@ -293,7 +309,12 @@ impl LensOverlayPanel {
                             // Euler angles θ / ψ / φ
                             row.col(|ui| {
                                 if ui
-                                    .add(egui::DragValue::new(&mut group.rotation[0]).speed(0.01))
+                                    .add(
+                                        egui::DragValue::new(
+                                            &mut specs.lens_groups[row_idx].rotation[0],
+                                        )
+                                        .speed(0.01),
+                                    )
                                     .changed()
                                 {
                                     changed = true;
@@ -301,7 +322,12 @@ impl LensOverlayPanel {
                             });
                             row.col(|ui| {
                                 if ui
-                                    .add(egui::DragValue::new(&mut group.rotation[1]).speed(0.01))
+                                    .add(
+                                        egui::DragValue::new(
+                                            &mut specs.lens_groups[row_idx].rotation[1],
+                                        )
+                                        .speed(0.01),
+                                    )
                                     .changed()
                                 {
                                     changed = true;
@@ -309,12 +335,32 @@ impl LensOverlayPanel {
                             });
                             row.col(|ui| {
                                 if ui
-                                    .add(egui::DragValue::new(&mut group.rotation[2]).speed(0.01))
+                                    .add(
+                                        egui::DragValue::new(
+                                            &mut specs.lens_groups[row_idx].rotation[2],
+                                        )
+                                        .speed(0.01),
+                                    )
                                     .changed()
                                 {
                                     changed = true;
                                 }
                             });
+
+                            if row.response().hovered() {
+                                let surf_idx = specs.lens_groups[row_idx]
+                                    .component_first_surfs
+                                    .first()
+                                    .copied();
+                                if let Some(idx) = surf_idx {
+                                    ctx.data_mut(|d| {
+                                        d.insert_temp(
+                                            egui::Id::new("annotation_hover_surface_idx"),
+                                            idx,
+                                        );
+                                    });
+                                }
+                            }
                         });
                     }
                 });

--- a/crates/cherry-rs/src/gui/panels/surfaces.rs
+++ b/crates/cherry-rs/src/gui/panels/surfaces.rs
@@ -35,9 +35,11 @@ pub fn surfaces_panel(
         .any(|s| s.variant == SurfaceVariant::Conic);
 
     egui::ScrollArea::horizontal().show(ui, |ui| {
+        let ctx = ui.ctx().clone();
         let table = TableBuilder::new(ui)
             .striped(true)
             .resizable(true)
+            .sense(egui::Sense::click())
             .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
             .column(Column::auto().at_least(30.0)) // #
             .column(Column::auto().at_least(70.0)) // Variant
@@ -388,6 +390,15 @@ pub fn surfaces_panel(
                                 });
                             }
                         });
+
+                        if row.response().hovered() && !is_object && !is_image {
+                            ctx.data_mut(|d| {
+                                d.insert_temp(
+                                    egui::Id::new("annotation_hover_surface_idx"),
+                                    row_idx,
+                                );
+                            });
+                        }
                     });
                 }
 

--- a/crates/cherry-rs/src/gui/windows/cross_section.rs
+++ b/crates/cherry-rs/src/gui/windows/cross_section.rs
@@ -1,6 +1,8 @@
 use crate::{
     gui::{colors::wavelength_to_color, result_package::ResultPackage},
-    views::cross_section::{Bounds2D, CrossSectionView, DrawElement, FlatPlaneKind, PlaneGeometry},
+    views::cross_section::{
+        Bounds2D, CrossSectionView, DrawElement, FlatPlaneKind, PlaneGeometry, SurfaceFrame2D,
+    },
 };
 
 const VIEWPORT_HEIGHT_RATIO: f32 = 0.5;
@@ -8,7 +10,10 @@ const MAX_CROSS_SECTION_N_RAYS: u32 = 32;
 const MIN_VIEWPORT_HEIGHT: f32 = 200.0;
 const SCALEBAR_MARGIN: f32 = 8.0;
 const SCALEBAR_HEIGHT: f32 = 4.0;
-const AXIS_LENGTH: f32 = 20.0;
+const AXIS_LENGTH: f32 = 25.0;
+const CIRCLE_RADIUS: f32 = 4.0;
+const DOT_RADIUS: f32 = 1.5;
+const CROSS_HALF: f32 = 2.5;
 
 /// SVG canvas dimensions in logical pixels (for file export only).
 const SVG_W: f64 = 700.0;
@@ -34,6 +39,7 @@ struct AnnotationSettings {
     show_axis: bool,
     show_scalebar: bool,
     show_global_axes: bool,
+    show_ruf_axes: bool,
 }
 
 impl Default for AnnotationSettings {
@@ -42,6 +48,7 @@ impl Default for AnnotationSettings {
             show_axis: true,
             show_scalebar: true,
             show_global_axes: true,
+            show_ruf_axes: false,
         }
     }
 }
@@ -159,6 +166,7 @@ impl CrossSectionWindow {
                 ui.checkbox(&mut self.annotations.show_axis, "Optical axis");
                 ui.checkbox(&mut self.annotations.show_scalebar, "Scale bar");
                 ui.checkbox(&mut self.annotations.show_global_axes, "Global axes");
+                ui.checkbox(&mut self.annotations.show_ruf_axes, "RUF axes");
             });
         });
         changed
@@ -211,6 +219,21 @@ impl CrossSectionWindow {
         }
         if self.annotations.show_global_axes {
             draw_global_axes(&painter, rect, self.cutting_plane);
+        }
+
+        // Always clear the hover key, even when the annotation is disabled, to prevent
+        // a stale surface index from appearing the moment the annotation is re-enabled.
+        let hover_id = egui::Id::new("annotation_hover_surface_idx");
+        let hover_idx = ui.ctx().data_mut(|d| {
+            let v = d.get_temp::<usize>(hover_id);
+            d.remove::<usize>(hover_id);
+            v
+        });
+        if self.annotations.show_ruf_axes
+            && let Some(idx) = hover_idx
+            && let Some(Some(frame)) = geom.surface_frames.get(idx)
+        {
+            draw_ruf_axes(&painter, frame, &w2s, self.cutting_plane);
         }
     }
 
@@ -601,15 +624,14 @@ fn draw_global_axes(painter: &egui::Painter, rect: egui::Rect, cutting_plane: Cu
         rect.left() + SCALEBAR_MARGIN,
         rect.bottom() - SCALEBAR_MARGIN,
     );
-    let z_tip = egui::pos2(origin.x + AXIS_LENGTH, origin.y);
-    let t_tip = egui::pos2(origin.x, origin.y - AXIS_LENGTH);
+    let z_dir = egui::Vec2::new(1.0, 0.0);
+    let t_dir = egui::Vec2::new(0.0, -1.0);
 
     let z_color = egui::Color32::from_rgb(80, 130, 230);
-    let stroke_z = egui::Stroke::new(2.0, z_color);
-    painter.line_segment([origin, z_tip], stroke_z);
+    painter.arrow(origin, z_dir * AXIS_LENGTH, egui::Stroke::new(2.0, z_color));
     painter.text(
-        egui::pos2(z_tip.x + 2.0, z_tip.y),
-        egui::Align2::LEFT_CENTER,
+        origin + z_dir * (AXIS_LENGTH + 9.0),
+        egui::Align2::CENTER_CENTER,
         "Z",
         egui::FontId::proportional(10.0),
         z_color,
@@ -619,14 +641,129 @@ fn draw_global_axes(painter: &egui::Painter, rect: egui::Rect, cutting_plane: Cu
         CuttingPlane::YZ => ("Y", egui::Color32::from_rgb(60, 200, 60)),
         CuttingPlane::XZ => ("X", egui::Color32::from_rgb(220, 60, 60)),
     };
-    let stroke_t = egui::Stroke::new(2.0, t_color);
-    painter.line_segment([origin, t_tip], stroke_t);
+    painter.arrow(origin, t_dir * AXIS_LENGTH, egui::Stroke::new(2.0, t_color));
     painter.text(
-        egui::pos2(t_tip.x, t_tip.y - 2.0),
-        egui::Align2::CENTER_BOTTOM,
+        origin + t_dir * (AXIS_LENGTH + 9.0),
+        egui::Align2::CENTER_CENTER,
         t_label,
         egui::FontId::proportional(10.0),
         t_color,
+    );
+
+    let (oop_label, oop_color) = match cutting_plane {
+        CuttingPlane::YZ => ("X", egui::Color32::from_rgb(220, 60, 60)),
+        CuttingPlane::XZ => ("Y", egui::Color32::from_rgb(60, 200, 60)),
+    };
+    painter.circle_stroke(origin, CIRCLE_RADIUS, egui::Stroke::new(1.5, oop_color));
+    match cutting_plane {
+        CuttingPlane::YZ => {
+            painter.line_segment(
+                [
+                    origin - egui::Vec2::new(CROSS_HALF, 0.0),
+                    origin + egui::Vec2::new(CROSS_HALF, 0.0),
+                ],
+                egui::Stroke::new(1.5, oop_color),
+            );
+            painter.line_segment(
+                [
+                    origin - egui::Vec2::new(0.0, CROSS_HALF),
+                    origin + egui::Vec2::new(0.0, CROSS_HALF),
+                ],
+                egui::Stroke::new(1.5, oop_color),
+            );
+        }
+        CuttingPlane::XZ => {
+            painter.circle_filled(origin, DOT_RADIUS, oop_color);
+        }
+    }
+    // The origin is pinned to the bottom-left corner, so +bisector (upper-right,
+    // between the two arrows) is the only direction that stays inside the viewport.
+    let bisector = (z_dir + t_dir).normalized();
+    painter.text(
+        origin + bisector * (CIRCLE_RADIUS + 13.0),
+        egui::Align2::CENTER_CENTER,
+        oop_label,
+        egui::FontId::proportional(10.0),
+        oop_color,
+    );
+}
+
+fn draw_ruf_axes(
+    painter: &egui::Painter,
+    frame: &SurfaceFrame2D,
+    w2s: &WorldToScreen,
+    cutting_plane: CuttingPlane,
+) {
+    let origin = w2s.map(frame.vertex_z as f32, frame.vertex_t as f32);
+
+    let r_color = egui::Color32::from_rgb(220, 60, 60);
+    let u_color = egui::Color32::from_rgb(60, 200, 60);
+    let f_color = egui::Color32::from_rgb(80, 130, 230);
+
+    // World (dz, dt) maps to screen (dx, -dy) because WorldToScreen negates
+    // the transverse axis. The world vectors are unit vectors so the screen
+    // vectors are also unit vectors — no renormalization needed.
+    let f_screen = egui::Vec2::new(frame.f_z as f32, -(frame.f_t as f32));
+    let t_screen = egui::Vec2::new(frame.t_z as f32, -(frame.t_t as f32));
+
+    let (in1_dir, in1_color, in1_label) = (f_screen, f_color, "F");
+    let (in2_dir, in2_color, in2_label, oop_color, oop_label) = match cutting_plane {
+        CuttingPlane::YZ => (t_screen, u_color, "U", r_color, "R"),
+        CuttingPlane::XZ => (t_screen, r_color, "R", u_color, "U"),
+    };
+
+    painter.arrow(
+        origin,
+        in1_dir * AXIS_LENGTH,
+        egui::Stroke::new(2.0, in1_color),
+    );
+    painter.text(
+        origin + in1_dir * (AXIS_LENGTH + 9.0),
+        egui::Align2::CENTER_CENTER,
+        in1_label,
+        egui::FontId::proportional(10.0),
+        in1_color,
+    );
+
+    painter.arrow(
+        origin,
+        in2_dir * AXIS_LENGTH,
+        egui::Stroke::new(2.0, in2_color),
+    );
+    painter.text(
+        origin + in2_dir * (AXIS_LENGTH + 9.0),
+        egui::Align2::CENTER_CENTER,
+        in2_label,
+        egui::FontId::proportional(10.0),
+        in2_color,
+    );
+
+    painter.circle_stroke(origin, CIRCLE_RADIUS, egui::Stroke::new(1.5, oop_color));
+    if frame.oop_out_of_screen {
+        painter.circle_filled(origin, DOT_RADIUS, oop_color);
+    } else {
+        painter.line_segment(
+            [
+                origin - egui::Vec2::new(CROSS_HALF, 0.0),
+                origin + egui::Vec2::new(CROSS_HALF, 0.0),
+            ],
+            egui::Stroke::new(1.5, oop_color),
+        );
+        painter.line_segment(
+            [
+                origin - egui::Vec2::new(0.0, CROSS_HALF),
+                origin + egui::Vec2::new(0.0, CROSS_HALF),
+            ],
+            egui::Stroke::new(1.5, oop_color),
+        );
+    }
+    let bisector = (in1_dir + in2_dir).normalized();
+    painter.text(
+        origin - bisector * (CIRCLE_RADIUS + 13.0),
+        egui::Align2::CENTER_CENTER,
+        oop_label,
+        egui::FontId::proportional(10.0),
+        oop_color,
     );
 }
 
@@ -1015,6 +1152,7 @@ mod tests {
                 elements: Vec::new(),
                 ray_paths: Vec::new(),
                 axis_path: Vec::new(),
+                surface_frames: Vec::new(),
             },
             xz: PlaneGeometry {
                 bounding_box: Bounds2D {
@@ -1024,6 +1162,7 @@ mod tests {
                 elements: Vec::new(),
                 ray_paths: Vec::new(),
                 axis_path: Vec::new(),
+                surface_frames: Vec::new(),
             },
         };
         let result = ResultPackage {

--- a/crates/cherry-rs/src/views/cross_section.rs
+++ b/crates/cherry-rs/src/views/cross_section.rs
@@ -29,6 +29,25 @@ pub struct CrossSectionView {
     pub xz: PlaneGeometry,
 }
 
+/// Local RUF coordinate frame for one surface, projected into 2D plot space.
+///
+/// `f` is the cursor forward direction; `t` is the in-plane transverse axis
+/// (U in the YZ cutting plane, R in the XZ cutting plane). Both are unit
+/// vectors in (z, transverse) world coordinates. The out-of-plane axis is
+/// implicit in the cutting plane.
+pub struct SurfaceFrame2D {
+    pub vertex_z: f64,
+    pub vertex_t: f64,
+    pub f_z: f64,
+    pub f_t: f64,
+    pub t_z: f64,
+    pub t_t: f64,
+    /// True when the out-of-plane axis points toward the viewer.
+    /// YZ plane is viewed from −X toward +X: R.x() < 0 → out of screen.
+    /// XZ plane is viewed from +Y downward:  U.y() > 0 → out of screen.
+    pub oop_out_of_screen: bool,
+}
+
 /// 2D geometry for one cutting plane.
 pub struct PlaneGeometry {
     pub bounding_box: Bounds2D,
@@ -40,6 +59,9 @@ pub struct PlaneGeometry {
     /// systems, or at the first lens surface for infinite-conjugate systems
     /// (where the object placement is infinite).
     pub axis_path: Vec<[f64; 2]>,
+    /// Per-surface local RUF frame in 2D plot coordinates, indexed by surface
+    /// index. `None` for surfaces with an infinite vertex position.
+    pub surface_frames: Vec<Option<SurfaceFrame2D>>,
 }
 
 /// Axis-aligned bounding box in the (z, transverse) 2D coordinate system.
@@ -169,6 +191,8 @@ fn build_plane_geometry(
                     GlobalAxis::Y => placement.position.y(),
                     GlobalAxis::X => placement.position.x(),
                 };
+                // Surface normal in global coordinates (used to orient the iris
+                // perpendicular to the surface).
                 let fwd = placement.inv_rotation_matrix * Vec3::new(0.0, 0.0, 1.0);
                 let fwd_z = fwd.z();
                 let fwd_t = match axis {
@@ -234,9 +258,7 @@ fn build_plane_geometry(
             GlobalAxis::X => placement.position.x(),
         };
 
-        // Forward direction of the cursor at this surface in global coordinates.
-        // inv_rotation_matrix maps local → global; applying to (0,0,1) gives the
-        // cursor forward direction.
+        // Surface normal direction in global coordinates.
         let fwd = placement.inv_rotation_matrix * Vec3::new(0.0, 0.0, 1.0);
         let fwd_z = fwd.z();
         let fwd_t = match axis {
@@ -313,11 +335,59 @@ fn build_plane_geometry(
 
     let bounding_box = compute_bounds(&elements, &ray_paths);
 
+    // Use cursor_positions (axis position before any decenter) rather than
+    // placement.position (physical vertex) so that group tilts and decenters
+    // don't displace the annotation away from the optical axis.
+    let cursor_positions = model.cursor_positions();
+    let surface_frames: Vec<Option<SurfaceFrame2D>> = placements
+        .iter()
+        .zip(cursor_positions.iter())
+        .map(|(p, cursor_pos)| {
+            if p.is_infinite() {
+                return None;
+            }
+            let crm_t = p.cursor_rotation_matrix.transpose();
+            let f = crm_t * Vec3::new(0.0, 0.0, 1.0);
+            let r = crm_t * Vec3::new(1.0, 0.0, 0.0);
+            let u = crm_t * Vec3::new(0.0, 1.0, 0.0);
+            let (vertex_z, vertex_t, f_z, f_t, t_z, t_t, oop_out_of_screen) = match axis {
+                GlobalAxis::Y => (
+                    cursor_pos.z(),
+                    cursor_pos.y(),
+                    f.z(),
+                    f.y(),
+                    u.z(),
+                    u.y(),
+                    r.x() < 0.0,
+                ),
+                GlobalAxis::X => (
+                    cursor_pos.z(),
+                    cursor_pos.x(),
+                    f.z(),
+                    f.x(),
+                    r.z(),
+                    r.x(),
+                    u.y() > 0.0,
+                ),
+            };
+            Some(SurfaceFrame2D {
+                vertex_z,
+                vertex_t,
+                f_z,
+                f_t,
+                t_z,
+                t_t,
+                oop_out_of_screen,
+            })
+        })
+        .collect();
+
     PlaneGeometry {
         bounding_box,
         elements,
         ray_paths,
         axis_path,
+        surface_frames,
     }
 }
 
@@ -815,6 +885,168 @@ mod tests {
     }
 
     #[test]
+    fn surface_frames_length_matches_surfaces() {
+        let model = straight_sphere_model(Vec3::new(0.0, 0.0, 0.0), Rotation3D::None);
+        let components = components_view(&model, n!(1.0)).unwrap();
+        let cs = cross_section_view(&model, None, &components);
+        assert_eq!(
+            cs.yz.surface_frames.len(),
+            model.surfaces().len(),
+            "surface_frames must have one entry per surface"
+        );
+    }
+
+    #[test]
+    fn surface_frames_object_at_infinity_is_none() {
+        // straight_sphere_model has thickness=100.0, so object is at a finite position.
+        // Use convexplano_lens which has an infinite first gap to get a None frame.
+        let air = n!(1.0);
+        let nbk7 = n!(1.515);
+        let wavelengths: [Float; 1] = [0.5876];
+        let model = convexplano_lens::sequential_model(air.clone(), nbk7, &wavelengths);
+        let components = components_view(&model, air).unwrap();
+        let cs = cross_section_view(&model, None, &components);
+        assert!(
+            cs.yz.surface_frames[0].is_none(),
+            "object at infinity must produce a None surface frame"
+        );
+    }
+
+    #[test]
+    fn surface_frames_straight_system_directions() {
+        // For a straight (unrotated) system the cursor frame equals the global frame.
+        // F → (f_z=1, f_t=0); U → (t_z=0, t_t=1) in the YZ cutting plane.
+        // Cherry places the first lens at z=0; the object is at negative z.
+        let model = straight_sphere_model(Vec3::new(0.0, 0.0, 0.0), Rotation3D::None);
+        let components = components_view(&model, n!(1.0)).unwrap();
+        let cs = cross_section_view(&model, None, &components);
+
+        // Surface 1 is the sphere. Check directions; don't assert specific z since
+        // Cherry places the first refracting surface at z=0.
+        let frame = cs.yz.surface_frames[1]
+            .as_ref()
+            .expect("sphere surface frame must be Some");
+        assert!(
+            frame.vertex_t.abs() < 1e-9,
+            "vertex_t ≈ 0 (on-axis), got {}",
+            frame.vertex_t
+        );
+        assert!(
+            (frame.f_z - 1.0).abs() < 1e-9,
+            "F points along +Z: f_z ≈ 1, got {}",
+            frame.f_z
+        );
+        assert!(
+            frame.f_t.abs() < 1e-9,
+            "F points along +Z: f_t ≈ 0, got {}",
+            frame.f_t
+        );
+        assert!(
+            frame.t_z.abs() < 1e-9,
+            "U points along +Y: t_z ≈ 0, got {}",
+            frame.t_z
+        );
+        assert!(
+            (frame.t_t - 1.0).abs() < 1e-9,
+            "U points along +Y: t_t ≈ 1, got {}",
+            frame.t_t
+        );
+        assert!(
+            !frame.oop_out_of_screen,
+            "straight system: R = +X is into screen (cross), not out of screen"
+        );
+    }
+
+    #[test]
+    fn surface_frames_folded_system_directions() {
+        // Use the same 45° fold model as
+        // iris_in_folded_system_has_correct_forward_direction. After the 45°
+        // fold the cursor F direction rotates 90° from +Z toward ±Y.
+        // The surface frame for the iris (index 3, after the fold) must reflect this.
+        let air = n!(1.0);
+        let gaps = vec![
+            GapSpec {
+                thickness: 100.0,
+                refractive_index: air.clone(),
+            },
+            GapSpec {
+                thickness: 50.0,
+                refractive_index: air.clone(),
+            },
+            GapSpec {
+                thickness: 25.0,
+                refractive_index: air.clone(),
+            },
+            GapSpec {
+                thickness: 50.0,
+                refractive_index: air.clone(),
+            },
+        ];
+        let mirror_rotation =
+            Rotation3D::IntrinsicPassiveRUF(EulerAngles(45.0_f64.to_radians(), 0.0, 0.0));
+        let surfs = vec![
+            SurfaceSpec::Object,
+            SurfaceSpec::Sphere {
+                semi_diameter: 12.7,
+                radius_of_curvature: 102.4,
+                surf_kind: BoundaryKind::Refracting,
+                rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
+            },
+            SurfaceSpec::Sphere {
+                semi_diameter: 10.0,
+                radius_of_curvature: Float::INFINITY,
+                surf_kind: BoundaryKind::Reflecting,
+                rotation: mirror_rotation,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
+            },
+            SurfaceSpec::Iris {
+                semi_diameter: 7.1,
+                rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
+            },
+            SurfaceSpec::Image {
+                rotation: Rotation3D::None,
+                decenter: Vec3::new(0.0, 0.0, 0.0),
+                rotation_offset: Rotation3D::None,
+            },
+        ];
+        let model = SequentialModel::from_surface_specs(&gaps, &surfs, &[0.5876], None).unwrap();
+        let components = components_view(&model, air).unwrap();
+        let cs = cross_section_view(&model, None, &components);
+
+        // Iris is at index 3, after the 45° fold — its cursor F should point in
+        // the transverse direction (f_z ≈ 0, |f_t| ≈ 1).
+        let frame = cs.yz.surface_frames[3]
+            .as_ref()
+            .expect("iris surface frame must be Some");
+        assert!(
+            frame.f_z.abs() < 0.01,
+            "after 45° fold, iris f_z ≈ 0, got {}",
+            frame.f_z
+        );
+        assert!(
+            frame.f_t.abs() > 0.99,
+            "after 45° fold, iris |f_t| ≈ 1, got {}",
+            frame.f_t
+        );
+        // T must be perpendicular to F.
+        let dot = frame.f_z * frame.t_z + frame.f_t * frame.t_t;
+        assert!(
+            dot.abs() < 0.01,
+            "F and T must be perpendicular (dot ≈ 0), got {}",
+            dot
+        );
+        assert!(
+            frame.oop_out_of_screen,
+            "after 45° YZ fold: cursor right = (-1,0,0), so R.x() < 0 → out of screen (dot)"
+        );
+    }
+
+    #[test]
     fn axis_path_unaffected_by_lens_decenter() {
         // A 2 mm U-decenter shifts the surface vertex to t = 2, but the cursor
         // (optical axis) must remain at t = 0.
@@ -828,6 +1060,23 @@ mod tests {
                 "axis_path must stay on-axis despite decenter, got t={t}"
             );
         }
+    }
+
+    #[test]
+    fn surface_frame_vertex_on_axis_despite_decenter() {
+        // A 2 mm U-decenter shifts placement.position.y() to 2, but the RUF
+        // annotation must use cursor_positions (on-axis) so vertex_t stays 0.
+        let model = straight_sphere_model(Vec3::new(0.0, 2.0, 0.0), Rotation3D::None);
+        let components = components_view(&model, n!(1.0)).unwrap();
+        let cs = cross_section_view(&model, None, &components);
+        let frame = cs.yz.surface_frames[1]
+            .as_ref()
+            .expect("sphere surface frame must be Some");
+        assert!(
+            frame.vertex_t.abs() < 1e-9,
+            "decentered surface: vertex_t must be on-axis (0), got {}",
+            frame.vertex_t
+        );
     }
 
     #[test]


### PR DESCRIPTION
This feature adds a RUF axis annotation to the cross section window on both surfaces and lens groups to assist the user in tilts and decenters. The annotation only appears if:

1. it is enabled in the cross section window's annotation drop down, and
2. the mouse is hovering over a surface or lens group in the surface specs panel or lens overlay.

The global axes triad style has been updated to match the RUF axes style.

<img width="378" height="290" alt="image" src="https://github.com/user-attachments/assets/28f505af-8ee4-434b-ba14-a7b07e1c8f12" />
