### PR TITLE
fix: ThinLens as stop surface

### DIFF
--- a/crates/cherry-rs/src/core/sequential_model/mod.rs
+++ b/crates/cherry-rs/src/core/sequential_model/mod.rs
@@ -773,7 +773,8 @@ impl SequentialModel {
             SurfaceKind::BeamSplitter
             | SurfaceKind::Conic
             | SurfaceKind::Sphere
-            | SurfaceKind::Iris => Ok(()),
+            | SurfaceKind::Iris
+            | SurfaceKind::ThinLens => Ok(()),
             kind => Err(anyhow!(
                 "surface {i} ({kind:?}) is not eligible as the aperture stop; \
                  only Conic and Iris surfaces are allowed"

--- a/crates/cherry-rs/src/gui/app.rs
+++ b/crates/cherry-rs/src/gui/app.rs
@@ -434,6 +434,10 @@ impl eframe::App for CherryApp {
         egui::TopBottomPanel::top("top_panel").show(ctx, |ui| {
             egui::MenuBar::new().ui(ui, |ui| {
                 ui.menu_button("File", |ui| {
+                    if ui.button("New").clicked() {
+                        ui.close();
+                        self.load_specs(SystemSpecs::new_blank());
+                    }
                     if ui.button("Open\u{2026}").clicked() {
                         ui.close();
                         self.open_from_file();

--- a/crates/cherry-rs/src/gui/app.rs
+++ b/crates/cherry-rs/src/gui/app.rs
@@ -352,15 +352,18 @@ fn is_mobile(ctx: &egui::Context) -> bool {
 
 impl CherryApp {
     fn window_list_ui(&mut self, ui: &mut egui::Ui) {
-        ui.label(egui::RichText::new("Input").strong());
+        ui.label(egui::RichText::new("Inputs").strong());
         ui.separator();
         ui.toggle_value(&mut self.windows.specs, "Specs");
         #[cfg(feature = "ri-info")]
         ui.toggle_value(&mut self.windows.materials, "Materials");
         ui.toggle_value(&mut self.windows.system, "System");
+        ui.add_space(8.0);
+        ui.label(egui::RichText::new("Overlays").strong());
+        ui.separator();
         ui.toggle_value(&mut self.windows.lens_overlay, "Lens Overlay");
         ui.add_space(8.0);
-        ui.label(egui::RichText::new("Output").strong());
+        ui.label(egui::RichText::new("Outputs").strong());
         ui.separator();
         ui.toggle_value(&mut self.windows.paraxial_summary, "Paraxial Summary");
         ui.toggle_value(&mut self.windows.spot_diagram, "Spot Diagram");

--- a/crates/cherry-rs/src/gui/model.rs
+++ b/crates/cherry-rs/src/gui/model.rs
@@ -517,6 +517,32 @@ impl SystemSpecs {
             .iter()
             .find(|s| s.surface_index() == surface_index && s.parameter() == parameter)
     }
+
+    /// Blank system: only the object and image planes, in refractive-index
+    /// mode (no materials).
+    pub fn new_blank() -> Self {
+        Self {
+            surfaces: vec![SurfaceRow::new_object("Infinity"), SurfaceRow::new_image()],
+            fields: vec![FieldRow {
+                chi: "0.0".into(),
+                phi: "90.0".into(),
+                x: "0.0".into(),
+            }],
+            aperture_semi_diameter: "10.0".into(),
+            wavelengths: vec!["0.5876".into()],
+            field_mode: FieldMode::Angle,
+            use_materials: false,
+            selected_materials: Vec::new(),
+            cross_section_n_rays: default_cross_section_n_rays(),
+            full_pupil_spacing: default_full_pupil_spacing(),
+            n_fan_rays: default_n_fan_rays(),
+            background_n: default_background_n(),
+            background_material_key: None,
+            stop_surface: None,
+            solves: Vec::new(),
+            lens_groups: Vec::new(),
+        }
+    }
 }
 
 fn default_cross_section_n_rays() -> u32 {

--- a/crates/cherry-rs/src/gui/panels/aperture.rs
+++ b/crates/cherry-rs/src/gui/panels/aperture.rs
@@ -34,7 +34,10 @@ pub fn aperture_panel(ui: &mut egui::Ui, specs: &mut SystemSpecs) -> bool {
         .filter(|(_, row)| {
             matches!(
                 row.variant,
-                SurfaceVariant::Conic | SurfaceVariant::Sphere | SurfaceVariant::Iris
+                SurfaceVariant::Conic
+                    | SurfaceVariant::Sphere
+                    | SurfaceVariant::Iris
+                    | SurfaceVariant::ThinLens
             )
         })
         .map(|(i, _)| i)

--- a/crates/cherry-rs/src/gui/panels/surfaces.rs
+++ b/crates/cherry-rs/src/gui/panels/surfaces.rs
@@ -165,6 +165,7 @@ pub fn surfaces_panel(
                                                         SurfaceVariant::Conic
                                                             | SurfaceVariant::Sphere
                                                             | SurfaceVariant::Iris
+                                                            | SurfaceVariant::ThinLens
                                                     )
                                                 {
                                                     specs.stop_surface = None;


### PR DESCRIPTION
The previous implementation of the `ThinLens` surface type was not allowed to be set as a stop surface. This is now fixed.

I additionally added a `File > New` entry to the menu bar and an `Overlays` category to the Windows sidebar.