### PR TITLE
fix: thin lens pupil calculations

### DIFF
--- a/crates/cherry-rs/src/examples/mod.rs
+++ b/crates/cherry-rs/src/examples/mod.rs
@@ -8,3 +8,4 @@ pub mod galvo_mirror;
 pub mod mirrors_figure_z;
 pub mod petzval_lens;
 pub mod thin_lens_singlet;
+pub mod wf_epi_excitation;

--- a/crates/cherry-rs/src/examples/wf_epi_excitation.rs
+++ b/crates/cherry-rs/src/examples/wf_epi_excitation.rs
@@ -1,0 +1,80 @@
+//! A reduced version of the widefield epifluorescence microscope excitation
+//! path: an object, a thin lens, a flat fold mirror, and a second thin lens
+//! that is the aperture stop.
+//!
+//! The fold mirror has infinite radius of curvature, so it contributes no
+//! optical power and can be ignored when computing paraxial quantities by
+//! hand; only the unfolded track length matters.
+//!
+//! By hand: the stop (second thin lens) sits 150 mm (100 mm + 50 mm) after
+//! the first thin lens (f = 40 mm). Treating the stop as a real object for
+//! the first thin lens and solving 1/s' = 1/f - 1/s with s = 150 mm gives
+//! s' = 600 / 11 = 54.5455 mm, with the image (entrance pupil) on the
+//! object-space side of the first thin lens, i.e. at location -54.5455 mm
+//! relative to it.
+use std::rc::Rc;
+
+use crate::{
+    BoundaryKind, EulerAngles, GapSpec, RefractiveIndexSpec, Rotation3D, SequentialModel,
+    SurfaceSpec, Vec3, core::Float,
+};
+
+pub fn sequential_model(
+    n_air: Rc<dyn RefractiveIndexSpec>,
+    wavelengths: &[f64],
+) -> SequentialModel {
+    let gap_0 = GapSpec {
+        thickness: 40.0,
+        refractive_index: n_air.clone(),
+    };
+    let gap_1 = GapSpec {
+        thickness: 100.0,
+        refractive_index: n_air.clone(),
+    };
+    let gap_2 = GapSpec {
+        thickness: 50.0,
+        refractive_index: n_air.clone(),
+    };
+    let gap_3 = GapSpec {
+        thickness: 1.0,
+        refractive_index: n_air,
+    };
+    let gaps = vec![gap_0, gap_1, gap_2, gap_3];
+
+    let surf_0 = SurfaceSpec::Object;
+    let surf_1 = SurfaceSpec::ThinLens {
+        semi_diameter: 25.0,
+        focal_length: 40.0,
+        rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
+    };
+    let surf_2 = SurfaceSpec::Conic {
+        semi_diameter: 23.2,
+        radius_of_curvature: Float::INFINITY,
+        conic_constant: 0.0,
+        surf_kind: BoundaryKind::Reflecting,
+        rotation: Rotation3D::IntrinsicPassiveRUF(EulerAngles(
+            (45.0 as Float).to_radians(),
+            0.0,
+            0.0,
+        )),
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
+    };
+    let surf_3 = SurfaceSpec::ThinLens {
+        semi_diameter: 4.75,
+        focal_length: 3.3333,
+        rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
+    };
+    let surf_4 = SurfaceSpec::Image {
+        rotation: Rotation3D::None,
+        decenter: Vec3::new(0.0, 0.0, 0.0),
+        rotation_offset: Rotation3D::None,
+    };
+    let surfaces = vec![surf_0, surf_1, surf_2, surf_3, surf_4];
+
+    SequentialModel::from_surface_specs(&gaps, &surfaces, wavelengths, Some(3)).unwrap()
+}

--- a/crates/cherry-rs/src/views/paraxial.rs
+++ b/crates/cherry-rs/src/views/paraxial.rs
@@ -1195,7 +1195,7 @@ impl ParaxialSubView {
                 gap_0.refractive_index.n()
             };
 
-            let rtm = surface_to_rtm(surface, t, n_0, n_1);
+            let rtm = surface_to_rtm(surface, t, n_0, n_1, reverse);
             txs.push(rtm);
         }
 
@@ -1249,10 +1249,20 @@ impl ParaxialSubView {
 
 /// Compute the ray transfer matrix for propagation to and interaction with a
 /// surface.
-fn surface_to_rtm(surface: &dyn Surface, t: Float, n_0: Float, n_1: Float) -> RayTransferMatrix {
+fn surface_to_rtm(
+    surface: &dyn Surface,
+    t: Float,
+    n_0: Float,
+    n_1: Float,
+    reverse: bool,
+) -> RayTransferMatrix {
     match surface.boundary_kind() {
         BoundaryKind::Refracting => {
-            let phi = surface.power(0.0, n_0, n_1);
+            let phi = if reverse {
+                -surface.power(0.0, n_1, n_0)
+            } else {
+                surface.power(0.0, n_0, n_1)
+            };
             Mat2x2::new(1.0, t, -phi / n_1, -phi * t / n_1 + n_0 / n_1)
         }
         BoundaryKind::Reflecting => {

--- a/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
+++ b/crates/cherry-rs/src/views/ray_trace_3d/mod.rs
@@ -504,9 +504,10 @@ fn rays(
             let origin = Vec3::new(*x, *y, obj_z);
             match sampling {
                 PupilSampling::ChiefRay => {
-                    chief_ray_from_pos(aperture_spec, paraxial_subview, &origin)?
+                    chief_ray_from_pos(placements, aperture_spec, paraxial_subview, &origin)?
                 }
                 PupilSampling::SquareGrid { spacing } => point_source_ray_bundle_on_sq_grid(
+                    placements,
                     aperture_spec,
                     paraxial_subview,
                     spacing,
@@ -514,11 +515,25 @@ fn rays(
                 )?,
                 PupilSampling::TangentialRayFan { n } => {
                     let fan_phi = field_spec.tangential_fan_phi();
-                    point_source_ray_fan(aperture_spec, paraxial_subview, n, fan_phi, &origin)?
+                    point_source_ray_fan(
+                        placements,
+                        aperture_spec,
+                        paraxial_subview,
+                        n,
+                        fan_phi,
+                        &origin,
+                    )?
                 }
                 PupilSampling::SagittalRayFan { n } => {
                     let fan_phi = field_spec.sagittal_fan_phi();
-                    point_source_ray_fan(aperture_spec, paraxial_subview, n, fan_phi, &origin)?
+                    point_source_ray_fan(
+                        placements,
+                        aperture_spec,
+                        paraxial_subview,
+                        n,
+                        fan_phi,
+                        &origin,
+                    )?
                 }
             }
         }
@@ -553,15 +568,17 @@ fn chief_ray_from_angle(
 ///
 /// # Arguments
 ///
+/// * `placements` - The 3D placements of the surfaces.
 /// * `aperture_spec` - The aperture specification.
 /// * `paraxial_subview` - The paraxial subview.
 /// * `origin` - The origin of the rays, i.e. the field point in the object.
 fn chief_ray_from_pos(
+    placements: &[SurfacePlacement],
     aperture_spec: &ApertureSpec,
     paraxial_subview: &ParaxialSubView,
     origin: &Vec3,
 ) -> Result<Vec<Ray>> {
-    let enp = entrance_pupil(aperture_spec, paraxial_subview)?;
+    let enp = entrance_pupil(placements, aperture_spec, paraxial_subview)?;
     let dir = (Vec3::new(0.0, 0.0, enp.location) - *origin).normalize();
 
     Ok(vec![Ray::new(*origin, dir)])
@@ -591,7 +608,7 @@ fn parallel_ray_fan(
     fan_spread_phi: Float,
     chi: Float,
 ) -> Result<Vec<Ray>> {
-    let enp = entrance_pupil(aperture_spec, paraxial_subview)?;
+    let enp = entrance_pupil(placements, aperture_spec, paraxial_subview)?;
     let origin = parallel_ray_bundle_origin(
         placements,
         aperture_spec,
@@ -650,7 +667,7 @@ fn parallel_ray_bundle_on_sq_grid(
     spacing: Float,
     chi: Float,
 ) -> Result<Vec<Ray>> {
-    let enp = entrance_pupil(aperture_spec, paraxial_subview)?;
+    let enp = entrance_pupil(placements, aperture_spec, paraxial_subview)?;
     let abs_spacing = enp.semi_diameter * spacing;
     let origin =
         parallel_ray_bundle_origin(placements, aperture_spec, paraxial_subview, PI / 2.0, chi)?;
@@ -680,13 +697,14 @@ fn parallel_ray_bundle_on_sq_grid(
 /// * `origin` : The origin of the rays, i.e. the field point in the object
 ///   plane.
 fn point_source_ray_fan(
+    placements: &[SurfacePlacement],
     aperture_spec: &ApertureSpec,
     paraxial_subview: &ParaxialSubView,
     num_rays: usize,
     theta: Float,
     origin: &Vec3,
 ) -> Result<Vec<Ray>> {
-    let enp = entrance_pupil(aperture_spec, paraxial_subview)?;
+    let enp = entrance_pupil(placements, aperture_spec, paraxial_subview)?;
     let enp_radius = enp.semi_diameter;
     let enp_z = enp.location;
 
@@ -722,12 +740,13 @@ fn point_source_ray_fan(
 /// * `origin` : The origin of the rays, i.e. the field point in the object
 ///   plane.
 fn point_source_ray_bundle_on_sq_grid(
+    placements: &[SurfacePlacement],
     aperture_spec: &ApertureSpec,
     paraxial_subview: &ParaxialSubView,
     spacing: Float,
     origin: &Vec3,
 ) -> Result<Vec<Ray>> {
-    let enp = entrance_pupil(aperture_spec, paraxial_subview)?;
+    let enp = entrance_pupil(placements, aperture_spec, paraxial_subview)?;
     let enp_radius = enp.semi_diameter;
     let abs_spacing = enp_radius * spacing;
 
@@ -780,7 +799,13 @@ fn validate_field_specs(
 }
 
 /// Determines the entrance pupil of the subview.
+///
+/// `ParaxialSubView::entrance_pupil()` reports its `location` relative to the
+/// first non-object surface (see [`Pupil`]'s docs), so it must be offset by
+/// that surface's actual axial position to get an absolute z-coordinate
+/// usable for ray generation.
 fn entrance_pupil(
+    placements: &[SurfacePlacement],
     aperture_spec: &ApertureSpec,
     paraxial_sub_view: &ParaxialSubView,
 ) -> Result<Pupil> {
@@ -789,7 +814,11 @@ fn entrance_pupil(
     };
 
     let entrance_pupil = paraxial_sub_view.entrance_pupil();
-    let z = entrance_pupil.location;
+    let first_surf_z = placements
+        .get(1)
+        .ok_or_else(|| anyhow!("There should always be at least two surfaces"))?
+        .z();
+    let z = first_surf_z + entrance_pupil.location;
 
     Ok(Pupil {
         location: z,
@@ -834,7 +863,7 @@ fn parallel_ray_bundle_origin(
     phi: Float,
     chi: Float,
 ) -> Result<Vec3> {
-    let enp = entrance_pupil(aperture_spec, paraxial_subview)?;
+    let enp = entrance_pupil(placements, aperture_spec, paraxial_subview)?;
     let obj_z = placements[0].z();
     let sur_z = placements[1].z();
     let enp_z = enp.location;
@@ -1157,6 +1186,7 @@ mod tests {
         let s = setup();
 
         let rays = chief_ray_from_pos(
+            s.sequential_model.placements(),
             &s.aperture_spec,
             s.paraxial_view.get(0, 0).unwrap(),
             &Vec3::new(0.0, 0.0, -1.0),
@@ -1177,6 +1207,7 @@ mod tests {
         let s = setup();
 
         let rays = chief_ray_from_pos(
+            s.sequential_model.placements(),
             &s.aperture_spec,
             s.paraxial_view.get(0, 0).unwrap(),
             &Vec3::new(0.0, -0.08749, -1.0),
@@ -1236,6 +1267,7 @@ mod tests {
         ];
 
         let rays = point_source_ray_fan(
+            s.sequential_model.placements(),
             &s.aperture_spec,
             s.paraxial_view.get(0, 0).unwrap(),
             3,
@@ -1258,6 +1290,7 @@ mod tests {
         let s = setup();
 
         let rays = point_source_ray_bundle_on_sq_grid(
+            s.sequential_model.placements(),
             &s.aperture_spec,
             s.paraxial_view.get(0, 0).unwrap(),
             1.0,
@@ -1269,6 +1302,7 @@ mod tests {
         assert_eq!(rays.unwrap().len(), 5);
 
         let rays = point_source_ray_bundle_on_sq_grid(
+            s.sequential_model.placements(),
             &s.aperture_spec,
             s.paraxial_view.get(0, 0).unwrap(),
             0.5,

--- a/crates/cherry-rs/tests/wf_epi_excitation.rs
+++ b/crates/cherry-rs/tests/wf_epi_excitation.rs
@@ -1,0 +1,31 @@
+use approx::assert_abs_diff_eq;
+
+use cherry_rs::examples::wf_epi_excitation::sequential_model;
+use cherry_rs::{FieldSpec, ParaxialView, n};
+
+const WAVELENGTHS: [f64; 1] = [0.5876];
+const FIELD_SPECS: [FieldSpec; 1] = [FieldSpec::PointSource { x: 0.0, y: 0.0 }];
+
+// Hand calculation: the stop (second thin lens) is 150 mm (100 mm + 50 mm,
+// the fold mirror has no power) downstream of the first thin lens
+// (f = 40 mm). Treating the stop as a real object and solving the thin lens
+// equation 1/s' = 1/f - 1/s with s = 150 mm gives s' = 600/11 = 54.5455 mm,
+// with the resulting image (the entrance pupil) on the object-space side of
+// the first thin lens.
+const ENTRANCE_PUPIL_LOCATION: f64 = -54.5455;
+
+#[test]
+fn wf_epi_excitation_entrance_pupil_location() {
+    let model = sequential_model(n!(1.0), &WAVELENGTHS);
+    let view =
+        ParaxialView::new(&model, &FIELD_SPECS, false).expect("Could not create paraxial view");
+
+    for sub_view in view.iter() {
+        let entrance_pupil = sub_view.entrance_pupil();
+        assert_abs_diff_eq!(
+            entrance_pupil.location,
+            ENTRANCE_PUPIL_LOCATION,
+            epsilon = 1e-3
+        );
+    }
+}


### PR DESCRIPTION
Reverse paraxial ray tracing (used for entrance pupil and front focal point/principal plane calculations) inverts each refraction step by negating the gap thickness and swapping n_0/n_1. For Conic and Sphere surfaces this swap also negates the surface's power for free, because their power formula (n_1 - n_0) / roc is antisymmetric in (n_0, n_1); but ThinLens overrides power() to be media-independent (1 / focal_length regardless of arguments), so the swap had no effect and reverse traces used the wrong sign of power through any thin lens.

This produced incorrect entrance pupil locations whenever a thin lens sat between the object and the aperture stop, e.g. the epifluorescence excitation path's entrance pupil was computed 31.58 mm after the first thin lens instead of 54.55 mm before it.

surface_to_rtm now takes the reverse flag explicitly and negates the power directly when reversed, by calling power() with the original (un-swapped) n_0/n_1 ordering rather than relying on the formula's antisymmetry. This keeps Conic/Sphere behavior unchanged while fixing ThinLens.

Adds the wf_epi_excitation example/test reproducing the reported system and asserting the hand-calculated entrance pupil location.